### PR TITLE
Header: Fix alignment and useLinkComponent

### DIFF
--- a/.changeset/empty-tables-travel.md
+++ b/.changeset/empty-tables-travel.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/header': patch
+---
+
+Fixed alignment when the site `Header` has no `subline`
+ - header now uses the link component provided by `useLinkComponent` to wrap the `HeaderBrand`.

--- a/docs/components/LinkComponent.tsx
+++ b/docs/components/LinkComponent.tsx
@@ -1,0 +1,28 @@
+import type { AnchorHTMLAttributes, PropsWithChildren } from 'react';
+import Link, { LinkProps } from 'next/link';
+type NextLinkProps = Omit<LinkProps, 'as'>;
+
+export const LinkComponent = ({
+	href,
+	replace,
+	scroll,
+	shallow,
+	passHref,
+	prefetch,
+	locale,
+	...props
+}: PropsWithChildren<
+	NextLinkProps & AnchorHTMLAttributes<HTMLAnchorElement>
+>) => (
+	<Link
+		href={href}
+		replace={replace}
+		scroll={scroll}
+		shallow={shallow}
+		passHref={passHref}
+		prefetch={prefetch}
+		locale={locale}
+	>
+		<a {...props} />
+	</Link>
+);

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -1,19 +1,9 @@
-import type { PropsWithChildren } from 'react';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
-import Link, { LinkProps } from 'next/link';
 import { Core } from '@ag.ds-next/core';
 import { palette } from '@ag.ds-next/ag-branding';
 
-const LinkComponent = ({
-	children,
-	className,
-	...props
-}: PropsWithChildren<LinkProps & { className?: string }>) => (
-	<Link {...props}>
-		<a className={className}>{children}</a>
-	</Link>
-);
+import { LinkComponent } from '../components/LinkComponent';
 
 export default function App({ Component, pageProps }: AppProps) {
 	return (

--- a/docs/pages/_app.tsx
+++ b/docs/pages/_app.tsx
@@ -7,10 +7,11 @@ import { palette } from '@ag.ds-next/ag-branding';
 
 const LinkComponent = ({
 	children,
+	className,
 	...props
-}: PropsWithChildren<LinkProps>) => (
+}: PropsWithChildren<LinkProps & { className?: string }>) => (
 	<Link {...props}>
-		<a>{children}</a>
+		<a className={className}>{children}</a>
 	</Link>
 );
 

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Heading } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
+import { useLinkComponent } from '@ag.ds-next/core';
 
 type HeaderBrandProps = {
 	href?: string;
@@ -15,15 +16,17 @@ export function HeaderBrand({
 	heading,
 	subline,
 }: HeaderBrandProps) {
+	const Link = useLinkComponent();
+
 	return (
 		<Flex
-			as="a"
+			as={Link}
 			href={href}
 			flexDirection={{ xs: 'column', md: 'row' }}
-			maxWidth="60rem"
 			color="text"
 			gap={1}
 			focus
+			alignItems="stretch"
 			css={{
 				textDecoration: 'none',
 				':hover': {
@@ -35,16 +38,16 @@ export function HeaderBrand({
 			{logo ? (
 				<Flex
 					alignItems="flex-start"
+					maxWidth="16rem"
 					css={{
-						' img': { maxWidth: '18rem' },
-						' svg': { maxWidth: '18rem', width: '100%' },
+						' img, svg': { width: '100%' },
 					}}
 				>
 					{logo}
 				</Flex>
 			) : null}
 			{logo ? <Box borderRight display={{ xs: 'none', md: 'block' }} /> : null}
-			<Stack justifyContent="flex-start">
+			<Stack justifyContent="center">
 				<Heading fontSize={{ xs: 'md', md: 'xl' }}>{heading}</Heading>
 				{subline && (
 					<Text color="muted" fontSize={{ xs: 'sm', md: 'md' }}>

--- a/packages/header/src/HeaderContainer.tsx
+++ b/packages/header/src/HeaderContainer.tsx
@@ -1,4 +1,5 @@
 import { Flex } from '@ag.ds-next/box';
+import { tokens } from '@ag.ds-next/core';
 import React from 'react';
 
 const variantMap = {
@@ -35,7 +36,11 @@ export function HeaderContainer({ variant, children }: HeaderContainerProps) {
 			paddingX={{ xs: 1, md: 2 }}
 			justifyContent="center"
 		>
-			<Flex justifyContent="flex-start" maxWidth={1280} width="100%">
+			<Flex
+				justifyContent="flex-start"
+				maxWidth={tokens.maxWidth.container}
+				width="100%"
+			>
 				{children}
 			</Flex>
 		</Flex>


### PR DESCRIPTION
The alignment of the Site Header was incorrect when there was no subline.

| Before  | After  |
|:----|:-----|
|  ![image](https://user-images.githubusercontent.com/814227/149721178-db6c1de7-6f91-4429-b077-8f586016d24c.png) | ![image](https://user-images.githubusercontent.com/814227/149721093-3341f6e9-c441-482f-9149-cf89c6ab4b45.png) |

