### PR TITLE
Fix: MainNav color variants 

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -52,7 +52,6 @@ export const parameters = {
 	},
 	viewport: {
 		viewports: makeViewports(tokens.breakpoint),
-		defaultViewport: 'fullscreen',
 	},
 };
 

--- a/docs/components/ReactLive/index.tsx
+++ b/docs/components/ReactLive/index.tsx
@@ -8,7 +8,7 @@ import { Box } from '@ag.ds-next/box';
 
 import { CodeHighlight } from '../CodeHighlight';
 import styles from './styles.module.css';
-import { themeVars, tokens } from '@ag.ds-next/core';
+import { themeValues, tokens } from '@ag.ds-next/core';
 
 // FIXME!!!! - styling is a mess in here. Also why we have `CodeBlock`, `CodeHighlight`, `InlineCode` and `ReactLive` is unclear. This needs thought and consolidation.
 // That plus the fact this gets rendered inside a `ag.ds/body` component is making things hard here.
@@ -124,7 +124,7 @@ export function ReactLive({
 						onValueChange={setLiveCode}
 						css={{
 							backgroundColor: 'transparent',
-							color: themeVars.foreground.text,
+							color: themeValues.foreground.text,
 							fontFamily: tokens.font.monospace,
 							fontSize: `${tokens.fontSize.xs}rem`,
 							maxWidth: '100%',
@@ -145,13 +145,13 @@ export function ReactLive({
 						<button
 							css={{
 								// background: 'var(--code-bg)',
-								background: themeVars.background.shade,
+								background: themeValues.background.shade,
 								border: 0,
 								bottom: 0,
 								borderBottomLeftRadius: '3px',
 								borderBottomRightRadius: '3px',
 								boxSizing: 'border-box',
-								color: themeVars.foreground.text, // 'var(--code)',
+								color: themeValues.foreground.text, // 'var(--code)',
 								cursor: 'pointer',
 								fontSize: '0.875rem',
 								fontWeight: 500,

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -1,8 +1,8 @@
-import { themeVars } from '@ag.ds-next/core';
+import { themeValues } from '@ag.ds-next/core';
 
 export const theme = {
 	plain: {
-		color: themeVars.foreground.text,
+		color: themeValues.foreground.text,
 		backgroundColor: '#f6f7f9',
 	},
 	styles: [

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import {
 	forwardRefWithAs,
 	tokens,
-	themeVars,
+	themeValues,
 	mapSpacing,
 	fontGrid,
 } from '@ag.ds-next/core';
@@ -20,14 +20,14 @@ export const bodyClass = css({
 	textSizeAdjust: '100%',
 
 	// can we use themes here? ... do we need to?
-	color: themeVars.foreground.text,
+	color: themeValues.foreground.text,
 
 	// Font grid
 	fontFamily: tokens.font.body,
 	...fontGrid('sm', 'default'),
 
 	a: {
-		color: themeVars.foreground.action,
+		color: themeValues.foreground.action,
 		textDecoration: 'underline',
 		textDecorationSkipInk: 'auto',
 
@@ -45,16 +45,16 @@ export const bodyClass = css({
 	 * `mark` styling.
 	 */
 	mark: {
-		color: themeVars.background.page,
-		backgroundColor: themeVars.foreground.action,
+		color: themeValues.background.page,
+		backgroundColor: themeValues.foreground.action,
 	},
 
 	/**
 	 * Text selection styling
 	 */
 	'& ::selection': {
-		color: themeVars.background.page,
-		backgroundColor: themeVars.foreground.action,
+		color: themeValues.background.page,
+		backgroundColor: themeValues.foreground.action,
 		// Why RGBA 0.99? https://stackoverflow.com/a/7224621
 	},
 
@@ -66,7 +66,7 @@ export const bodyClass = css({
 	'img::selection,video::selection,iframe::selection': {
 		// TODO: verify this doesn't need to be a RGBA color
 		// with 75% transparency
-		backgroundColor: themeVars.foreground.action,
+		backgroundColor: themeValues.foreground.action,
 	},
 
 	/**
@@ -249,8 +249,8 @@ export const bodyClass = css({
 	blockquote: {
 		padding: mapSpacing(2),
 		borderLeft: '4px solid',
-		borderColor: themeVars.border,
-		background: themeVars.background.shade,
+		borderColor: themeValues.border,
+		background: themeValues.background.shade,
 	},
 
 	/**
@@ -264,7 +264,7 @@ export const bodyClass = css({
 		display: 'inline-block',
 		borderRadius: tokens.borderRadius,
 		// backgroundColor: themeVars.background.shade, // FIXME: This conflicts with the Live Code rending in the docs site.
-		color: themeVars.foreground.text,
+		color: themeValues.foreground.text,
 	},
 
 	pre: {
@@ -285,7 +285,7 @@ export const bodyClass = css({
 		height: 0,
 		overflow: 'visible',
 		border: 'none',
-		borderTop: `1px solid ${themeVars.border}`,
+		borderTop: `1px solid ${themeValues.border}`,
 		marginBottom: mapSpacing(1.5),
 	},
 
@@ -297,10 +297,10 @@ export const bodyClass = css({
 	 *  Body colour schemes
 	 */
 	'&.au-body--alt': {
-		background: themeVars.background.pageAlt,
+		background: themeValues.background.pageAlt,
 
 		'kbd,code,samp': {
-			backgroundColor: themeVars.background.shadeAlt,
+			backgroundColor: themeValues.background.shadeAlt,
 		},
 	},
 
@@ -339,7 +339,7 @@ export const bodyClass = css({
 		},
 
 		hr: {
-			borderTopColor: themeVars.border,
+			borderTopColor: themeValues.border,
 		},
 
 		'code, kbd,samp': {

--- a/packages/box/src/Divider.tsx
+++ b/packages/box/src/Divider.tsx
@@ -1,4 +1,4 @@
-import { themeVars, globalVars } from '@ag.ds-next/core';
+import { themeValues, globalVars } from '@ag.ds-next/core';
 
 export function Divider({ accent }: { accent?: boolean }) {
 	return (
@@ -11,7 +11,7 @@ export function Divider({ accent }: { accent?: boolean }) {
 				border: 'none',
 				borderTopWidth: 1,
 				borderTopStyle: 'solid',
-				borderColor: accent ? globalVars.accent : themeVars.border,
+				borderColor: accent ? globalVars.accent : themeValues.border,
 				width: '100%',
 			}}
 		/>

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -4,7 +4,7 @@ import {
 	outline,
 	BoxTheme,
 	themes,
-	themeVars,
+	themeValues,
 	ResponsiveProp,
 	mapResponsiveProp,
 	mapSpacing,
@@ -18,14 +18,16 @@ type ThemeProps = Partial<{
 }>;
 
 type ColorProps = Partial<{
-	color: keyof typeof themeVars.foreground;
-	background: keyof typeof themeVars.background;
+	color: keyof typeof themeValues.foreground;
+	background: keyof typeof themeValues.background;
 }>;
 
 function colorStyles({ color, background }: ColorProps) {
 	return {
-		color: color ? themeVars.foreground[color] : undefined,
-		backgroundColor: background ? themeVars.background[background] : undefined,
+		color: color ? themeValues.foreground[color] : undefined,
+		backgroundColor: background
+			? themeValues.background[background]
+			: undefined,
 	};
 }
 
@@ -163,7 +165,7 @@ function borderStyles({
 		borderRightWidth: border ?? borderX ?? borderRight ? `1px` : undefined,
 		borderTopWidth: border ?? borderY ?? borderTop ? `1px` : undefined,
 		borderBottomWidth: border ?? borderY ?? borderBottom ? `1px` : undefined,
-		borderColor: anyBorder ? themeVars.border : undefined,
+		borderColor: anyBorder ? themeValues.border : undefined,
 		borderStyle: anyBorder ? 'solid' : undefined,
 		borderRadius: rounded ? tokens.borderRadius : undefined,
 	};

--- a/packages/core/src/colors.tsx
+++ b/packages/core/src/colors.tsx
@@ -25,10 +25,10 @@ export const themeValues = {
 		muted: `var(${themeVars.foreground.muted})`,
 	},
 	background: {
-		page: `var(${themeVars.background.page}`,
-		shade: `var(${themeVars.background.shade}`,
-		pageAlt: `var(${themeVars.background.pageAlt}`,
-		shadeAlt: `var(${themeVars.background.shadeAlt}`,
+		page: `var(${themeVars.background.page})`,
+		shade: `var(${themeVars.background.shade})`,
+		pageAlt: `var(${themeVars.background.pageAlt})`,
+		shadeAlt: `var(${themeVars.background.shadeAlt})`,
 	},
 	border: `var(${themeVars.border})`,
 };

--- a/packages/core/src/colors.tsx
+++ b/packages/core/src/colors.tsx
@@ -108,7 +108,7 @@ export const defaultPalette = {
 	darkBackgroundShadeAlt: '#0a323c',
 	darkBorder: '#95b7bf',
 	// system colors
-	// accent: themeValues.foreground.action, // accent does not exist in GOLD. Here we fallback to the dark or light themed action color
+	accent: undefined, // accent does not exist in GOLD.
 	error: '#d60000',
 	success: '#0b996c',
 	warning: '#f69900',
@@ -150,7 +150,7 @@ export const globalVars = {
 		},
 		border: `var(${paletteVars.darkBorder})`,
 	},
-	accent: `var(${paletteVars.accent})`, // NOTE: accent is optional
+	accent: `var(${paletteVars.accent}, ${themeValues.foreground.action})`, // NOTE: accent is optional
 	error: `var(${paletteVars.error})`,
 	success: `var(${paletteVars.success})`,
 	warning: `var(${paletteVars.warning})`,

--- a/packages/core/src/colors.tsx
+++ b/packages/core/src/colors.tsx
@@ -1,21 +1,36 @@
 import { css } from '@emotion/react';
 import { tokens } from './tokens';
 
-// Used in Box component
 export const themeVars = {
 	foreground: {
-		text: `var(--agds-foreground-text)`,
-		action: `var(--agds-foreground-action)`,
-		focus: `var(--agds-foreground-focus)`,
-		muted: `var(--agds-foreground-muted)`,
+		text: '--agds-foreground-text',
+		action: '--agds-foreground-action',
+		focus: '--agds-foreground-focus',
+		muted: '--agds-foreground-muted',
 	},
 	background: {
-		page: `var(--agds-background-page)`,
-		shade: `var(--agds-background-shade)`,
-		pageAlt: `var(--agds-background-page-alt)`,
-		shadeAlt: `var(--agds-background-shade-alt)`,
+		page: '--agds-background-page',
+		shade: '--agds-background-shade',
+		pageAlt: '--agds-background-page-alt',
+		shadeAlt: '--agds-background-shade-alt',
 	},
-	border: `var(--agds-border)`,
+	border: '--agds-border',
+};
+
+export const themeValues = {
+	foreground: {
+		text: `var(${themeVars.foreground.text})`,
+		action: `var(${themeVars.foreground.action})`,
+		focus: `var(${themeVars.foreground.focus})`,
+		muted: `var(${themeVars.foreground.muted})`,
+	},
+	background: {
+		page: `var(${themeVars.background.page}`,
+		shade: `var(${themeVars.background.shade}`,
+		pageAlt: `var(${themeVars.background.pageAlt}`,
+		shadeAlt: `var(${themeVars.background.shadeAlt}`,
+	},
+	border: `var(${themeVars.border})`,
 };
 
 // names of color
@@ -93,7 +108,7 @@ export const defaultPalette = {
 	darkBackgroundShadeAlt: '#0a323c',
 	darkBorder: '#95b7bf',
 	// system colors
-	accent: themeVars.foreground.action, // accent does not exist in GOLD. Here we fallback to the dark or light themed action color
+	// accent: themeValues.foreground.action, // accent does not exist in GOLD. Here we fallback to the dark or light themed action color
 	error: '#d60000',
 	success: '#0b996c',
 	warning: '#f69900',
@@ -135,7 +150,7 @@ export const globalVars = {
 		},
 		border: `var(${paletteVars.darkBorder})`,
 	},
-	accent: `var(${paletteVars.accent}, var(--agds-foreground-action))`,
+	accent: `var(${paletteVars.accent})`, // NOTE: accent is optional
 	error: `var(${paletteVars.error})`,
 	success: `var(${paletteVars.success})`,
 	warning: `var(${paletteVars.warning})`,
@@ -143,11 +158,6 @@ export const globalVars = {
 	hint: `var(${paletteVars.hint})`,
 	hintAlt: `var(${paletteVars.hintAlt})`,
 } as const;
-
-export type BoxthemeVars = {
-	foreground: keyof typeof themeVars.foreground;
-	background: keyof typeof themeVars.background;
-};
 
 export const themes = {
 	light: css({
@@ -181,6 +191,6 @@ export type BoxTheme = keyof typeof themes;
 export const outline = {
 	outlineWidth: '3px',
 	outlineStyle: 'solid',
-	outlineColor: themeVars.foreground.focus,
+	outlineColor: themeValues.foreground.focus,
 	outlineOffset: 0.5 * tokens.unit,
 };

--- a/packages/link-list/src/LinkListItem.tsx
+++ b/packages/link-list/src/LinkListItem.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
-import { useLinkComponent, themeVars, outline } from '@ag.ds-next/core';
+import { useLinkComponent, themeValues, outline } from '@ag.ds-next/core';
 
 export const LinkListItem = (
 	props: PropsWithChildren<{
@@ -16,11 +16,11 @@ export const LinkListItem = (
 			lineHeight="default"
 			css={{
 				a: {
-					color: themeVars.foreground.action,
+					color: themeValues.foreground.action,
 					textDecoration: 'underline',
 
 					'&:hover': {
-						color: themeVars.foreground.action,
+						color: themeValues.foreground.action,
 						textDecoration: 'none',
 					},
 

--- a/packages/main-nav/src/MainNav.stories.tsx
+++ b/packages/main-nav/src/MainNav.stories.tsx
@@ -22,7 +22,7 @@ const Template: ComponentStory<typeof MainNav> = (args) => (
 export const MainNavDark = Template.bind({});
 MainNavDark.args = {
 	links: NAV_ITEMS,
-	activePath: '#home',
+	activePath: '#content',
 	variant: 'dark',
 };
 

--- a/packages/main-nav/src/MenuButtons.tsx
+++ b/packages/main-nav/src/MenuButtons.tsx
@@ -1,5 +1,5 @@
 import { Box } from '@ag.ds-next/box';
-import { themeVars } from '@ag.ds-next/core';
+import { themeValues } from '@ag.ds-next/core';
 
 import { localValues } from './utils';
 
@@ -24,10 +24,10 @@ function MenuButton({
 			focus
 			css={{
 				background: 'transparent',
-				color: themeVars.foreground.action,
+				color: themeValues.foreground.action,
 
 				'&:hover': {
-					color: themeVars.foreground.text,
+					color: themeValues.foreground.text,
 					backgroundColor: localValues.linkHoverBg,
 				},
 			}}

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -3,32 +3,36 @@ import FocusTrap from 'focus-trap-react';
 
 import { Box, Flex } from '@ag.ds-next/box';
 import {
-	globalVars,
+	paletteVars,
 	themeValues,
 	useTernaryState,
 	mapSpacing,
 	tokens,
 } from '@ag.ds-next/core';
 
-import { localVars } from './utils';
+import { localValues, localVars } from './utils';
 import { CloseButton, ToggleButton } from './MenuButtons';
 
 const variantMap = {
 	light: {
 		theme: 'light',
 		background: 'page',
+		hover: 'shade',
 	},
 	lightAlt: {
 		theme: 'light',
-		background: 'shade',
+		background: 'pageAlt',
+		hover: 'shadeAlt',
 	},
 	dark: {
 		theme: 'dark',
 		background: 'page',
+		hover: 'shade',
 	},
 	darkAlt: {
 		theme: 'dark',
-		background: 'shade',
+		background: 'pageAlt',
+		hover: 'shadeAlt',
 	},
 } as const;
 
@@ -37,19 +41,20 @@ export type NavContainerProps = React.PropsWithChildren<{
 }>;
 
 export function NavContainer({ variant, children }: NavContainerProps) {
-	const { theme, background } = variantMap[variant];
+	const { theme, background, hover } = variantMap[variant];
 	const [menuOpen, open, close] = useTernaryState(false);
 
 	return (
 		<Box
+			data-name="nav-container"
 			theme={theme}
 			background={background}
 			color="text"
 			css={{
 				position: 'relative',
-				[localVars.linkHoverBg]: themeValues.background.shade,
-				[localVars.linkHoverBorder]: themeValues.background.page,
-				[localVars.linkActiveBorder]: themeValues.background[background],
+				[localVars.linkHoverBg]: themeValues.background[hover],
+				[localVars.linkActiveBg]: themeValues.background[background],
+				[localVars.bottomBar]: `var(${paletteVars.accent}, ${themeValues.foreground.action})`,
 			}}
 		>
 			<BottomBar />
@@ -126,6 +131,7 @@ function Overlay({ menuOpen }: { menuOpen: boolean }) {
 function BottomBar() {
 	return (
 		<Box
+			data-name="nav-bottom-bar"
 			display={{ xs: 'none', md: 'block' }}
 			paddingTop={0.5}
 			css={{
@@ -133,7 +139,7 @@ function BottomBar() {
 				bottom: 0,
 				left: 0,
 				right: 0,
-				backgroundColor: globalVars.accent,
+				backgroundColor: localValues.bottomBar,
 			}}
 		/>
 	);

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -4,7 +4,7 @@ import FocusTrap from 'focus-trap-react';
 import { Box, Flex } from '@ag.ds-next/box';
 import {
 	globalVars,
-	themeVars,
+	themeValues,
 	useTernaryState,
 	mapSpacing,
 	tokens,
@@ -47,9 +47,9 @@ export function NavContainer({ variant, children }: NavContainerProps) {
 			color="text"
 			css={{
 				position: 'relative',
-				[localVars.linkHoverBg]: themeVars.background.shade,
-				[localVars.linkHoverBorder]: themeVars.background.page,
-				[localVars.linkActiveBorder]: themeVars.background[background],
+				[localVars.linkHoverBg]: themeValues.background.shade,
+				[localVars.linkHoverBorder]: themeValues.background.page,
+				[localVars.linkActiveBorder]: themeValues.background[background],
 			}}
 		>
 			<BottomBar />
@@ -73,7 +73,7 @@ export function NavContainer({ variant, children }: NavContainerProps) {
 									zIndex: 200,
 									position: 'fixed',
 									display: menuOpen ? 'block' : 'none',
-									background: themeVars.background.page,
+									background: themeValues.background.page,
 									top: 0,
 									left: 0,
 									bottom: 0,

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -8,6 +8,7 @@ import {
 	useTernaryState,
 	mapSpacing,
 	tokens,
+	globalVars,
 } from '@ag.ds-next/core';
 
 import { localValues, localVars } from './utils';
@@ -54,7 +55,7 @@ export function NavContainer({ variant, children }: NavContainerProps) {
 				position: 'relative',
 				[localVars.linkHoverBg]: themeValues.background[hover],
 				[localVars.linkActiveBg]: themeValues.background[background],
-				[localVars.bottomBar]: `var(${paletteVars.accent}, ${themeValues.foreground.action})`,
+				[localVars.bottomBar]: globalVars.accent,
 			}}
 		>
 			<BottomBar />

--- a/packages/main-nav/src/NavItem.tsx
+++ b/packages/main-nav/src/NavItem.tsx
@@ -1,5 +1,5 @@
 import {
-	themeVars,
+	themeValues,
 	mapSpacing,
 	outline,
 	mq,
@@ -8,7 +8,7 @@ import {
 import { Box } from '@ag.ds-next/box';
 import type { ReactNode } from 'react';
 
-import { localVars } from './utils';
+import { localValues } from './utils';
 
 export function NavItem({
 	children,
@@ -27,7 +27,7 @@ export function NavItem({
 				' a': {
 					position: 'relative',
 					display: 'block',
-					color: themeVars.foreground[active ? 'text' : 'action'],
+					color: themeValues.foreground[active ? 'text' : 'action'],
 					padding: mapSpacing(1),
 					textDecoration: 'none',
 
@@ -45,7 +45,7 @@ export function NavItem({
 						left: 0,
 						right: 0,
 						backgroundColor: active
-							? `var(${localVars.linkActiveBorder})`
+							? localValues.linkActiveBorder
 							: 'transparent',
 					},
 
@@ -71,13 +71,11 @@ export function NavItem({
 					'&:hover': {
 						textDecoration: 'underline',
 						textDecorationSkipInk: 'auto',
-						color: themeVars.foreground.text,
-						backgroundColor: `var(${localVars.linkHoverBg})`,
+						color: themeValues.foreground.text,
+						backgroundColor: localValues.linkHoverBg,
 
 						'&::after': {
-							background: active
-								? `var(${localVars.linkHoverBg})`
-								: 'transparent',
+							background: active ? localValues.linkHoverBg : 'transparent',
 						},
 					},
 				},

--- a/packages/main-nav/src/NavItem.tsx
+++ b/packages/main-nav/src/NavItem.tsx
@@ -44,9 +44,7 @@ export function NavItem({
 						top: '100%',
 						left: 0,
 						right: 0,
-						backgroundColor: active
-							? localValues.linkActiveBorder
-							: 'transparent',
+						backgroundColor: active ? localValues.linkActiveBg : 'transparent',
 					},
 
 					// Focus styles

--- a/packages/main-nav/src/NavList.tsx
+++ b/packages/main-nav/src/NavList.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Flex } from '@ag.ds-next/box';
-import { themeVars, tokens, useLinkComponent } from '@ag.ds-next/core';
+import { themeValues, tokens, useLinkComponent } from '@ag.ds-next/core';
 
 import { NavItem } from './NavItem';
 
@@ -21,7 +21,7 @@ export function NavList({ links, activePath }: NavListProps) {
 			css={{
 				[tokens.mediaQuery.max.sm]: {
 					'& > li': {
-						borderTop: `1px solid ${themeVars.border}`,
+						borderTop: `1px solid ${themeValues.border}`,
 					},
 				},
 			}}

--- a/packages/main-nav/src/utils.ts
+++ b/packages/main-nav/src/utils.ts
@@ -1,10 +1,10 @@
 export const localVars = {
 	linkHoverBg: '--nav-linkHoverBg',
-	linkHoverBorder: '--nav-linkHoverBorder',
-	linkActiveBorder: '--nav-linkActiveBorder',
+	linkActiveBg: '--nav-linkActiveBg',
+	bottomBar: '--nav-bottomBar',
 };
 export const localValues = {
-	linkHoverBg: 'var(--nav-linkHoverBg)',
-	linkHoverBorder: 'var(--nav-linkHoverBorder)',
-	linkActiveBorder: 'var(--nav-linkActiveBorder)',
+	linkHoverBg: `var(${localVars.linkHoverBg})`,
+	linkActiveBg: `var(${localVars.linkActiveBg})`,
+	bottomBar: `var(${localVars.bottomBar})`,
 };

--- a/packages/text-link/src/index.tsx
+++ b/packages/text-link/src/index.tsx
@@ -1,13 +1,13 @@
-import { themeVars, outline } from '@ag.ds-next/core';
+import { themeValues, outline } from '@ag.ds-next/core';
 import { HTMLProps } from 'react';
 
 export function textLinkStyles() {
 	return {
-		color: themeVars.foreground.action,
+		color: themeValues.foreground.action,
 		textDecoration: 'underline',
 
 		'&:hover': {
-			color: themeVars.foreground.action,
+			color: themeValues.foreground.action,
 			textDecoration: 'none',
 		},
 


### PR DESCRIPTION
Somewhere along the way we broke the color variant for this.

Before:
![image](https://user-images.githubusercontent.com/814227/150234769-b14db6c8-e473-422c-9f1a-ab69c25e7830.png)


After:
![image](https://user-images.githubusercontent.com/814227/150234815-82cafdbf-bb14-438b-bc9e-f122f3b233ce.png)

Also, in a bid for consistency of naming, I've renamed `themeVars` to `themeValues`. The convention I'm creating here is as follows:

`...Vars` is the css variable name. `--agds-foreground-text`.
`...Values` is the css variable as a value. `var(--agds-foreground-text)`.

So `vars` are for setting, `values` are for getting.

This still needs to be changed for `GlobalVars`.
