### PR TITLE
LinkList: Enable wrapping for longer lists

### DIFF
--- a/.changeset/light-actors-rush.md
+++ b/.changeset/light-actors-rush.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/link-list': minor
+---
+
+Enable wrapping for LinkList

--- a/packages/link-list/src/LinkListContainer.tsx
+++ b/packages/link-list/src/LinkListContainer.tsx
@@ -15,6 +15,7 @@ export const LinkListContainer = ({
 			as="ul"
 			gap={horizontal ? 1 : 0.5}
 			flexDirection={horizontal ? 'row' : 'column'}
+			flexWrap="wrap"
 		>
 			{children}
 		</Stack>


### PR DESCRIPTION
For horizontal link lists, we want to enable wrapping so they layout doesn't break.

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/12689383/151475432-7730bbbb-f3d9-42be-aa45-9f24af777906.png">
