### PR TITLE
Header: Compose with Columns. Add rightContent slot.

### DIFF
--- a/.changeset/blue-toes-raise.md
+++ b/.changeset/blue-toes-raise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/header': minor
+---
+
+Compose with Columns. Add rightContent slot.

--- a/.changeset/kind-vans-cheat.md
+++ b/.changeset/kind-vans-cheat.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/core': minor
+'@ag.ds-next/content': patch
+'@ag.ds-next/footer': patch
+---
+
+Core: Rename gutter token to containerPadding

--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -2,7 +2,7 @@ const snippits = [
 	{
 		group: 'Boilerplate',
 		name: 'One',
-		code: `<Header logo={<Logo />} heading="Export services" />
+		code: `<Header logo={<Logo />} heading="Export Service" />
     <MainNav links={[{ label: "Hello", href: "#" }]} variant='agriculture' />
 
     <Content>

--- a/packages/content/src/Content.tsx
+++ b/packages/content/src/Content.tsx
@@ -27,7 +27,7 @@ export function Content({
 				width="100%"
 				maxWidth={tokens.maxWidth.container}
 				paddingY={paddingYMap[spacing]}
-				paddingX={{ xs: 1, md: 2 }}
+				paddingX={tokens.containerPadding}
 				gap={1}
 			>
 				{children}

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -68,7 +68,7 @@ export function mapSpacing(v: Spacing) {
 	return `${v}rem`;
 }
 
-const gutter = { xs: 1, md: 2 } as const;
+const containerPadding = { xs: 0.75, md: 2 } as const;
 
 const maxWidth = {
 	bodyText: '42em',
@@ -87,7 +87,7 @@ export const tokens = {
 	fontSize,
 	fontWeight,
 	lineHeight,
-	gutter,
+	containerPadding,
 	maxWidth,
 	borderRadius,
 };

--- a/packages/footer/src/Footer.tsx
+++ b/packages/footer/src/Footer.tsx
@@ -32,7 +32,7 @@ export const Footer = ({ variant = 'dark', children }: FooterProps) => {
 				maxWidth={tokens.maxWidth.container}
 				width="100%"
 				gap={1.5}
-				paddingX={tokens.gutter}
+				paddingX={tokens.containerPadding}
 			>
 				{children}
 			</Stack>

--- a/packages/header/README.md
+++ b/packages/header/README.md
@@ -6,12 +6,13 @@ description: The masthead of our applications, Header incorporates our AWE brand
 
 ```jsx live
 <Header
-  heading="Export Service"
-  subline="Supporting Australian agricultural exports"
-  logo={<AgLogo />}
+	heading="Export Service"
+	subline="Supporting Australian agricultural exports"
+	logo={<AgLogo />}
 	variant="dark"
 />
 ```
+
 ## Heading and Subline
 
 Heading should be set to the website or service title.

--- a/packages/header/README.md
+++ b/packages/header/README.md
@@ -6,9 +6,14 @@ description: The masthead of our applications, Header incorporates our AWE brand
 
 ```jsx live
 <Header
+  heading="Export Service"
+  subline="Supporting Australian agricultural exports"
+  logo={<AgLogo />}
 	variant="dark"
-	logo={<AgLogo />}
-	heading="AG Design-System"
-	subline="Welcome to the AG Design-System"
 />
 ```
+## Heading and Subline
+
+Heading should be set to the website or service title.
+
+Subline can provide additional information to describe your website or service.

--- a/packages/header/src/Header.stories.tsx
+++ b/packages/header/src/Header.stories.tsx
@@ -28,8 +28,8 @@ export default {
 } as ComponentMeta<typeof Header>;
 
 const defaultArgs = {
-	heading: 'Example heading',
-	subline: 'Example subline',
+	heading: 'Export Service',
+	subline: 'Supporting Australian agricultural exports',
 };
 
 function getLogo(context: any, variant = 'dark') {
@@ -119,7 +119,7 @@ export const HeaderSearch: ComponentStory<typeof Header> = (args, context) => (
 	/>
 );
 HeaderSearch.args = {
-	heading: 'Export Services',
-	subline: 'Example subline',
+	heading: 'Export Service',
+	subline: 'Supporting Australian agricultural exports',
 };
 HeaderSearch.storyName = '🕥 Header Search';

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@ag.ds-next/box';
+import { Column } from '@ag.ds-next/columns';
 import { HeaderContainer } from './HeaderContainer';
 import { HeaderBrand } from './HeaderBrand';
 import type { ReactNode } from 'react';
@@ -20,23 +20,21 @@ export function Header({
 	variant = 'dark',
 	href = '/',
 }: HeaderProps) {
+	const hasRightContent = !!rightContent;
 	return (
 		<HeaderContainer variant={variant}>
-			<HeaderBrand
-				logo={logo}
-				href={href}
-				heading={heading}
-				subline={subline}
-			/>
-			<HeaderRight>{rightContent}</HeaderRight>
+			<Column columnSpan={{ xs: 12, md: hasRightContent ? 8 : 12 }}>
+				<HeaderBrand
+					logo={logo}
+					href={href}
+					heading={heading}
+					subline={subline}
+				/>
+			</Column>
+
+			{hasRightContent && (
+				<Column columnSpan={{ xs: 12, md: 4 }}>{rightContent}</Column>
+			)}
 		</HeaderContainer>
 	);
 }
-
-const HeaderRight = ({ children }: { children: ReactNode }) => {
-	return (
-		<Flex width={{ xs: '100%', md: '33.33%' }} alignItems="flex-end">
-			{children}
-		</Flex>
-	);
-};

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -48,7 +48,7 @@ export function HeaderBrand({
 			{logo ? <Box borderRight display={{ xs: 'none', md: 'block' }} /> : null}
 			<Stack justifyContent="center">
 				<Text
-					lineHeight="default"
+					lineHeight="heading"
 					fontSize={{ xs: 'md', md: 'xl' }}
 					fontWeight="bold"
 				>

--- a/packages/header/src/HeaderContainer.tsx
+++ b/packages/header/src/HeaderContainer.tsx
@@ -1,5 +1,6 @@
 import { Flex } from '@ag.ds-next/box';
 import { tokens } from '@ag.ds-next/core';
+import { Columns } from '@ag.ds-next/columns';
 import React from 'react';
 
 const variantMap = {
@@ -35,17 +36,14 @@ export function HeaderContainer({ variant, children }: HeaderContainerProps) {
 			paddingY={{ xs: 1, md: 3 }}
 			justifyContent="center"
 		>
-			<Flex
-				justifyContent="space-between"
-				flexDirection={{ xs: 'column', md: 'row' }}
-				alignItems={{ md: 'center' }}
-				gap={1.5}
+			<Columns
+				alignItems="center"
 				maxWidth={tokens.maxWidth.container}
-				paddingX={{ xs: 0.75, md: 2 }}
+				paddingX={tokens.containerPadding}
 				width="100%"
 			>
 				{children}
-			</Flex>
+			</Columns>
 		</Flex>
 	);
 }


### PR DESCRIPTION
- Recompose Header with Columns component
- Change HeaderBrand title line height
- Add changeset, including a recent change to add the rightContent prop (which was recently merged in)

Pictured: New Header with placeholder SearchBox component
<img width="1102" alt="image" src="https://user-images.githubusercontent.com/12689383/152279609-8cc19118-e575-4113-b266-2f6b63508b8b.png">
