### PR TITLE
Core: Remove `hint` and `hintAlt` color tokens

### DIFF
--- a/.changeset/funny-panthers-brush.md
+++ b/.changeset/funny-panthers-brush.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/core': minor
+---
+
+Retire hint color

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -17,13 +17,13 @@ export const agTheme: PrismTheme = {
 		{
 			types: ['punctuation', 'entity'],
 			style: {
-				color: globalVars.hintAlt,
+				color: globalVars.light.foreground.muted,
 			},
 		},
 		{
 			types: ['operator', 'doctype'],
 			style: {
-				color: globalVars.hintAlt,
+				color: globalVars.light.foreground.muted,
 				opacity: 0.7,
 			},
 		},

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -25,8 +25,6 @@ const foregroundColorMap = {
 	success: globalVars.success,
 	warning: globalVars.warning,
 	info: globalVars.info,
-	hint: globalVars.hint,
-	hintAlt: globalVars.hintAlt,
 };
 
 type ColorProps = Partial<{

--- a/packages/core/src/colors.tsx
+++ b/packages/core/src/colors.tsx
@@ -61,8 +61,6 @@ export const paletteVars = {
 	success: '--agds-success',
 	warning: '--agds-warning',
 	info: '--agds-info',
-	hint: '--agds-hint',
-	hintAlt: '--agds-hint-alt',
 } as const;
 
 export type Palette = Partial<Record<keyof typeof paletteVars, string>>;
@@ -113,8 +111,6 @@ export const defaultPalette = {
 	success: '#0b996c',
 	warning: '#f69900',
 	info: '#00bfe9',
-	hint: '#6f777b',
-	hintAlt: '#61696b',
 } as const;
 
 export type PaletteKey = keyof typeof paletteVars;
@@ -155,8 +151,6 @@ export const globalVars = {
 	success: `var(${paletteVars.success})`,
 	warning: `var(${paletteVars.warning})`,
 	info: `var(${paletteVars.info})`,
-	hint: `var(${paletteVars.hint})`,
-	hintAlt: `var(${paletteVars.hintAlt})`,
 } as const;
 
 export const themes = {


### PR DESCRIPTION
We (Adrian and I) identified that our system doesn't currently use hint text anywhere consistently, and that it does not have sufficient contrast with all backgrounds. We therefore move to use the foregroundMuted color for each palette instead.

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/12689383/152284987-4b39b5ef-fccb-4a97-bd05-ebd41c4f1dce.png">
