### PR TITLE
Docs: Remove next image

### DIFF
--- a/.changeset/ten-humans-compete.md
+++ b/.changeset/ten-humans-compete.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/docs': patch
+'@ag.ds-next/example-site': patch
+---
+
+Remove usage of NextImage to fix builds

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,4 +8,14 @@ module.exports = {
 		'next/core-web-vitals',
 		'prettier',
 	],
+	overrides: [
+		{
+			// Both of these sites are hosted using GitHub pages
+			// which is incompatible with @next/image
+			files: ['docs/**/*', 'example-site/**/*'],
+			rules: {
+				'@next/next/no-img-element': 'off',
+			},
+		},
+	],
 };

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -31,11 +31,10 @@ const PlaceholderImage = ({
 }: Omit<ComponentProps<typeof Image>, 'src'> & {
 	width: number;
 	height: number;
-	alt: string;
 }) => (
 	<img
 		src="/agds-next/img/placeholder/600x200.png"
-		alt={alt}
+		alt="Grey placeholder image"
 		width={width}
 		height={height}
 		layout="responsive"

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -33,8 +33,8 @@ const PlaceholderImage = ({
 	height: number;
 	alt: string;
 }) => (
-	<Image
-		src={`/agds-next/img/placeholder/${width}x${height}.png`}
+	<img
+		src="/agds-next/img/placeholder/600x200.png"
 		alt={alt}
 		width={width}
 		height={height}

--- a/docs/components/PkgCardList.tsx
+++ b/docs/components/PkgCardList.tsx
@@ -21,7 +21,7 @@ const PkgCard = ({ pkg }: { pkg: Pkg }) => (
 			padding={1}
 			background="shade"
 		>
-			<Image src={getPictogram(pkg.slug)} alt={`Pictogram of ${pkg.title}`} />
+			<img src={getPictogram(pkg.slug).src} alt={`Pictogram of ${pkg.title}`} />
 		</Flex>
 		<CardInner>
 			<CardLink href={`/packages/${pkg.group}/${pkg.slug}`}>

--- a/example-site/pages/index.tsx
+++ b/example-site/pages/index.tsx
@@ -1,7 +1,5 @@
 import type { NextPage } from 'next';
 import Head from 'next/head';
-import Image from 'next/image';
-import placeholder from '../public/placeholder.png';
 
 import { Body } from '@ag.ds-next/body';
 import { Flex } from '@ag.ds-next/box';
@@ -38,10 +36,10 @@ const Home: NextPage = () => {
 							sit amet, consectetur adipiscing elit.
 						</p>
 					</Body>
-					<Image
+					<img
 						width={600}
 						height={260}
-						src={placeholder}
+						src="/placeholder.png"
 						alt="Place holder image"
 					/>
 				</Flex>

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -39,7 +39,7 @@ A card with an image. For full width images, add the img tag outside the `CardIn
 
 ```jsx live
 <Card>
-	<PlaceholderImage alt="Grey placeholder image" />
+	<PlaceholderImage />
 	<CardInner>
 		<Body>
 			<a href="#">Action</a>
@@ -54,7 +54,7 @@ For cards that contain a single link, the hit area for that link can be made to 
 
 ```jsx live
 <Card shadow clickable>
-	<PlaceholderImage alt="Grey placeholder image" />
+	<PlaceholderImage />
 	<CardInner>
 		<Body>
 			<h3>

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -39,7 +39,7 @@ A card with an image. For full width images, add the img tag outside the `CardIn
 
 ```jsx live
 <Card>
-	<PlaceholderImage width={600} height={260} alt="Grey placeholder image" />
+	<PlaceholderImage alt="Grey placeholder image" />
 	<CardInner>
 		<Body>
 			<a href="#">Action</a>
@@ -54,7 +54,7 @@ For cards that contain a single link, the hit area for that link can be made to 
 
 ```jsx live
 <Card shadow clickable>
-	<PlaceholderImage width={600} height={260} alt="Grey placeholder image" />
+	<PlaceholderImage alt="Grey placeholder image" />
 	<CardInner>
 		<Body>
 			<h3>


### PR DESCRIPTION
Next's Image component is incompatible with Github Pages, so we need to take it out in order to get the website to build again.