### PR TITLE
Docs: Apply button weights to code preview

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -102,10 +102,10 @@ const LiveCode = withLive((props: unknown) => {
 				</Box>
 			) : null}
 			<Flex theme="light" padding={0.5} gap={0.5} justifyContent="flex-end">
-				<Button size="sm" onClick={copyLiveCode}>
+				<Button size="sm" variant="secondary" onClick={copyLiveCode}>
 					Copy
 				</Button>
-				<Button size="sm" variant="secondary" onClick={resetLiveCode}>
+				<Button size="sm" variant="tertiary" onClick={resetLiveCode}>
 					Reset
 				</Button>
 			</Flex>


### PR DESCRIPTION
Demote buttons in CodePreview component to secondary and tertiary.
<img width="234" alt="image" src="https://user-images.githubusercontent.com/12689383/152708341-4bda79e4-bbe3-4ce4-ae2b-b0fa4b2322b8.png">
