### PR TITLE
docs: Update padding in code examples

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -9,7 +9,7 @@ import {
 import { Language } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
 
-import { globalVars, tokens } from '@ag.ds-next/core';
+import { globalVars, mapSpacing, tokens } from '@ag.ds-next/core';
 import { Box, Flex } from '@ag.ds-next/box';
 import { Button } from '@ag.ds-next/button';
 
@@ -66,7 +66,7 @@ const LiveCode = withLive((props: unknown) => {
 				boxShadow: `0 0 1px ${globalVars.light.border}`,
 			}}
 		>
-			<Box padding={0.5}>
+			<Box padding={1}>
 				<LivePreview
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
@@ -83,6 +83,9 @@ const LiveCode = withLive((props: unknown) => {
 				disabled={live.disabled}
 				onChange={handleChange}
 				css={{
+					'textarea, pre': {
+						padding: `${mapSpacing(1)} !important`,
+					},
 					'& ::selection': {
 						color: globalVars.dark.background.body,
 						backgroundColor: globalVars.dark.foreground.action,
@@ -101,7 +104,7 @@ const LiveCode = withLive((props: unknown) => {
 					{live.error}
 				</Box>
 			) : null}
-			<Flex theme="light" padding={0.5} gap={0.5} justifyContent="flex-end">
+			<Flex theme="light" padding={1} gap={0.5} justifyContent="flex-end">
 				<Button size="sm" variant="secondary" onClick={copyLiveCode}>
 					Copy
 				</Button>


### PR DESCRIPTION
Replace `0.5rem` padding with `1rem` padding

The default padding for [react-simple-code-editor](https://www.npmjs.com/package/react-simple-code-editor) is 10px. They do not offer a very nice way to override this value, which is why I had to use `!important`).