### PR TITLE
Box: Add `inherit` to foreground color map

### DIFF
--- a/.changeset/wise-terms-guess.md
+++ b/.changeset/wise-terms-guess.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/box': patch
+---
+
+Added `inherit` to the foreground color map

--- a/docs/pages/packages/index.tsx
+++ b/docs/pages/packages/index.tsx
@@ -43,7 +43,7 @@ export default function PackagesHome({
 					{groupList.map((group) => (
 						<Stack gap={1} key={group.slug}>
 							<TextLink href={`/packages/${group.slug}`}>
-								<H2>{group.title}</H2>
+								<H2 color="inherit">{group.title}</H2>
 							</TextLink>
 							<PkgCardList
 								items={pkgList.filter((p) => p.group === group.slug)}

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -36,6 +36,7 @@ export const foregroundColorMap = {
 	success: globalPalette.success,
 	warning: globalPalette.warning,
 	info: globalPalette.info,
+	inherit: 'inherit',
 };
 
 export const backgroundColorMap = {


### PR DESCRIPTION
This change enables us to use text components (such as `H1`, `H2` etc) inside of `TextLink` and have the colours from all states (hover/focus etc) applied.