### PR TITLE
Header: Tweak responsive logic for text sizes

### DIFF
--- a/.changeset/mighty-seals-flash.md
+++ b/.changeset/mighty-seals-flash.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/footer': patch
+---
+
+Storybook fixes

--- a/.changeset/silent-items-protect.md
+++ b/.changeset/silent-items-protect.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/header': patch
+---
+
+Tweak responsive logic for text sizes

--- a/packages/footer/src/Footer.stories.tsx
+++ b/packages/footer/src/Footer.stories.tsx
@@ -22,9 +22,10 @@ const AgSimpleFooter: ComponentStory<typeof Footer> = (args) => {
 			<LinkList
 				horizontal
 				links={[
-					{ href: '#', label: 'Link 1' },
-					{ href: '#', label: 'Link 2' },
-					{ href: '#', label: 'Link 3' },
+					{ href: '#', label: 'Home' },
+					{ href: '#', label: 'Terms and conditions' },
+					{ href: '#', label: 'Privacy policy' },
+					{ href: '#', label: 'A really long link title' },
 				]}
 			/>
 			<FooterDivider />
@@ -54,7 +55,7 @@ SimpleFooterLight.args = {
 };
 
 export const SimpleFooterLightAlt = AgSimpleFooter.bind({});
-SimpleFooterLight.args = {
+SimpleFooterLightAlt.args = {
 	variant: 'lightAlt',
 };
 
@@ -64,7 +65,7 @@ SimpleFooterDark.args = {
 };
 
 export const SimpleFooterDarkAlt = AgSimpleFooter.bind({});
-SimpleFooterDark.args = {
+SimpleFooterDarkAlt.args = {
 	variant: 'darkAlt',
 };
 
@@ -156,7 +157,7 @@ ComplexFooterLight.args = {
 };
 
 export const ComplexFooterLightAlt = AgComplexFooter.bind({});
-ComplexFooterLight.args = {
+ComplexFooterLightAlt.args = {
 	variant: 'lightAlt',
 };
 
@@ -166,6 +167,6 @@ ComplexFooterDark.args = {
 };
 
 export const ComplexFooterDarkAlt = AgComplexFooter.bind({});
-ComplexFooterDark.args = {
+ComplexFooterDarkAlt.args = {
 	variant: 'darkAlt',
 };

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -49,13 +49,13 @@ export function HeaderBrand({
 			<Stack justifyContent="center">
 				<Text
 					lineHeight="heading"
-					fontSize={{ xs: 'md', md: 'xl' }}
+					fontSize={{ xs: 'md', sm: 'xl' }}
 					fontWeight="bold"
 				>
 					{heading}
 				</Text>
 				{subline && (
-					<Text color="muted" fontSize={{ xs: 'sm', md: 'md' }}>
+					<Text color="muted" fontSize={{ xs: 'sm', sm: 'md' }}>
 						{subline}
 					</Text>
 				)}


### PR DESCRIPTION
Update responsive logic in Header, so larger font size is shown for tablet viewport.

<img width="434" alt="image" src="https://user-images.githubusercontent.com/12689383/152734910-a597492c-83ef-43fd-bec8-fd45d7d44ca5.png">
<img width="660" alt="image" src="https://user-images.githubusercontent.com/12689383/152734925-88265a4b-ae44-4ad8-ad78-a31d0c1ee9dc.png">
<img width="814" alt="image" src="https://user-images.githubusercontent.com/12689383/152734947-78d2e51a-c9fb-4b97-b160-f1399d514f7e.png">

Also, make some updates to Footer's stories