### PR TITLE
Header: Adjust logo sizing for small breakpoints

### DIFF
--- a/.changeset/tame-tables-attack.md
+++ b/.changeset/tame-tables-attack.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/header': patch
+---
+
+Adjust logo sizing for small breakpoints

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -37,7 +37,7 @@ export function HeaderBrand({
 			{logo ? (
 				<Flex
 					alignItems="flex-start"
-					maxWidth="16rem"
+					maxWidth={{ xs: '12rem', sm: '16rem' }}
 					css={{
 						' img, svg': { width: '100%' },
 					}}


### PR DESCRIPTION
Logo now has a smaller size for mobile viewports
<img width="462" alt="image" src="https://user-images.githubusercontent.com/12689383/152894069-c39ff51e-959b-41f3-af67-c0a93f6a3c4e.png">
