### PR TITLE
Docs: Show secondary button in CodePreview

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -140,7 +140,7 @@ const StaticCode = ({
 				disabled
 			/>
 			<Flex palette="light" padding={1} justifyContent="flex-end">
-				<Button size="sm" onClick={() => copy(code)}>
+				<Button size="sm" variant="secondary" onClick={() => copy(code)}>
 					Copy
 				</Button>
 			</Flex>


### PR DESCRIPTION
<img width="674" alt="image" src="https://user-images.githubusercontent.com/12689383/152897972-41ec71a0-658a-4036-ae88-1f141bebb6b4.png">
