### PR TITLE
docs: Add breadcrumbs to guides and releases

### DIFF
--- a/docs/lib/mdxUtils.ts
+++ b/docs/lib/mdxUtils.ts
@@ -213,6 +213,23 @@ export function getReleaseList() {
 	);
 }
 
+function releaseNavMetaData(
+	slug: string,
+	data: Awaited<ReturnType<typeof getMarkdownData>>['data']
+) {
+	return {
+		title: (data?.title ?? slug) as string,
+		slug,
+	};
+}
+
+export function getReleaseBreadcrumbs(slug: string) {
+	return getMarkdownData(releasePath(slug)).then(({ data }) => {
+		const meta = releaseNavMetaData(slug, data);
+		return [{ href: '/releases', label: 'Releases' }, { label: meta.title }];
+	});
+}
+
 export type Release = Awaited<ReturnType<typeof getRelease>>;
 export type ReleaseList = Awaited<ReturnType<typeof getReleaseList>>;
 
@@ -256,6 +273,23 @@ export function getGuideList() {
 			)
 		)
 	);
+}
+
+function guideNavMetaData(
+	slug: string,
+	data: Awaited<ReturnType<typeof getMarkdownData>>['data']
+) {
+	return {
+		title: (data?.title ?? slug) as string,
+		slug,
+	};
+}
+
+export function getGuidesBreadcrumbs(slug: string) {
+	return getMarkdownData(guidePath(slug)).then(({ data }) => {
+		const meta = guideNavMetaData(slug, data);
+		return [{ href: '/guides', label: 'Guides' }, { label: meta.title }];
+	});
 }
 
 export type Guide = Awaited<ReturnType<typeof getGuide>>;

--- a/docs/pages/guides/[slug].tsx
+++ b/docs/pages/guides/[slug].tsx
@@ -7,6 +7,7 @@ import { Body } from '@ag.ds-next/body';
 import {
 	getGuide,
 	getGuideList,
+	getGuidesBreadcrumbs,
 	getGuideSlugs,
 	Guide,
 } from '../../lib/mdxUtils';
@@ -18,6 +19,7 @@ import { PageLayout } from '../../components/PageLayout';
 export default function Guides({
 	guide,
 	guideLinks,
+	breadcrumbs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<AppLayout>
@@ -28,6 +30,7 @@ export default function Guides({
 					items: guideLinks,
 				}}
 				editPath={`/guides/${guide.slug}.mdx`}
+				breadcrumbs={breadcrumbs}
 			>
 				<Flex as="main" flexDirection="column" gap={1} alignItems="flex-start">
 					<H1>{guide.data.title}</H1>
@@ -44,25 +47,30 @@ export const getStaticProps: GetStaticProps<
 	{
 		guide: Guide;
 		guideLinks: { href: string; label: string }[];
+		breadcrumbs: Awaited<ReturnType<typeof getGuidesBreadcrumbs>>;
 	},
 	{ slug: string }
 > = async ({ params }) => {
-	const guide = params ? await getGuide(params.slug) : undefined;
+	const { slug } = params ?? {};
+	const guide = slug ? await getGuide(slug) : undefined;
 	const guideList = await getGuideList();
 	const guideLinks = guideList.map(({ title, slug }) => ({
 		href: `/guides/${slug}`,
 		label: title,
 	}));
 
-	if (!guide) {
+	if (!(slug && guide)) {
 		return { notFound: true };
 	}
+
+	const breadcrumbs = await getGuidesBreadcrumbs(slug);
 
 	return {
 		props: {
 			guide,
 			guideLinks,
-			slug: params?.slug,
+			breadcrumbs,
+			slug,
 		},
 	};
 };

--- a/docs/pages/releases/[slug].tsx
+++ b/docs/pages/releases/[slug].tsx
@@ -6,6 +6,7 @@ import { Body } from '@ag.ds-next/body';
 
 import {
 	getRelease,
+	getReleaseBreadcrumbs,
 	getReleaseList,
 	getReleaseSlugs,
 	Release,
@@ -18,6 +19,7 @@ import { PageLayout } from '../../components/PageLayout';
 export default function Releases({
 	release,
 	releaseLinks,
+	breadcrumbs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<AppLayout>
@@ -28,6 +30,7 @@ export default function Releases({
 					items: releaseLinks,
 				}}
 				editPath={`/releases/${release.slug}.mdx`}
+				breadcrumbs={breadcrumbs}
 			>
 				<Flex as="main" flexDirection="column" gap={1} alignItems="flex-start">
 					<H1>{release.data.title}</H1>
@@ -56,25 +59,30 @@ export const getStaticProps: GetStaticProps<
 	{
 		release: Release;
 		releaseLinks: { href: string; label: string }[];
+		breadcrumbs: Awaited<ReturnType<typeof getReleaseBreadcrumbs>>;
 	},
 	{ slug: string }
 > = async ({ params }) => {
-	const release = params ? await getRelease(params.slug) : undefined;
+	const { slug } = params ?? {};
+	const release = slug ? await getRelease(slug) : undefined;
 	const releaseList = await getReleaseList();
 	const releaseLinks = releaseList.map(({ title, slug }) => ({
 		href: `/releases/${slug}`,
 		label: title,
 	}));
 
-	if (!release) {
+	if (!(slug && release)) {
 		return { notFound: true };
 	}
+
+	const breadcrumbs = await getReleaseBreadcrumbs(slug);
 
 	return {
 		props: {
 			release,
 			releaseLinks,
-			slug: params?.slug,
+			breadcrumbs,
+			slug,
 		},
 	};
 };


### PR DESCRIPTION
<img width="1837" alt="Screen Shot 2022-02-08 at 1 24 47 pm" src="https://user-images.githubusercontent.com/6265154/152912360-46b83560-e25a-423d-907c-04f6c803f6ae.png">
