### PR TITLE
docs: Automatically generate release notes page content

### DIFF
--- a/docs/lib/mdxUtils.ts
+++ b/docs/lib/mdxUtils.ts
@@ -206,7 +206,7 @@ export function getReleaseList() {
 			slugs.map((slug) =>
 				getMarkdownData(releasePath(slug)).then(({ data }) => ({
 					title: (data?.title ?? slug) as string,
-					description: data.description as string,
+					description: (data.description ?? null) as string | null,
 					slug,
 				}))
 			)

--- a/docs/lib/mdxUtils.ts
+++ b/docs/lib/mdxUtils.ts
@@ -206,6 +206,7 @@ export function getReleaseList() {
 			slugs.map((slug) =>
 				getMarkdownData(releasePath(slug)).then(({ data }) => ({
 					title: (data?.title ?? slug) as string,
+					description: data.description as string,
 					slug,
 				}))
 			)

--- a/docs/pages/releases/index.tsx
+++ b/docs/pages/releases/index.tsx
@@ -15,11 +15,7 @@ import { PageLayout } from '../../components/PageLayout';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
-export default function ReleasesHome({
-	source,
-	releaseLinks,
-	releaseNotesList,
-}: StaticProps) {
+export default function ReleasesHome({ source, releaseLinks }: StaticProps) {
 	return (
 		<>
 			<DocumentTitle title="Releases" />
@@ -36,7 +32,7 @@ export default function ReleasesHome({
 						<MDXRemote {...source} components={mdxComponents} />
 					</Body>
 					<Stack as="ul" gap={1}>
-						{releaseNotesList.map(({ href, label, description }) => (
+						{releaseLinks.map(({ href, label, description }) => (
 							<Card key={label} as="li" clickable shadow>
 								<CardInner>
 									<Body>
@@ -62,12 +58,7 @@ export async function getStaticProps() {
 	const source = await serializeMarkdown(content);
 	const releaseList = await getReleaseList();
 
-	const releaseLinks = releaseList.map(({ slug, title }) => ({
-		href: `/releases/${slug}`,
-		label: title,
-	}));
-
-	const releaseNotesList = releaseList.map(({ slug, title, description }) => ({
+	const releaseLinks = releaseList.map(({ slug, title, description }) => ({
 		href: `/releases/${slug}`,
 		label: title,
 		description,
@@ -77,7 +68,6 @@ export async function getStaticProps() {
 		props: {
 			source,
 			releaseLinks,
-			releaseNotesList,
 		},
 	};
 }

--- a/docs/pages/releases/index.tsx
+++ b/docs/pages/releases/index.tsx
@@ -43,7 +43,7 @@ export default function ReleasesHome({
 										<h3>
 											<CardLink href={href}>{label}</CardLink>
 										</h3>
-										<p>{description}</p>
+										{description ? <p>{description}</p> : null}
 									</Body>
 								</CardInner>
 							</Card>

--- a/docs/pages/releases/index.tsx
+++ b/docs/pages/releases/index.tsx
@@ -1,7 +1,8 @@
 import { MDXRemote } from 'next-mdx-remote';
 import { normalize } from 'path';
 import { Body } from '@ag.ds-next/body';
-
+import { Card, CardInner, CardLink } from '@ag.ds-next/card';
+import { Stack } from '@ag.ds-next/box';
 import {
 	getMarkdownData,
 	getReleaseList,
@@ -14,7 +15,11 @@ import { PageLayout } from '../../components/PageLayout';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
-export default function ReleasesHome({ source, releaseLinks }: StaticProps) {
+export default function ReleasesHome({
+	source,
+	releaseLinks,
+	releaseNotesList,
+}: StaticProps) {
 	return (
 		<>
 			<DocumentTitle title="Releases" />
@@ -30,6 +35,20 @@ export default function ReleasesHome({ source, releaseLinks }: StaticProps) {
 					<Body>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Body>
+					<Stack as="ul" gap={1}>
+						{releaseNotesList.map(({ href, label, description }) => (
+							<Card key={label} as="li" clickable shadow>
+								<CardInner>
+									<Body>
+										<h3>
+											<CardLink href={href}>{label}</CardLink>
+										</h3>
+										<p>{description}</p>
+									</Body>
+								</CardInner>
+							</Card>
+						))}
+					</Stack>
 				</PageLayout>
 			</AppLayout>
 		</>
@@ -42,15 +61,23 @@ export async function getStaticProps() {
 	);
 	const source = await serializeMarkdown(content);
 	const releaseList = await getReleaseList();
+
 	const releaseLinks = releaseList.map(({ slug, title }) => ({
 		href: `/releases/${slug}`,
 		label: title,
+	}));
+
+	const releaseNotesList = releaseList.map(({ slug, title, description }) => ({
+		href: `/releases/${slug}`,
+		label: title,
+		description,
 	}));
 
 	return {
 		props: {
 			source,
 			releaseLinks,
+			releaseNotesList,
 		},
 	};
 }

--- a/releases/2022-01-05.mdx
+++ b/releases/2022-01-05.mdx
@@ -1,6 +1,7 @@
 ---
 title: January 5th, 2022
 type: major
+description: Initial release. This is the first release of the upcoming Agriculture Design-System components.
 ---
 
 Initial release. This is the first release of the upcoming Agriculture Design-System components.

--- a/releases/2022-01-07.mdx
+++ b/releases/2022-01-07.mdx
@@ -1,9 +1,10 @@
 ---
 title: January 7th, 2022
 type: patch
+description: Changes to improve usability of primitive components and to better enable using framework provided link components.
 ---
 
-Changes to imporve usability of primitive components and to better enable using framework provided link components.
+Changes to improve usability of primitive components and to better enable using framework provided link components.
 
 - `Body`: Applied fontGrid to some content elements
 - `Core`, `LinkList`, `MainNav`: Add a linkComponent to Core which can be used in LinkList and MainNav. This enables supporting Link components from `next.js` or `react-router` inside DS components.

--- a/releases/2022-01-24.mdx
+++ b/releases/2022-01-24.mdx
@@ -1,6 +1,7 @@
 ---
 title: January 24th, 2022
 type: patch
+description: Add new components "Breadcrumbs", "Icon" and "SideNav".
 ---
 
 Add new components!

--- a/releases/2022-02-08.mdx
+++ b/releases/2022-02-08.mdx
@@ -1,6 +1,7 @@
 ---
 title: February 8th, 2022
 type: major
+description: Add new components "Button", "ButtonLink", "Columns", "Column" and "Card".
 ---
 
 > ⚠️ Note: All releases under the `@ag.ds-next` package scope should be considered alpha pre-releases. Expect breaking changes. Once we are happy with the state of the core packages we will migrate all packages to `@ag.ds`.

--- a/releases/index.mdx
+++ b/releases/index.mdx
@@ -1,9 +1,1 @@
 # Release notes
-
-## [January 5th, 2022](/releases/2022-01-05)
-
-**latest**
-
-Initial release. This is the first release of the upcoming Agriculture Design-System components.
-
-> 🔎 You can also find all the [AG DS releases on GitHub](https://github.com/steelthreads/agds-next/releases)!


### PR DESCRIPTION

<img width="1303" alt="Screen Shot 2022-02-09 at 9 25 35 am" src="https://user-images.githubusercontent.com/6265154/153092880-a1d71605-6c1c-4356-99f5-2d07c880082d.png">
