### PR TITLE
Breadcrumbs: Remove typographic props from `BreadcrumbsItem`

### DIFF
--- a/.changeset/mighty-files-suffer.md
+++ b/.changeset/mighty-files-suffer.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+---
+
+Remove typographic box props from `BreadcrumbsItem`

--- a/packages/breadcrumbs/src/BreadcrumbsItem.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsItem.tsx
@@ -9,7 +9,7 @@ export const BreadcrumbsItem = (
 ) => {
 	const { children, href } = props;
 	return (
-		<Box as="li" fontSize="sm" fontFamily="body" lineHeight="default">
+		<Box as="li">
 			{href ? <TextLink href={href} {...props} /> : <Text>{children}</Text>}
 		</Box>
 	);


### PR DESCRIPTION
We don't need these as they are applied from the `TextLink`