### PR TITLE
Columns: Remove `BoxProps` from `Column` and `Columns`

### DIFF
--- a/.changeset/serious-poets-fetch.md
+++ b/.changeset/serious-poets-fetch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/columns': patch
+---
+
+Remove `BoxProps` from `Column` and `Columns`

--- a/.changeset/serious-poets-fetch.md
+++ b/.changeset/serious-poets-fetch.md
@@ -1,5 +1,6 @@
 ---
 '@ag.ds-next/columns': patch
+'@ag.ds-next/header': patch
 ---
 
 Remove `BoxProps` from `Column` and `Columns`

--- a/docs/components/PageLayout.tsx
+++ b/docs/components/PageLayout.tsx
@@ -28,7 +28,7 @@ export function PageLayout({
 		<Content>
 			<Columns>
 				{sideNav && (
-					<Column columnSpan={{ xs: 12, md: 3 }} flexShrink={0}>
+					<Column columnSpan={{ xs: 12, md: 3 }}>
 						<SideNav
 							variant="light"
 							activePath={router.asPath}

--- a/docs/components/PkgCardList.tsx
+++ b/docs/components/PkgCardList.tsx
@@ -8,7 +8,7 @@ type Pkg = {
 };
 
 export const PkgCardList = ({ items }: { items: Pkg[] }) => (
-	<Columns gap={1} flexWrap="wrap" as="ul">
+	<Columns gap={1} as="ul">
 		{items.map(({ title, slug, group }) => (
 			<Column
 				key={slug}

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -57,7 +57,7 @@ export default function Homepage() {
 								hard to get a stable release out as soon as we can.
 							</p>
 						</Body>
-						<Columns gap={1} flexWrap="wrap" as="ul">
+						<Columns gap={1} as="ul">
 							<Column
 								as="li"
 								columnSpan={{ xs: 12, sm: 6, md: 6, lg: 4, xl: 3 }}

--- a/packages/columns/README.md
+++ b/packages/columns/README.md
@@ -1,25 +1,49 @@
 ---
 title: Columns
 description: A grid consists of a framework of cells laid out and aligned vertically and horizontally. It helps users read and visually navigate website content more easily, using a responsive, scrollable column structure.
-group: Foundations
+group: Layout
 ---
 
 This package includes the components `<Columns />` and `<Column />`.
 
 ```jsx live
 <Columns gap={0.5}>
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
-	<Column columnSpan={1} background="shade" padding={1} />
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={1}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
 </Columns>
 ```
 
@@ -29,27 +53,69 @@ Use the `columnSpan` prop to control how many columns you want to column to span
 
 ```jsx live
 <Columns gap={0.5}>
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={6} background="shade" padding={1} />
-	<Column columnSpan={6} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={8} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
-	<Column columnSpan={2} background="shade" padding={1} />
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={6}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={6}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={8}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={2}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
 </Columns>
 ```
 
@@ -59,13 +125,27 @@ The `gap` prop effects both the row and column gap. To set a different gap for r
 
 ```jsx live
 <Columns columnGap={0.5} rowGap={2}>
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={3} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
-	<Column columnSpan={4} background="shade" padding={1} />
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={3}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
+	<Column columnSpan={4}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
 </Columns>
 ```
 
@@ -75,6 +155,8 @@ The `columnStart` and `columnEnd` props can be used to determine the Column's st
 
 ```jsx live
 <Columns>
-	<Column columnStart={3} columnEnd={9} background="shade" padding={1} />
+	<Column columnStart={3} columnEnd={9}>
+		<Box background="shadeAlt" padding={1} />
+	</Column>
 </Columns>
 ```

--- a/packages/columns/src/Column.stories.tsx
+++ b/packages/columns/src/Column.stories.tsx
@@ -4,82 +4,200 @@ import { Box } from '@ag.ds-next/box';
 import { Columns, Column } from './index';
 
 export default {
-	title: 'foundations/Columns',
+	title: 'layout/Columns',
 	component: Columns,
 } as ComponentMeta<typeof Columns>;
+
+const Cell = () => <Box background="shadeAlt" padding={1} />;
 
 export const Basic: ComponentStory<typeof Columns> = (args) => (
 	<Box palette="light" background="body">
 		<Columns {...args}>
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
 		</Columns>
 	</Box>
 );
-Basic.args = {
-	gap: 2,
-};
+Basic.args = {};
 
 export const ColSpans: ComponentStory<typeof Columns> = (args) => (
 	<Box palette="light" background="body">
 		<Columns {...args}>
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={1} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={4} background="shade" padding={1} />
-			<Column columnSpan={4} background="shade" padding={1} />
-			<Column columnSpan={4} background="shade" padding={1} />
-			<Column columnSpan={5} background="shade" padding={1} />
-			<Column columnSpan={5} background="shade" padding={1} />
-			<Column columnSpan={2} background="shade" padding={1} />
-			<Column columnSpan={6} background="shade" padding={1} />
-			<Column columnSpan={6} background="shade" padding={1} />
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={1}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={4}>
+				<Cell />
+			</Column>
+			<Column columnSpan={4}>
+				<Cell />
+			</Column>
+			<Column columnSpan={4}>
+				<Cell />
+			</Column>
+			<Column columnSpan={5}>
+				<Cell />
+			</Column>
+			<Column columnSpan={5}>
+				<Cell />
+			</Column>
+			<Column columnSpan={2}>
+				<Cell />
+			</Column>
+			<Column columnSpan={6}>
+				<Cell />
+			</Column>
+			<Column columnSpan={6}>
+				<Cell />
+			</Column>
 		</Columns>
 	</Box>
 );
-ColSpans.args = {
-	gap: 2,
+ColSpans.args = {};
+
+export const Gap: ComponentStory<typeof Columns> = (args) => (
+	<Box palette="light" background="body">
+		<Columns {...args}>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+		</Columns>
+	</Box>
+);
+Gap.args = {
+	gap: 3,
 };
 
 export const RowAndColumnGaps: ComponentStory<typeof Columns> = (args) => (
 	<Box palette="light" background="body">
 		<Columns {...args}>
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={3} background="shade" padding={1} />
-			<Column columnSpan={4} background="shade" padding={1} />
-			<Column columnSpan={4} background="shade" padding={1} />
-			<Column columnSpan={4} background="shade" padding={1} />
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={3}>
+				<Cell />
+			</Column>
+			<Column columnSpan={4}>
+				<Cell />
+			</Column>
+			<Column columnSpan={4}>
+				<Cell />
+			</Column>
+			<Column columnSpan={4}>
+				<Cell />
+			</Column>
 		</Columns>
 	</Box>
 );

--- a/packages/columns/src/Column.tsx
+++ b/packages/columns/src/Column.tsx
@@ -4,11 +4,11 @@ import {
 	mapResponsiveProp,
 	mq,
 } from '@ag.ds-next/core';
-import { Box, BoxProps } from '@ag.ds-next/box';
+import { Box } from '@ag.ds-next/box';
 
 type ColumnRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-export type ColumnProps = BoxProps & {
+export type ColumnProps = {
 	columnSpan?: ResponsiveProp<ColumnRange>;
 	columnStart?: ResponsiveProp<ColumnRange | 'first' | 'last'>;
 	columnEnd?: ResponsiveProp<ColumnRange | 'first' | 'last'>;

--- a/packages/columns/src/Columns.tsx
+++ b/packages/columns/src/Columns.tsx
@@ -7,10 +7,11 @@ import {
 	mapSpacing,
 	mq,
 } from '@ag.ds-next/core';
-import { Box, BoxProps } from '@ag.ds-next/box';
+import { Box } from '@ag.ds-next/box';
 
-export type ColumnsProps = BoxProps & {
+export type ColumnsProps = {
 	children: ReactNode;
+	gap?: ResponsiveProp<Spacing>;
 	columnGap?: ResponsiveProp<Spacing>;
 	rowGap?: ResponsiveProp<Spacing>;
 };

--- a/packages/columns/src/Columns.tsx
+++ b/packages/columns/src/Columns.tsx
@@ -7,11 +7,10 @@ import {
 	mapSpacing,
 	mq,
 } from '@ag.ds-next/core';
-import { Box } from '@ag.ds-next/box';
+import { Box, BoxProps } from '@ag.ds-next/box';
 
-export type ColumnsProps = {
+export type ColumnsProps = Pick<BoxProps, 'gap' | 'alignItems'> & {
 	children: ReactNode;
-	gap?: ResponsiveProp<Spacing>;
 	columnGap?: ResponsiveProp<Spacing>;
 	rowGap?: ResponsiveProp<Spacing>;
 };

--- a/packages/header/src/HeaderContainer.tsx
+++ b/packages/header/src/HeaderContainer.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@ag.ds-next/box';
+import { Box, Flex } from '@ag.ds-next/box';
 import { tokens } from '@ag.ds-next/core';
 import { Columns } from '@ag.ds-next/columns';
 import React from 'react';
@@ -36,14 +36,13 @@ export function HeaderContainer({ variant, children }: HeaderContainerProps) {
 			paddingY={{ xs: 1, md: 3 }}
 			justifyContent="center"
 		>
-			<Columns
-				alignItems="center"
+			<Box
 				maxWidth={tokens.maxWidth.container}
 				paddingX={tokens.containerPadding}
 				width="100%"
 			>
-				{children}
-			</Columns>
+				<Columns alignItems="center">{children}</Columns>
+			</Box>
 		</Flex>
 	);
 }


### PR DESCRIPTION
As discussed with @mikehazell , we don't really want to be supporting all of the box props in components.

Also I've moved the component into the `Layout` group, as it appears in Gold.