### PR TITLE
Update `Button` padding styles

### DIFF
--- a/.changeset/thirty-emus-sniff.md
+++ b/.changeset/thirty-emus-sniff.md
@@ -1,0 +1,8 @@
+---
+'@ag.ds-next/button': patch
+---
+
+- Updated horizontal padding for the `sm` variant in the `Button` component
+- Added `size` prop to `ButtonLink`
+- Refactored how disabled styles are applied
+

--- a/.changeset/thirty-emus-sniff.md
+++ b/.changeset/thirty-emus-sniff.md
@@ -5,4 +5,3 @@
 - Updated horizontal padding for the `sm` variant in the `Button` component
 - Added `size` prop to `ButtonLink`
 - Refactored how disabled styles are applied
-

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -23,7 +23,7 @@ export function Button({
 	ButtonHTMLAttributes<HTMLButtonElement>,
 	HTMLButtonElement
 >) {
-	const styles = buttonStyles({ block, disabled, size, variant });
+	const styles = buttonStyles({ block, size, variant });
 	return (
 		<button disabled={disabled} css={styles} {...props}>
 			{loading ? 'Loading...' : children}
@@ -35,16 +35,18 @@ export function ButtonLink({
 	children,
 	href,
 	block,
+	size,
 	variant,
 	...props
 }: {
 	block?: boolean;
+	size?: ButtonSize;
 	variant?: ButtonVariant;
 } & DetailedHTMLProps<
 	AnchorHTMLAttributes<HTMLAnchorElement>,
 	HTMLAnchorElement
 >) {
-	const styles = buttonStyles({ block, variant });
+	const styles = buttonStyles({ block, size, variant });
 	const Link = useLinkComponent();
 	return (
 		<Link href={href} css={styles} {...props}>

--- a/packages/button/src/utils.tsx
+++ b/packages/button/src/utils.tsx
@@ -54,13 +54,15 @@ const variants = {
 	},
 } as const;
 
-export const sizes = {
+export type ButtonVariant = keyof typeof variants;
+
+const sizes = {
 	sm: {
 		...fontGrid('xs', 'default'),
 		paddingTop: mapSpacing(0.25),
 		paddingBottom: mapSpacing(0.25),
-		paddingLeft: mapSpacing(0.5),
-		paddingRight: mapSpacing(0.5),
+		paddingLeft: mapSpacing(0.75),
+		paddingRight: mapSpacing(0.75),
 	},
 	md: {
 		...fontGrid('sm', 'default'),
@@ -71,17 +73,14 @@ export const sizes = {
 	},
 };
 
-export type ButtonVariant = keyof typeof variants;
 export type ButtonSize = keyof typeof sizes;
 
 export function buttonStyles({
 	block,
-	disabled,
 	variant = 'primary',
 	size = 'md',
 }: {
 	block?: boolean;
-	disabled?: boolean;
 	variant?: ButtonVariant;
 	size?: ButtonSize;
 }) {
@@ -102,12 +101,12 @@ export function buttonStyles({
 			width: '100%',
 		}),
 
-		...(disabled && {
+		'&:disabled': {
 			cursor: 'not-allowed',
 			opacity: 0.3,
 			// reset hover and focus styles
 			'&:hover': {},
 			'&:focus': {},
-		}),
+		},
 	} as const;
 }


### PR DESCRIPTION
Fixes #121

- Updated horizontal padding for the `sm` variant in the `Button` component
- Added `size` prop to `ButtonLink`
- Refactored how disabled styles are applied

