### PR TITLE
Box: Fix bug with `borderTop`

### DIFF
--- a/.changeset/fast-sheep-unite.md
+++ b/.changeset/fast-sheep-unite.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/box': patch
+---
+
+Fixed bug in `Box` where border top styles were not being applied when using the `borderTop` prop

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -189,7 +189,13 @@ function borderStyles({
 	rounded,
 }: BorderProps) {
 	const anyBorder =
-		border || borderLeft || borderRight || borderBottom || borderX || borderY;
+		border ||
+		borderLeft ||
+		borderRight ||
+		borderTop ||
+		borderBottom ||
+		borderX ||
+		borderY;
 	return {
 		borderWidth: 0,
 		borderLeftWidth: border ?? borderX ?? borderLeft ? `1px` : undefined,


### PR DESCRIPTION
Fixed bug in `Box` where border top styles were not being applied when using the `borderTop` prop
