### PR TITLE
Core: Update `useElementSize` hook

### DIFF
--- a/.changeset/odd-moose-tie.md
+++ b/.changeset/odd-moose-tie.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/core': patch
+---
+
+Replaced usage of `useLayoutEffect` with `useEffect` in `useElementSize`

--- a/packages/core/src/utils/useElementSize.ts
+++ b/packages/core/src/utils/useElementSize.ts
@@ -1,4 +1,4 @@
-import { RefObject, useCallback, useLayoutEffect, useState } from 'react';
+import { RefObject, useCallback, useEffect, useState } from 'react';
 
 export function useElementSize<T extends HTMLElement = HTMLDivElement>(
 	ref: RefObject<T>
@@ -12,7 +12,7 @@ export function useElementSize<T extends HTMLElement = HTMLDivElement>(
 		});
 	}, [ref]);
 
-	useLayoutEffect(() => {
+	useEffect(() => {
 		handleSize();
 		window.addEventListener('resize', handleSize);
 		return () => window.removeEventListener('resize', handleSize);


### PR DESCRIPTION
## Describe your changes

Replaced usage of `useLayoutEffect` with `useEffect` in our custom hook `useElementSize`. This is because it gives us an ugly warning message when server rendering and since the effect isn't important for first render, we can use `useEffect` instead.

For more information please see https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [] Write documentation (README.md)
- [] Create stories for Storybook

For new components...

- [] Add components to Playroom (docs/playroom/components.js)
- [] Add snippets to Playroom (docs/playroom/snippets.js)
- [] Add to Docs for jsx live (docs/components/utils.tsx)
- [] Add pictogram to Docs (docs/components/pictograms/index.tsx)
