### PR TITLE
Docs: Add support for external URLs to link component

### DIFF
--- a/.changeset/empty-owls-rescue.md
+++ b/.changeset/empty-owls-rescue.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': minor
+---
+
+Add support for external URLs to link component

--- a/docs/components/LinkComponent.tsx
+++ b/docs/components/LinkComponent.tsx
@@ -17,6 +17,9 @@ export const LinkComponent = ({
 }) => {
 	if (!href) return <a {...props} />;
 
+	if (typeof href === 'string' && /^https?:\/\//.test(href))
+		return <a href={href} {...props} />;
+
 	return (
 		<Link
 			href={href}


### PR DESCRIPTION
## Describe your changes
The link component in our docs site should use an anchor element (rather than the next.js Link component) for external link.

## Checklist

- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [X] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
