### PR TITLE
SideNav: Improve focus state

### DIFF
--- a/.changeset/cyan-spies-kick.md
+++ b/.changeset/cyan-spies-kick.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/side-nav': patch
+---
+
+Removed overflow to improve focus state

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -64,7 +64,7 @@ export const SideNavContainer = ({
 					[tokens.mediaQuery.min.md]: {
 						// Overwrite the animated height
 						// for tablet/desktop sizes.
-						overflow: 'auto',
+						overflow: 'unset',
 						height: 'auto !important',
 					},
 				}}

--- a/packages/side-nav/src/SideNavTitle.tsx
+++ b/packages/side-nav/src/SideNavTitle.tsx
@@ -26,6 +26,7 @@ export const SideNavTitle = ({
 				fontWeight="bold"
 				lineHeight="heading"
 				display="block"
+				focus
 				css={{
 					borderBottom: `2px solid ${boxPalette.border}`,
 					textDecoration: 'none',


### PR DESCRIPTION
## Describe your changes

Removed overflow to improve focus state and applied focus ring to side nav collapse button.

<img width="493" alt="Screen Shot 2022-02-28 at 9 13 52 am" src="https://user-images.githubusercontent.com/6265154/155904205-7fdaf9d5-96e6-491b-8d14-e203f4522928.png">

<img width="466" alt="Screen Shot 2022-02-28 at 9 13 38 am" src="https://user-images.githubusercontent.com/6265154/155904201-35181ed2-0b9c-448f-825f-d8d1b815d545.png">


## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook

For new components...

- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
