### PR TITLE
Improve types of components with children or extend default HTML elements

### DIFF
--- a/.changeset/tiny-lions-count.md
+++ b/.changeset/tiny-lions-count.md
@@ -1,0 +1,18 @@
+---
+'@ag.ds-next/a11y': patch
+'@ag.ds-next/accordion': patch
+'@ag.ds-next/columns': patch
+'@ag.ds-next/control-input': patch
+'@ag.ds-next/field': patch
+'@ag.ds-next/header': patch
+'@ag.ds-next/icon': patch
+'@ag.ds-next/link-list': patch
+'@ag.ds-next/main-nav': patch
+'@ag.ds-next/search-box': patch
+'@ag.ds-next/select': patch
+'@ag.ds-next/side-nav': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Improved the typescript types of components with children or extend default HTML elements

--- a/packages/a11y/src/VisuallyHidden.tsx
+++ b/packages/a11y/src/VisuallyHidden.tsx
@@ -1,6 +1,8 @@
 import React, { ReactNode } from 'react';
 
-export const VisuallyHidden = ({ children }: { children: ReactNode }) => (
+export type VisuallyHiddenProps = { children: ReactNode };
+
+export const VisuallyHidden = ({ children }: VisuallyHiddenProps) => (
 	<span css={visuallyHiddenStyles}>{children}</span>
 );
 

--- a/packages/accordion/src/AccordionItem.tsx
+++ b/packages/accordion/src/AccordionItem.tsx
@@ -64,6 +64,8 @@ export const AccordionItem = ({
 	);
 };
 
-export const AccordionItemContent = ({ children }: { children: ReactNode }) => (
-	<Box padding={1}>{children}</Box>
-);
+export type AccordionItemContentProps = { children: ReactNode };
+
+export const AccordionItemContent = ({
+	children,
+}: AccordionItemContentProps) => <Box padding={1}>{children}</Box>;

--- a/packages/columns/src/Columns.tsx
+++ b/packages/columns/src/Columns.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from 'react';
 import {
 	forwardRefWithAs,
 	ResponsiveProp,
@@ -8,12 +7,14 @@ import {
 	mq,
 } from '@ag.ds-next/core';
 import { Box, BoxProps } from '@ag.ds-next/box';
+import { PropsWithChildren } from 'react';
 
-export type ColumnsProps = Pick<BoxProps, 'gap' | 'alignItems'> & {
-	children: ReactNode;
-	columnGap?: ResponsiveProp<Spacing>;
-	rowGap?: ResponsiveProp<Spacing>;
-};
+export type ColumnsProps = PropsWithChildren<
+	Pick<BoxProps, 'gap' | 'alignItems'> & {
+		columnGap?: ResponsiveProp<Spacing>;
+		rowGap?: ResponsiveProp<Spacing>;
+	}
+>;
 
 export const Columns = forwardRefWithAs<'div', ColumnsProps>(function Columns(
 	{ gap, columnGap, rowGap, ...props },

--- a/packages/control-input/src/Checkbox.tsx
+++ b/packages/control-input/src/Checkbox.tsx
@@ -1,25 +1,18 @@
-import React, {
-	forwardRef,
-	PropsWithRef,
-	DetailedHTMLProps,
-	InputHTMLAttributes,
-} from 'react';
+import React, { forwardRef, InputHTMLAttributes } from 'react';
 import { CheckboxIndicator } from './CheckboxIndicator';
 import { ControlInput } from './ControlInput';
 import { ControlContainer } from './ControlContainer';
 import { ControlLabel } from './ControlLabel';
 import { ControlSize } from './utils';
 
-export type CheckboxProps = PropsWithRef<
-	Omit<
-		DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
-		'size'
-	> & {
-		invalid?: boolean;
-		valid?: boolean;
-		size?: ControlSize;
-	}
->;
+export type CheckboxProps = Omit<
+	InputHTMLAttributes<HTMLInputElement>,
+	'size'
+> & {
+	invalid?: boolean;
+	valid?: boolean;
+	size?: ControlSize;
+};
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 	function Checkbox(

--- a/packages/control-input/src/ControlContainer.tsx
+++ b/packages/control-input/src/ControlContainer.tsx
@@ -1,13 +1,12 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import { Flex } from '@ag.ds-next/box';
-import { globalPalette, themeVars } from '@ag.ds-next/core';
+import { globalPalette } from '@ag.ds-next/core';
 
-export type ControlContainerProps = {
-	children: ReactNode;
+export type ControlContainerProps = PropsWithChildren<{
 	disabled?: boolean;
 	invalid?: boolean;
 	valid?: boolean;
-};
+}>;
 
 export const ControlContainer = ({
 	children,

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -1,18 +1,17 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { mapSpacing } from '@ag.ds-next/core';
 import { FieldContainer, FieldHint, FieldMessage } from '@ag.ds-next/field';
 
-export type ControlGroupProps = {
+export type ControlGroupProps = PropsWithChildren<{
 	block?: boolean;
-	children: ReactNode;
 	hint?: string;
 	invalid?: boolean;
 	label?: string;
 	message?: string;
 	required?: boolean;
-};
+}>;
 
 export const ControlGroup = ({
 	block,

--- a/packages/control-input/src/ControlInput.tsx
+++ b/packages/control-input/src/ControlInput.tsx
@@ -1,11 +1,8 @@
-import { forwardRef, DetailedHTMLProps, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { visuallyHiddenStyles } from '@ag.ds-next/a11y';
 import { packs } from '@ag.ds-next/core';
 
-export type ControlInputProps = DetailedHTMLProps<
-	InputHTMLAttributes<HTMLInputElement>,
-	HTMLInputElement
->;
+export type ControlInputProps = InputHTMLAttributes<HTMLInputElement>;
 
 export const ControlInput = forwardRef<HTMLInputElement, ControlInputProps>(
 	function ControlInput(props, ref) {

--- a/packages/control-input/src/ControlLabel.tsx
+++ b/packages/control-input/src/ControlLabel.tsx
@@ -1,10 +1,9 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import { Text } from '@ag.ds-next/text';
 
-export type ControlLabelProps = {
-	children: ReactNode;
+export type ControlLabelProps = PropsWithChildren<{
 	disabled?: boolean;
-};
+}>;
 
 export const ControlLabel = ({ children, disabled }: ControlLabelProps) => (
 	<Text flexGrow={1} color={disabled ? 'muted' : 'text'}>

--- a/packages/control-input/src/Radio.tsx
+++ b/packages/control-input/src/Radio.tsx
@@ -1,25 +1,15 @@
-import {
-	forwardRef,
-	PropsWithRef,
-	DetailedHTMLProps,
-	InputHTMLAttributes,
-} from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { RadioIndicator } from './RadioIndicator';
 import { ControlInput } from './ControlInput';
 import { ControlContainer } from './ControlContainer';
 import { ControlLabel } from './ControlLabel';
 import { ControlSize } from './utils';
 
-export type RadioProps = PropsWithRef<
-	Omit<
-		DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>,
-		'size'
-	> & {
-		invalid?: boolean;
-		valid?: boolean;
-		size?: ControlSize;
-	}
->;
+export type RadioProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> & {
+	invalid?: boolean;
+	valid?: boolean;
+	size?: ControlSize;
+};
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 	{ children, disabled, invalid, valid, size = 'md', ...props },

--- a/packages/field/src/FieldContainer.tsx
+++ b/packages/field/src/FieldContainer.tsx
@@ -1,11 +1,10 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import { Stack } from '@ag.ds-next/box';
 import { globalPalette } from '@ag.ds-next/core';
 
-export type FieldContainerProps = {
-	children: ReactNode;
+export type FieldContainerProps = PropsWithChildren<{
 	invalid?: boolean;
-};
+}>;
 
 export const FieldContainer = ({ children, invalid }: FieldContainerProps) => (
 	<Stack

--- a/packages/field/src/FieldLabel.tsx
+++ b/packages/field/src/FieldLabel.tsx
@@ -1,13 +1,11 @@
-import type { ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 import { Text } from '@ag.ds-next/text';
 
-export const FieldLabel = ({
-	children,
-	htmlFor,
-}: {
-	children: ReactNode;
+export type FieldLabelProps = PropsWithChildren<{
 	htmlFor: string;
-}) => (
+}>;
+
+export const FieldLabel = ({ children, htmlFor }: FieldLabelProps) => (
 	<Text as="label" htmlFor={htmlFor} display="block" fontWeight="bold">
 		{children}
 	</Text>

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -70,7 +70,9 @@ export function HeaderBrand({
 	);
 }
 
-const HeaderBadge = ({ children }: { children: ReactNode }) => {
+type HeaderBadgeProps = { children: ReactNode };
+
+const HeaderBadge = ({ children }: HeaderBadgeProps) => {
 	return (
 		<Box
 			fontSize="xs"

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -1,13 +1,13 @@
 import { boxPalette, mapSpacing, Spacing } from '@ag.ds-next/core';
 import { foregroundColorMap } from '@ag.ds-next/box';
-import { DetailedHTMLProps, SVGAttributes } from 'react';
+import { SVGAttributes } from 'react';
 
 import { ICONS } from './icons';
 
 export type IconNameType = keyof typeof ICONS;
 
 type SvgProps = Omit<
-	DetailedHTMLProps<SVGAttributes<SVGSVGElement>, SVGSVGElement>,
+	SVGAttributes<SVGSVGElement>,
 	'width' | 'height' | 'viewBox' | 'fill' | 'fillRule' | 'clipRule' | 'xmlns'
 >;
 

--- a/packages/link-list/src/LinkListContainer.tsx
+++ b/packages/link-list/src/LinkListContainer.tsx
@@ -1,10 +1,9 @@
-import type { ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 import { Stack } from '@ag.ds-next/box';
 
-export type LinkListContainerProps = {
-	children: ReactNode;
+export type LinkListContainerProps = PropsWithChildren<{
 	horizontal?: boolean;
-};
+}>;
 
 export const LinkListContainer = ({
 	children,

--- a/packages/main-nav/src/NavItem.tsx
+++ b/packages/main-nav/src/NavItem.tsx
@@ -6,17 +6,15 @@ import {
 	packs,
 } from '@ag.ds-next/core';
 import { Box } from '@ag.ds-next/box';
-import type { ReactNode } from 'react';
+import type { PropsWithChildren } from 'react';
 
 import { localPalette } from './utils';
 
-export function NavItem({
-	children,
-	active,
-}: {
-	children: ReactNode;
+export type NavItemProps = PropsWithChildren<{
 	active?: boolean;
-}) {
+}>;
+
+export function NavItem({ children, active }: NavItemProps) {
 	return (
 		<Box
 			as="li"

--- a/packages/search-box/src/SearchBox.tsx
+++ b/packages/search-box/src/SearchBox.tsx
@@ -1,10 +1,7 @@
-import React, { DetailedHTMLProps, FormHTMLAttributes } from 'react';
+import React, { FormHTMLAttributes } from 'react';
 import { Flex } from '@ag.ds-next/box';
 
-export type SearchBoxProps = DetailedHTMLProps<
-	FormHTMLAttributes<HTMLFormElement>,
-	HTMLFormElement
->;
+export type SearchBoxProps = FormHTMLAttributes<HTMLFormElement>;
 
 export const SearchBox = ({ children, ...props }: SearchBoxProps) => (
 	<form role="search" {...props}>

--- a/packages/search-box/src/SearchBoxButton.tsx
+++ b/packages/search-box/src/SearchBoxButton.tsx
@@ -1,14 +1,10 @@
-import { DetailedHTMLProps, ButtonHTMLAttributes, forwardRef } from 'react';
+import { ButtonHTMLAttributes, forwardRef } from 'react';
 import { Button } from '@ag.ds-next/button';
 import { Box } from '@ag.ds-next/box';
 import { Icon } from '@ag.ds-next/icon';
 import { mapResponsiveProp, mq, ResponsiveProp } from '@ag.ds-next/core';
 
-export type SearchBoxButtonProps = Omit<
-	DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>,
-	'children'
-> & {
-	children: string;
+export type SearchBoxButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 	iconOnly?: ResponsiveProp<boolean>;
 };
 
@@ -24,7 +20,7 @@ export const SearchBoxButton = forwardRef<
 			borderLeft
 			borderWidth="lg"
 		>
-			<Button ref={ref} type="submit" aria-label={children} css={buttonStyles}>
+			<Button ref={ref} type="submit" css={buttonStyles}>
 				<span>{children}</span>
 				{iconOnly ? <Icon icon="search" size={1.5} /> : null}
 			</Button>

--- a/packages/search-box/src/SearchBoxInput.tsx
+++ b/packages/search-box/src/SearchBoxInput.tsx
@@ -1,17 +1,10 @@
-import React, {
-	DetailedHTMLProps,
-	InputHTMLAttributes,
-	forwardRef,
-} from 'react';
+import React, { InputHTMLAttributes, forwardRef } from 'react';
 import { useId } from '@reach/auto-id';
 import { textInputStyles } from '@ag.ds-next/text-input';
 import { Stack } from '@ag.ds-next/box';
 import { SearchBoxLabel } from './SearchBoxLabel';
 
-export type SearchBoxInputProps = DetailedHTMLProps<
-	InputHTMLAttributes<HTMLInputElement>,
-	HTMLInputElement
-> & {
+export type SearchBoxInputProps = InputHTMLAttributes<HTMLInputElement> & {
 	label?: string;
 	labelVisible?: boolean;
 };

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -1,7 +1,6 @@
 import React, {
 	forwardRef,
-	ReactNode,
-	DetailedHTMLProps,
+	PropsWithChildren,
 	SelectHTMLAttributes,
 } from 'react';
 import { Field, FieldMaxWidth, fieldMaxWidth } from '@ag.ds-next/field';
@@ -26,10 +25,7 @@ export type OptionGroup = {
 };
 export type Options = (Option | OptionGroup)[];
 
-export type SelectProps = DetailedHTMLProps<
-	SelectHTMLAttributes<HTMLSelectElement>,
-	HTMLSelectElement
-> & {
+export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
 	label: string;
 	required?: boolean;
 	hint?: string;
@@ -92,11 +88,10 @@ const SelectContainer = ({
 	children,
 	block,
 	maxWidth,
-}: {
-	children: ReactNode;
+}: PropsWithChildren<{
 	block?: boolean;
 	maxWidth?: FieldMaxWidth;
-}) => (
+}>) => (
 	<div
 		css={{
 			position: 'relative',

--- a/packages/side-nav/src/SideNavGroup.tsx
+++ b/packages/side-nav/src/SideNavGroup.tsx
@@ -2,7 +2,9 @@ import { ReactNode } from 'react';
 import { Box } from '@ag.ds-next/box';
 import { LinkListContext, useLinkListDepth } from './context';
 
-export const SideNavGroup = ({ children }: { children: ReactNode }) => {
+type SideNavGroupProps = { children: ReactNode };
+
+export const SideNavGroup = ({ children }: SideNavGroupProps) => {
 	const depth = useLinkListDepth();
 	return (
 		<LinkListContext.Provider value={depth + 1}>

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -1,8 +1,4 @@
-import React, {
-	forwardRef,
-	DetailedHTMLProps,
-	InputHTMLAttributes,
-} from 'react';
+import React, { forwardRef, InputHTMLAttributes } from 'react';
 import { Field, fieldMaxWidth, FieldMaxWidth } from '@ag.ds-next/field';
 import {
 	packs,
@@ -12,10 +8,7 @@ import {
 	tokens,
 } from '@ag.ds-next/core';
 
-export type InputProps = DetailedHTMLProps<
-	InputHTMLAttributes<HTMLInputElement>,
-	HTMLInputElement
-> & {
+export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 	label: string;
 	required?: boolean;
 	hint?: string;

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -1,15 +1,8 @@
-import React, {
-	forwardRef,
-	DetailedHTMLProps,
-	TextareaHTMLAttributes,
-} from 'react';
+import React, { forwardRef, TextareaHTMLAttributes } from 'react';
 import { Field, FieldMaxWidth } from '@ag.ds-next/field';
 import { textInputStyles } from '@ag.ds-next/text-input';
 
-export type TextareaProps = DetailedHTMLProps<
-	TextareaHTMLAttributes<HTMLTextAreaElement>,
-	HTMLTextAreaElement
-> & {
+export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 	label: string;
 	required?: boolean;
 	hint?: string;


### PR DESCRIPTION
## Describe your changes


Improved the typescript types of components with children or extend default HTML elements

- Replaced `children: React.ReactNode` with `PropsWithChildren<{...}>` where possible
- Removed usage of `React.DetailedHTMLProps<{...}>`

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
