### PR TITLE
Breadcrumbs, LinkList: Fix small typescript bug in main component types

### DIFF
--- a/.changeset/eleven-shrimps-bathe.md
+++ b/.changeset/eleven-shrimps-bathe.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+'@ag.ds-next/link-list': patch
+---
+
+Fix small typescript bug in main component types

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -4,7 +4,7 @@ import { BreadcrumbsContainer } from './BreadcrumbsContainer';
 import { BreadcrumbsItem, BreadcrumbsItemProps } from './BreadcrumbsItem';
 
 export type BreadcrumbsProps = {
-	links: Omit<BreadcrumbsItemProps, 'children'> & { label: ReactNode }[];
+	links: (Omit<BreadcrumbsItemProps, 'children'> & { label: ReactNode })[];
 };
 
 export const Breadcrumbs = ({ links, ...props }: BreadcrumbsProps) => {

--- a/packages/link-list/src/LinkList.tsx
+++ b/packages/link-list/src/LinkList.tsx
@@ -3,7 +3,7 @@ import { LinkListContainer } from './LinkListContainer';
 import { LinkListItem, LinkListItemProps } from './LinkListItem';
 
 export type LinkListProps = {
-	links: Omit<LinkListItemProps, 'children'> & { label: ReactNode }[];
+	links: (Omit<LinkListItemProps, 'children'> & { label: ReactNode })[];
 	horizontal?: boolean;
 };
 


### PR DESCRIPTION
## Describe your changes

Fixes a small typescript bug when combing `Omit` and an array type.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook