### PR TITLE
Header: HeaderBadge visual tweaks

### DIFF
--- a/.changeset/silly-rockets-lie.md
+++ b/.changeset/silly-rockets-lie.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/header': patch
+---
+
+Visual tweaks to Header Badge

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -50,9 +50,9 @@ export function HeaderBrand({
 			) : null}
 			{logo ? <Box borderRight display={{ xs: 'none', md: 'block' }} /> : null}
 			<Stack justifyContent="center">
-				<Flex alignItems="center" gap={0.5}>
+				<Flex alignItems="flex-start" gap={0.5}>
 					<Text
-						lineHeight="heading"
+						lineHeight="default"
 						fontSize={{ xs: 'md', sm: 'xl' }}
 						fontWeight="bold"
 					>
@@ -75,13 +75,14 @@ type HeaderBadgeProps = { children: ReactNode };
 const HeaderBadge = ({ children }: HeaderBadgeProps) => {
 	return (
 		<Box
-			fontSize="xs"
+			fontWeight="bold"
 			paddingLeft={0.5}
 			paddingRight={0.5}
 			border
 			borderWidth="md"
 			css={{
 				// These values don't exist in our tokens
+				fontSize: '0.75rem',
 				paddingTop: '2px',
 				paddingBottom: '2px',
 				borderColor: boxPalette.foregroundText,


### PR DESCRIPTION
## Describe your changes

Improve visual appearance of HeaderBadge, to match GOLD
<img width="783" alt="image" src="https://user-images.githubusercontent.com/12689383/156107918-de9f372d-334e-4631-a845-461e0055abb5.png">


## Checklist

- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file