### PR TITLE
Select: Fix placeholder issue

### DIFF
--- a/.changeset/cuddly-pumpkins-camp.md
+++ b/.changeset/cuddly-pumpkins-camp.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/select': patch
+---
+
+Added blank value to placeholder option

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -115,7 +115,7 @@ const SelectOptions = ({
 }) => {
 	return (
 		<>
-			{placeholder ? <option>{placeholder}</option> : null}
+			{placeholder ? <option value="">{placeholder}</option> : null}
 			{options.map((opt) => {
 				if ('options' in opt) {
 					return (


### PR DESCRIPTION
## Describe your changes

Added an empty value to the select placeholder. This bug was discovered after I tried to integrate out select component into a form with `react-hook-form`

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file