### PR TITLE
Checkbox/Radio: Update size of indicators

### DIFF
--- a/.changeset/lemon-hotels-hear.md
+++ b/.changeset/lemon-hotels-hear.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/control-input': patch
+---
+
+Updated sizing of the `Checkbox` and `Radio` indicators

--- a/packages/control-input/src/CheckboxIndicator.tsx
+++ b/packages/control-input/src/CheckboxIndicator.tsx
@@ -30,7 +30,6 @@ export const CheckboxIndicator = ({
 			borderWidth="lg"
 			style={{
 				borderColor: 'transparent',
-				borderRadius: '100%',
 				opacity: disabled ? 0.3 : undefined,
 			}}
 		>

--- a/packages/control-input/src/CheckboxIndicator.tsx
+++ b/packages/control-input/src/CheckboxIndicator.tsx
@@ -26,13 +26,13 @@ export const CheckboxIndicator = ({
 		<Box
 			width={width}
 			height={height}
+			border
+			borderWidth="lg"
 			style={{
-				borderWidth,
-				borderStyle: 'solid',
 				borderColor: 'transparent',
+				borderRadius: '100%',
 				opacity: disabled ? 0.3 : undefined,
 			}}
-			rounded
 		>
 			<Flex
 				justifyContent="center"

--- a/packages/control-input/src/RadioIndicator.tsx
+++ b/packages/control-input/src/RadioIndicator.tsx
@@ -20,14 +20,13 @@ export const RadioIndicator = ({
 		<Box
 			width={width}
 			height={height}
+			border
+			borderWidth="lg"
 			style={{
-				borderWidth,
-				borderStyle: 'solid',
 				borderColor: 'transparent',
 				borderRadius: '100%',
 				opacity: disabled ? 0.3 : undefined,
 			}}
-			rounded
 		>
 			<Flex
 				justifyContent="center"


### PR DESCRIPTION
## Describe your changes

Fixes an issue where checkbox and radio indicators were rendering at 34x34, not 32x32 as intended.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file