### PR TITLE
TextInput: Rename type

### DIFF
--- a/.changeset/fair-cycles-attend.md
+++ b/.changeset/fair-cycles-attend.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text-input': patch
+---
+
+Renamed type `InputProps` to `TextInputProps`

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -8,7 +8,7 @@ import {
 	tokens,
 } from '@ag.ds-next/core';
 
-export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+export type TextInputProps = InputHTMLAttributes<HTMLInputElement> & {
 	label: string;
 	required?: boolean;
 	hint?: string;
@@ -19,7 +19,7 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 	maxWidth?: FieldMaxWidth;
 };
 
-export const TextInput = forwardRef<HTMLInputElement, InputProps>(
+export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 	function TextInput(
 		{
 			label,


### PR DESCRIPTION
## Describe your changes

Rename `InputProps` to `TextInputProps`