### PR TITLE
Replace usage of `required` with `aria-required`

### DIFF
--- a/.changeset/thin-pumas-appear.md
+++ b/.changeset/thin-pumas-appear.md
@@ -1,7 +1,8 @@
 ---
-'@ag.ds-next/select': patch
-'@ag.ds-next/text-input': patch
-'@ag.ds-next/textarea': patch
+'@ag.ds-next/field': minor
+'@ag.ds-next/select': minor
+'@ag.ds-next/text-input': minor
+'@ag.ds-next/textarea': minor
 ---
 
 Replace `required` with `aria-required` to improve a11y

--- a/.changeset/thin-pumas-appear.md
+++ b/.changeset/thin-pumas-appear.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/select': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Replace `required` with `aria-required` to improve a11y

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -27,6 +27,7 @@ export const Field = ({
 }: FieldProps) => {
 	const { fieldId, hintId, messageId } = useFieldIds();
 	const a11yProps = useFieldA11yProps({
+		required,
 		fieldId,
 		message,
 		messageId,
@@ -62,12 +63,14 @@ export const useFieldIds = () => {
 };
 
 type A11yProps = {
+	'aria-required': boolean;
 	'aria-invalid': boolean;
 	'aria-describedby': string;
 	id: string;
 };
 
 export const useFieldA11yProps = ({
+	required,
 	fieldId,
 	message,
 	messageId,
@@ -75,13 +78,15 @@ export const useFieldA11yProps = ({
 	hintId,
 	invalid,
 }: {
+	required?: boolean;
 	fieldId: string;
 	message?: string;
 	messageId: string;
 	hint?: string;
 	hintId: string;
 	invalid?: boolean;
-}) => ({
+}): A11yProps => ({
+	'aria-required': Boolean(required),
 	'aria-invalid': Boolean(invalid),
 	'aria-describedby': [message ? messageId : null, hint ? hintId : null]
 		.filter(Boolean)

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -67,13 +67,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 			>
 				{(allyProps) => (
 					<SelectContainer block={block} maxWidth={maxWidth}>
-						<select
-							ref={ref}
-							aria-required={required}
-							css={styles}
-							{...allyProps}
-							{...props}
-						>
+						<select ref={ref} css={styles} {...allyProps} {...props}>
 							<SelectOptions options={options} placeholder={placeholder} />
 						</select>
 						<SelectIcon disabled={props.disabled} />

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -69,7 +69,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 					<SelectContainer block={block} maxWidth={maxWidth}>
 						<select
 							ref={ref}
-							required={required}
+							aria-required={required}
 							css={styles}
 							{...allyProps}
 							{...props}

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -45,13 +45,7 @@ export const TextInput = forwardRef<HTMLInputElement, InputProps>(
 				valid={valid}
 			>
 				{(allyProps) => (
-					<input
-						ref={ref}
-						aria-required={required}
-						css={styles}
-						{...allyProps}
-						{...props}
-					/>
+					<input ref={ref} css={styles} {...allyProps} {...props} />
 				)}
 			</Field>
 		);

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -47,7 +47,7 @@ export const TextInput = forwardRef<HTMLInputElement, InputProps>(
 				{(allyProps) => (
 					<input
 						ref={ref}
-						required={required}
+						aria-required={required}
 						css={styles}
 						{...allyProps}
 						{...props}

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -48,7 +48,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 				{(allyProps) => (
 					<textarea
 						ref={ref}
-						required={required}
+						aria-required={required}
 						css={styles}
 						{...allyProps}
 						{...props}

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -46,13 +46,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 				valid={valid}
 			>
 				{(allyProps) => (
-					<textarea
-						ref={ref}
-						aria-required={required}
-						css={styles}
-						{...allyProps}
-						{...props}
-					/>
+					<textarea ref={ref} css={styles} {...allyProps} {...props} />
 				)}
 			</Field>
 		);


### PR DESCRIPTION
## Describe your changes

After researching the differences between `required` and `aria-required`, we have reached a conclusion that `aria-required` is better suited for our needs.

- We can't control the message
-  They’re not always announced properly when focusing a field (looking at you Firefox)
- They can’t cater for all the scenarios that we actually need, so you have to implement custom errors anyway, thus giving users inconsistent experiences

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file