### PR TITLE
SideNav: Accessibility improvements. Move collapse logic out of container.

### DIFF
--- a/.changeset/rude-pants-share.md
+++ b/.changeset/rude-pants-share.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/side-nav': major
+---
+
+- Move collapse logic outside of SideNavContainer.
+- Improve accessibility for screenreader users.

--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -193,23 +193,6 @@ items={[
 `,
 	},
 	{
-		group: 'SideNav',
-		name: 'Modular',
-		code: `<SideNavContainer variant='light' aria-label="side navigation">
-      <SideNavTitle href="#" text="SideNavTitle" />
-      <SideNavLinkGroup>
-        <SideNavLink active={true} href="#one" label="One" />
-        <SideNavLink href="#two" label="Two" />
-        <SideNavLink href="#three" label="Three" />
-        <SideNavLinkGroup>
-        <SideNavLink href="#four" label="Four" />
-        <SideNavLink href="#five" label="Five" />
-        <SideNavLink href="#six" label="Six" />
-      </SideNavLinkGroup>
-      </SideNavLinkGroup>
-    </SideNavContainer>`,
-	},
-	{
 		group: 'Button',
 		name: 'Primary',
 		code: `<Button>Submit</Button>`,

--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -77,7 +77,7 @@ const snippits = [
 		code: `<Footer variant="agriculture">
     <nav aria-label="footer">
       <Columns>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3  }}> 
+        <Column columnSpan={{ xs: 12, sm: 6, lg: 3  }}>
           <Stack gap={0.5}>
             <H3>Section</H3>
             <LinkList
@@ -89,7 +89,7 @@ const snippits = [
             />
           </Stack>
         </Column>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}> 
+        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
           <Stack gap={0.5}>
             <H3>Section</H3>
             <LinkList
@@ -101,7 +101,7 @@ const snippits = [
             />
           </Stack>
         </Column>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}> 
+        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
           <Stack gap={0.5}>
             <H3>Section</H3>
             <LinkList
@@ -113,7 +113,7 @@ const snippits = [
             />
           </Stack>
         </Column>
-        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}> 
+        <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
           <Stack gap={0.5}>
             <H3>Section</H3>
             <LinkList
@@ -195,7 +195,7 @@ items={[
 	{
 		group: 'SideNav',
 		name: 'Modular',
-		code: `<SideNavContainer variant='light'>
+		code: `<SideNavContainer variant='light' aria-label="side navigation">
       <SideNavTitle href="#" text="SideNavTitle" />
       <SideNavLinkGroup>
         <SideNavLink active={true} href="#one" label="One" />

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -98,9 +98,9 @@ DarkAltVariant.args = {
 	variant: 'darkAlt',
 };
 
-export const Modular: ComponentStory<typeof SideNavContainer> = (args) => (
-	<SideNavContainer {...args}>
-		<SideNavTitle href="#">SideNavTitle</SideNavTitle>
+export const Modular = () => (
+	<SideNavContainer variant="light" aria-label="side navigation">
+		<SideNavTitle href="#">SideNav Title</SideNavTitle>
 		<SideNavGroup>
 			<SideNavLink href="#one" label="One" />
 			<SideNavLink href="#two" label="Two" />
@@ -118,7 +118,3 @@ export const Modular: ComponentStory<typeof SideNavContainer> = (args) => (
 		</SideNavGroup>
 	</SideNavContainer>
 );
-Modular.args = {
-	collapseTitle: 'In this section',
-	variant: 'light',
-};

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -4,7 +4,7 @@ import { SideNavContainer } from './SideNavContainer';
 import { SideNavTitle } from './SideNavTitle';
 import { SideNavGroup } from './SideNavGroup';
 import { SideNavLink } from './SideNavLink';
-import { findBestMatch } from './utils';
+import { findBestMatch, useSideNavIds } from './utils';
 import { LinkProps } from '@ag.ds-next/core';
 
 export type SideNavProps = LinkListProps & {
@@ -24,13 +24,19 @@ export function SideNav({
 	titleLink,
 	title,
 }: SideNavProps) {
+	const sideNavIds = useSideNavIds();
 	return (
 		<SideNavContainer
 			aria-label={ariaLabel}
+			ids={sideNavIds}
 			variant={variant}
 			collapseTitle={collapseTitle}
 		>
-			<SideNavTitle isCurrentPage={activePath === titleLink} href={titleLink}>
+			<SideNavTitle
+				isCurrentPage={activePath === titleLink}
+				id={sideNavIds.titleId}
+				href={titleLink}
+			>
 				{title}
 			</SideNavTitle>
 			<LinkList activePath={activePath} items={items} />

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -57,7 +57,7 @@ function LinkList({ activePath, items }: LinkListProps) {
 				<SideNavLink
 					key={index}
 					active={item.href === bestMatch}
-					isCurrentPage={item.href === activePath}
+					aria-current={item.href === activePath ? 'page' : undefined}
 					{...item}
 				>
 					{subItems?.length ? (

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -1,16 +1,33 @@
-import { ReactNode, ComponentProps } from 'react';
+import { ReactNode, useRef } from 'react';
+import { useSpring, animated } from 'react-spring';
+import { Box, backgroundColorMap } from '@ag.ds-next/box';
+import {
+	LinkProps,
+	mapResponsiveProp,
+	mq,
+	tokens,
+	useElementSize,
+	usePrefersReducedMotion,
+	useToggleState,
+} from '@ag.ds-next/core';
 
 import { SideNavContainer } from './SideNavContainer';
 import { SideNavTitle } from './SideNavTitle';
 import { SideNavGroup } from './SideNavGroup';
 import { SideNavLink } from './SideNavLink';
-import { findBestMatch, useSideNavIds } from './utils';
-import { LinkProps } from '@ag.ds-next/core';
+import { SideNavCollapseButton } from './SideNavCollapseButton';
+import {
+	localPaletteVars,
+	variantMap,
+	SideNavVariant,
+	findBestMatch,
+	useSideNavIds,
+} from './utils';
 
 export type SideNavProps = LinkListProps & {
 	'aria-label'?: string;
 	collapseTitle: string;
-	variant?: ComponentProps<typeof SideNavContainer>['variant'];
+	variant?: SideNavVariant;
 	title: ReactNode;
 	titleLink: string; // TODO: should this be optional
 };
@@ -24,22 +41,71 @@ export function SideNav({
 	titleLink,
 	title,
 }: SideNavProps) {
-	const sideNavIds = useSideNavIds();
+	const { bodyId, buttonId, navId, titleId } = useSideNavIds();
+	const { hover } = variantMap[variant];
+	const [isOpen, onToggle] = useToggleState(false, true);
+	const ref = useRef<HTMLDivElement>(null);
+	const { height } = useElementSize(ref);
+
+	const prefersReducedMotion = usePrefersReducedMotion();
+	const animatedHeight = useSpring({
+		from: { height: 0 },
+		to: { height: isOpen ? height : 0 },
+		immediate: prefersReducedMotion,
+	});
 	return (
-		<SideNavContainer
-			aria-label={ariaLabel}
-			ids={sideNavIds}
-			variant={variant}
-			collapseTitle={collapseTitle}
-		>
-			<SideNavTitle
-				isCurrentPage={activePath === titleLink}
-				id={sideNavIds.titleId}
-				href={titleLink}
+		<SideNavContainer aria-label={ariaLabel} variant={variant}>
+			<SideNavCollapseButton
+				isOpen={isOpen}
+				onClick={onToggle}
+				ariaControls={bodyId}
+				variant={variant}
+				id={buttonId}
 			>
-				{title}
-			</SideNavTitle>
-			<LinkList activePath={activePath} items={items} />
+				{collapseTitle}
+			</SideNavCollapseButton>
+			<animated.div
+				id={bodyId}
+				aria-labelledby={buttonId}
+				style={animatedHeight}
+				css={{
+					overflow: 'hidden',
+					[tokens.mediaQuery.min.md]: {
+						// Overwrite the animated height
+						// for tablet/desktop sizes.
+						overflow: 'unset',
+						height: 'auto !important',
+					},
+				}}
+			>
+				<Box
+					ref={ref}
+					as="nav"
+					role="navigation"
+					aria-labelledby={titleId}
+					id={navId}
+					fontFamily="body"
+					paddingLeft={{ xs: 1, md: 0 }}
+					paddingRight={{ xs: 1, md: 0 }}
+					fontSize="sm"
+					lineHeight="default"
+					css={mq({
+						[localPaletteVars.hover]: mapResponsiveProp(
+							hover,
+							(t) => backgroundColorMap[t]
+						),
+					})}
+				>
+					<SideNavTitle
+						isCurrentPage={activePath === titleLink}
+						id={titleId}
+						href={titleLink}
+					>
+						{title}
+					</SideNavTitle>
+					<LinkList activePath={activePath} items={items} />
+				</Box>
+			</animated.div>
 		</SideNavContainer>
 	);
 }

--- a/packages/side-nav/src/SideNavCollapseButton.tsx
+++ b/packages/side-nav/src/SideNavCollapseButton.tsx
@@ -35,8 +35,10 @@ export const SideNavCollapseButton = ({
 	return (
 		<Flex
 			as="button"
+			role="button"
 			aria-controls={ariaControls}
 			aria-expanded={isOpen}
+			aria-haspopup="menu"
 			rounded
 			background={background}
 			color="action"

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -46,6 +46,7 @@ export const SideNavContainer = ({
 
 	return (
 		<Box
+			as="aside"
 			aria-label={ariaLabel}
 			rounded
 			background={background}

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -46,7 +46,6 @@ export const SideNavContainer = ({
 
 	return (
 		<Box
-			as="aside"
 			aria-label={ariaLabel}
 			rounded
 			background={background}
@@ -61,7 +60,7 @@ export const SideNavContainer = ({
 			>
 				{collapseTitle}
 			</SideNavCollapseButton>
-			<animated.section
+			<animated.div
 				id={bodyId}
 				aria-labelledby={titleId}
 				role="region"
@@ -93,7 +92,7 @@ export const SideNavContainer = ({
 				>
 					{children}
 				</Box>
-			</animated.section>
+			</animated.div>
 		</Box>
 	);
 };

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -1,45 +1,18 @@
-import { useRef } from 'react';
 import type { PropsWithChildren } from 'react';
-import { useSpring, animated } from 'react-spring';
-import { Box, backgroundColorMap } from '@ag.ds-next/box';
-import {
-	mapResponsiveProp,
-	mq,
-	tokens,
-	useElementSize,
-	usePrefersReducedMotion,
-	useToggleState,
-} from '@ag.ds-next/core';
-
-import { SideNavCollapseButton } from './SideNavCollapseButton';
-import { localPaletteVars, variantMap, SideNavVariant } from './utils';
+import { Box } from '@ag.ds-next/box';
+import { variantMap, SideNavVariant } from './utils';
 
 export type SideNavContainerProps = PropsWithChildren<{
-	collapseTitle?: string;
-	ids: { bodyId: string; buttonId: string; titleId: string; navId: string };
 	variant: SideNavVariant;
 	'aria-label': string;
 }>;
 
 export const SideNavContainer = ({
 	children,
-	collapseTitle,
-	ids: { bodyId, buttonId, titleId, navId },
 	variant,
 	'aria-label': ariaLabel,
 }: SideNavContainerProps) => {
-	const { palette, background, hover } = variantMap[variant];
-	const [isOpen, onToggle] = useToggleState(false, true);
-	const ref = useRef<HTMLDivElement>(null);
-	const { height } = useElementSize(ref);
-
-	const prefersReducedMotion = usePrefersReducedMotion();
-	const animatedHeight = useSpring({
-		from: { height: 0 },
-		to: { height: isOpen ? height : 0 },
-		immediate: prefersReducedMotion,
-	});
-
+	const { palette, background } = variantMap[variant];
 	return (
 		<Box
 			as="aside"
@@ -48,51 +21,7 @@ export const SideNavContainer = ({
 			background={background}
 			palette={palette}
 		>
-			<SideNavCollapseButton
-				isOpen={isOpen}
-				onClick={onToggle}
-				ariaControls={bodyId}
-				variant={variant}
-				id={buttonId}
-			>
-				{collapseTitle}
-			</SideNavCollapseButton>
-			<animated.div
-				id={bodyId}
-				aria-labelledby={buttonId}
-				role="region"
-				style={animatedHeight}
-				css={{
-					overflow: 'hidden',
-					[tokens.mediaQuery.min.md]: {
-						// Overwrite the animated height
-						// for tablet/desktop sizes.
-						overflow: 'unset',
-						height: 'auto !important',
-					},
-				}}
-			>
-				<Box
-					ref={ref}
-					as="nav"
-					role="navigation"
-					aria-labelledby={titleId}
-					id={navId}
-					fontFamily="body"
-					paddingLeft={{ xs: 1, md: 0 }}
-					paddingRight={{ xs: 1, md: 0 }}
-					fontSize="sm"
-					lineHeight="default"
-					css={mq({
-						[localPaletteVars.hover]: mapResponsiveProp(
-							hover,
-							(t) => backgroundColorMap[t]
-						),
-					})}
-				>
-					{children}
-				</Box>
-			</animated.div>
+			{children}
 		</Box>
 	);
 };

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -12,15 +12,11 @@ import {
 } from '@ag.ds-next/core';
 
 import { SideNavCollapseButton } from './SideNavCollapseButton';
-import {
-	localPaletteVars,
-	useSideNavIds,
-	variantMap,
-	SideNavVariant,
-} from './utils';
+import { localPaletteVars, variantMap, SideNavVariant } from './utils';
 
 export type SideNavContainerProps = PropsWithChildren<{
 	collapseTitle?: string;
+	ids: { bodyId: string; buttonId: string; titleId: string; navId: string };
 	variant: SideNavVariant;
 	'aria-label': string;
 }>;
@@ -28,6 +24,7 @@ export type SideNavContainerProps = PropsWithChildren<{
 export const SideNavContainer = ({
 	children,
 	collapseTitle,
+	ids: { bodyId, buttonId, titleId, navId },
 	variant,
 	'aria-label': ariaLabel,
 }: SideNavContainerProps) => {
@@ -35,7 +32,6 @@ export const SideNavContainer = ({
 	const [isOpen, onToggle] = useToggleState(false, true);
 	const ref = useRef<HTMLDivElement>(null);
 	const { height } = useElementSize(ref);
-	const { titleId, bodyId } = useSideNavIds();
 
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const animatedHeight = useSpring({
@@ -57,13 +53,13 @@ export const SideNavContainer = ({
 				onClick={onToggle}
 				ariaControls={bodyId}
 				variant={variant}
-				id={titleId}
+				id={buttonId}
 			>
 				{collapseTitle}
 			</SideNavCollapseButton>
 			<animated.div
 				id={bodyId}
-				aria-labelledby={titleId}
+				aria-labelledby={buttonId}
 				role="region"
 				style={animatedHeight}
 				css={{
@@ -79,6 +75,9 @@ export const SideNavContainer = ({
 				<Box
 					ref={ref}
 					as="nav"
+					role="navigation"
+					aria-labelledby={titleId}
+					id={navId}
 					fontFamily="body"
 					paddingLeft={{ xs: 1, md: 0 }}
 					paddingRight={{ xs: 1, md: 0 }}

--- a/packages/side-nav/src/SideNavGroup.tsx
+++ b/packages/side-nav/src/SideNavGroup.tsx
@@ -8,7 +8,9 @@ export const SideNavGroup = ({ children }: SideNavGroupProps) => {
 	const depth = useLinkListDepth();
 	return (
 		<LinkListContext.Provider value={depth + 1}>
-			<Box as="ul">{children}</Box>
+			<Box as="ul" role="menu">
+				{children}
+			</Box>
 		</LinkListContext.Provider>
 	);
 };

--- a/packages/side-nav/src/SideNavLink.tsx
+++ b/packages/side-nav/src/SideNavLink.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from 'react';
 import { Box } from '@ag.ds-next/box';
 import { useLinkComponent, mapSpacing, LinkProps } from '@ag.ds-next/core';
 import { boxPalette, fontGrid, packs } from '@ag.ds-next/core';
-import { VisuallyHidden } from '@ag.ds-next/a11y';
 
 import { useLinkListDepth } from './context';
 import { localPalette } from './utils';
@@ -15,7 +14,6 @@ export type SideNavLinkType = LinkProps & {
 
 export const SideNavLink = ({
 	active,
-	isCurrentPage,
 	children,
 	label,
 	...props
@@ -77,12 +75,7 @@ export const SideNavLink = ({
 					},
 				}}
 			>
-				<Link {...props}>
-					{label}
-					{isCurrentPage ? (
-						<VisuallyHidden> Current page</VisuallyHidden>
-					) : null}
-				</Link>
+				<Link {...props}>{label}</Link>
 			</Box>
 			{children}
 		</Box>

--- a/packages/side-nav/src/SideNavTitle.tsx
+++ b/packages/side-nav/src/SideNavTitle.tsx
@@ -11,12 +11,13 @@ export type SideNavTitleProps = LinkProps & {
 
 export const SideNavTitle = ({
 	children,
+	id,
 	isCurrentPage,
 	...props
 }: SideNavTitleProps) => {
 	const Link = useLinkComponent();
 	return (
-		<Box as="h2">
+		<Box as="h2" id={id}>
 			<Box
 				as={Link}
 				{...props}

--- a/packages/side-nav/src/utils.ts
+++ b/packages/side-nav/src/utils.ts
@@ -26,13 +26,13 @@ export const localPalette = {
 	hover: `var(${localPaletteVars.hover})`,
 };
 
-export const useSideNavIds = (initialId?: string | undefined) => {
-	const id = useId(initialId);
+export const useSideNavIds = () => {
+	const autoId = useId();
 	return {
-		buttonId: `${id}-button`,
-		bodyId: `${id}-default`,
-		navId: `${id}-nav`,
-		titleId: `${id}-title`,
+		buttonId: `sideNav-${autoId}-button`,
+		bodyId: `sideNav-${autoId}-default`,
+		navId: `sideNav-${autoId}-nav`,
+		titleId: `sideNav-${autoId}-title`,
 	};
 };
 

--- a/packages/side-nav/src/utils.ts
+++ b/packages/side-nav/src/utils.ts
@@ -29,8 +29,10 @@ export const localPalette = {
 export const useSideNavIds = (initialId?: string | undefined) => {
 	const id = useId(initialId);
 	return {
-		titleId: `${id}-title`,
+		buttonId: `${id}-button`,
 		bodyId: `${id}-default`,
+		navId: `${id}-nav`,
+		titleId: `${id}-title`,
 	};
 };
 


### PR DESCRIPTION
## Describe your changes

Improves accessibility of SideNav components, with assistance from @stowball. We did this by ensuring the right aria attributes were applied.

While doing this work, we realised that SideNavContainer was doing too much work, so the logic responsible for collapsing the nav in mobile viewports was uplifted to the core SideNav component.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
