### PR TITLE
LinkList, Breadcrumbs: Update docs

### DIFF
--- a/.changeset/flat-bikes-prove.md
+++ b/.changeset/flat-bikes-prove.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+'@ag.ds-next/link-list': patch
+---
+
+Updated documentation

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -7,13 +7,11 @@ group: Navigation
 Breadcrumbs show users where they are in the website hierarchy and how to navigate back/up to previous levels or content.
 
 ```jsx live
-<Box palette="light" background="body">
-	<Breadcrumbs
-		links={[
-			{ href: '#', label: 'Home' },
-			{ href: '#', label: 'Establishments' },
-			{ label: 'Applications' },
-		]}
-	/>
-</Box>
+<Breadcrumbs
+	links={[
+		{ href: '#', label: 'Home' },
+		{ href: '#', label: 'Establishments' },
+		{ label: 'Applications' },
+	]}
+/>
 ```

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -7,15 +7,13 @@ group: Navigation
 The default link list component removes the normal bullets and spacing associated with a list.
 
 ```jsx live
-<Box palette="light" background="body">
-	<LinkList
-		links={[
-			{ href: '#', label: 'Home' },
-			{ href: '#', label: 'Establishments' },
-			{ href: '#', label: 'Applications' },
-		]}
-	/>
-</Box>
+<LinkList
+	links={[
+		{ href: '#', label: 'Home' },
+		{ href: '#', label: 'Establishments' },
+		{ href: '#', label: 'Applications' },
+	]}
+/>
 ```
 
 ## Horizontal
@@ -23,14 +21,12 @@ The default link list component removes the normal bullets and spacing associate
 Setting the `horizontal` prop will stack the links horizontally.
 
 ```jsx live
-<Box palette="light" background="body">
-	<LinkList
-		links={[
-			{ href: '#', label: 'Home' },
-			{ href: '#', label: 'Establishments' },
-			{ href: '#', label: 'Applications' },
-		]}
-		horizontal
-	/>
-</Box>
+<LinkList
+	links={[
+		{ href: '#', label: 'Home' },
+		{ href: '#', label: 'Establishments' },
+		{ href: '#', label: 'Applications' },
+	]}
+	horizontal
+/>
 ```


### PR DESCRIPTION
## Describe your changes

Remove useless `Box` from documentation