### PR TITLE
Field: Update Ids

### DIFF
--- a/.changeset/fair-shoes-flash.md
+++ b/.changeset/fair-shoes-flash.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/field': patch
+'@ag.ds-next/search-box': patch
+'@ag.ds-next/select': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Fixed a bug in `Field` and updated usage so if an `id` prop is supplied, that value will be used instead of the auto generated ID.

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -8,24 +8,26 @@ import { useId } from '@reach/auto-id';
 
 export type FieldProps = {
 	children: ((allyProps: A11yProps) => ReactNode) | ReactNode;
-	label: string;
-	required: boolean;
 	hint: string | undefined;
-	message: string | undefined;
+	id?: string;
 	invalid?: boolean;
+	label: string;
+	message: string | undefined;
+	required: boolean;
 	valid?: boolean;
 };
 
 export const Field = ({
 	children,
 	hint,
+	id,
+	invalid,
 	label,
 	message,
 	required,
-	invalid,
 	valid,
 }: FieldProps) => {
-	const { fieldId, hintId, messageId } = useFieldIds();
+	const { fieldId, hintId, messageId } = useFieldIds(id);
 	const a11yProps = useFieldA11yProps({
 		required,
 		fieldId,
@@ -54,11 +56,11 @@ export const Field = ({
 	);
 };
 
-export const useFieldIds = () => {
-	const id = useId();
-	const fieldId = `field-${id}`;
-	const hintId = `field-${id}-hint`;
-	const messageId = `field-${id}-message`;
+export const useFieldIds = (idProp: string | undefined) => {
+	const autoId = useId(idProp);
+	const fieldId = idProp ? idProp : `field-${autoId}`;
+	const hintId = `field-${autoId}-hint`;
+	const messageId = `field-${autoId}-message`;
 	return { fieldId, hintId, messageId };
 };
 

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -56,7 +56,7 @@ export const Field = ({
 	);
 };
 
-export const useFieldIds = (idProp: string | undefined) => {
+export const useFieldIds = (idProp?: string) => {
 	const autoId = useId(idProp);
 	const fieldId = idProp ? idProp : `field-${autoId}`;
 	const hintId = `field-${autoId}-hint`;

--- a/packages/search-box/src/SearchBoxInput.tsx
+++ b/packages/search-box/src/SearchBoxInput.tsx
@@ -28,8 +28,8 @@ export const SearchBoxInput = forwardRef<HTMLInputElement, SearchBoxInputProps>(
 );
 
 const useInputId = (idProp?: string) => {
-	const id = useId(idProp);
-	return idProp || `search-${id}`;
+	const autoId = useId();
+	return idProp || `search-${autoId}`;
 };
 
 const inputStyles = () => {

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -51,6 +51,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 			maxWidth,
 			options,
 			placeholder,
+			id,
 			...props
 		},
 		ref
@@ -64,6 +65,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 				message={message}
 				invalid={invalid}
 				valid={valid}
+				id={id}
 			>
 				{(allyProps) => (
 					<SelectContainer block={block} maxWidth={maxWidth}>

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -30,6 +30,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			valid,
 			block,
 			maxWidth,
+			id,
 			...props
 		},
 		ref
@@ -43,6 +44,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 				message={message}
 				invalid={invalid}
 				valid={valid}
+				id={id}
 			>
 				{(allyProps) => (
 					<input ref={ref} css={styles} {...allyProps} {...props} />

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -24,6 +24,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 			valid,
 			block,
 			maxWidth,
+			id,
 			...props
 		},
 		ref
@@ -44,6 +45,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 				message={message}
 				invalid={invalid}
 				valid={valid}
+				id={id}
 			>
 				{(allyProps) => (
 					<textarea ref={ref} css={styles} {...allyProps} {...props} />


### PR DESCRIPTION
## Describe your changes

Fixed a bug in `Field` and updated usage so if an `id` prop is supplied, that value will be used instead of the auto generated ID. This fixes a bug where if you pass an ID into `TextInput`, `Textarea` or `Select, the labels and inputs will not be connected correctly via ids.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file