### PR TITLE
InpageNav, SkipLinks: Update default aria-label

### DIFF
--- a/.changeset/wild-coats-sneeze.md
+++ b/.changeset/wild-coats-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/inpage-nav': patch
+'@ag.ds-next/skip-link': patch
+---
+
+Updated default aria label

--- a/packages/inpage-nav/src/InpageNav.tsx
+++ b/packages/inpage-nav/src/InpageNav.tsx
@@ -11,7 +11,7 @@ export type InpageNavProps = {
 };
 
 export const InpageNav = ({
-	'aria-label': ariaLabel = 'In page',
+	'aria-label': ariaLabel = 'in page',
 	links,
 	title,
 }: InpageNavProps) => (

--- a/packages/skip-link/src/SkipLinks.tsx
+++ b/packages/skip-link/src/SkipLinks.tsx
@@ -9,7 +9,7 @@ export type SkipLinksProps = {
 
 export const SkipLinks = ({
 	links,
-	'aria-label': ariaLabel = 'skip links navigation',
+	'aria-label': ariaLabel = 'skip links',
 }: SkipLinksProps) => (
 	<SkipLinkContainer aria-label={ariaLabel}>
 		{links.map(({ label, ...props }, idx) => (


### PR DESCRIPTION
## Describe your changes

Updated the default aria label to be more consistent with other default aria labels in the system.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file