### PR TITLE
Button: Add `iconBefore` and `iconAfter` props

### DIFF
--- a/.changeset/kind-trees-smile.md
+++ b/.changeset/kind-trees-smile.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/icon': patch
+---
+
+Export `IconProps` type

--- a/.changeset/polite-seahorses-unite.md
+++ b/.changeset/polite-seahorses-unite.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/button': patch
+---
+
+Added `iconBefore` and `iconAfter` props

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -89,3 +89,11 @@ ButtonLink adopts the Link component from your chosen router framework, which yo
 ```jsx live
 <ButtonLink href="/sign-in">Sign in</ButtonLink>
 ```
+
+### Icon
+
+Is provided to support universial icons in buttons.
+
+```jsx live
+<ButtonLink href="/sign-in" iconRight={ChevronRighticon}>Sign in</Button>
+```

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -56,7 +56,7 @@ Size is another prop that allows adjustment of visual weight. The medium button 
 
 ### Disabled
 
-A button that can’t be clicked and doesn’t react to hover. A disabled button is typically greyed out to indicate to users that they cannot undertake the action associated with it. This is usually for page logic reasons.
+A button that can’t be interacted with. A disabled button is typically greyed out to indicate to users that they cannot undertake the action associated with it. This is usually for page logic reasons.
 
 ```jsx live
 <Flex gap={1}>
@@ -80,20 +80,27 @@ A block-level button uses 100% of the available width of the container or parent
 <Button block>Submit</Button>
 ```
 
-### ButtonLink
+### Icons
 
-For situations where you need something that has the visual weight of a Button, but the functionality of a link, you can use ButtonLink!
+The `iconAfter` and `iconBefore` props can be used to add system icons to buttons.
 
-ButtonLink adopts the Link component from your chosen router framework, which you can set in the Core component.
+```jsx live
+<ButtonLink
+	iconAfter={ExternalLinkIcon}
+	href="https://steelthreads.github.io/agds-next"
+	target="_blank"
+	rel="noopener noreferrer"
+>
+	Open external link
+</ButtonLink>
+```
+
+## Buttons links
+
+For situations where you need something that has the visual weight of a Button, but the functionality of a link, you can use `ButtonLink`!
+
+`ButtonLink` adopts the `Link` component from your chosen router framework, which you can set in the `Core` component.
 
 ```jsx live
 <ButtonLink href="/sign-in">Sign in</ButtonLink>
-```
-
-### Icon
-
-Is provided to support universial icons in buttons.
-
-```jsx live
-<ButtonLink href="/sign-in" iconRight={ChevronRighticon}>Sign in</Button>
 ```

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -81,14 +81,18 @@ export const ButtonWithIcon: ComponentStory<typeof Button> = (args) => (
 	<Button {...args} />
 );
 ButtonWithIcon.args = {
-	children: 'Button',
-	icon: ExternalLinkIcon,
+	children: 'Primary',
+	iconAfter: ExternalLinkIcon,
 };
 
 export const ButtonLinkWithIcon: ComponentStory<typeof ButtonLink> = (args) => (
 	<ButtonLink {...args} />
 );
+ButtonLinkWithIcon.storyName = 'ButtonLink With Icon';
 ButtonLinkWithIcon.args = {
-	children: 'Button link with icon',
-	icon: ExternalLinkIcon,
+	children: 'Open external link',
+	href: 'https://steelthreads.github.io/agds-next',
+	target: '_blank',
+	rel: 'noopener noreferrer',
+	iconAfter: ExternalLinkIcon,
 };

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -3,6 +3,7 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Button, ButtonLink } from './Button';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
+import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
 export default {
 	title: 'forms/Button',
@@ -66,11 +67,28 @@ export const Size: ComponentStory<typeof Button> = (args) => (
 );
 
 export const ButtonLinkStory: ComponentStory<typeof ButtonLink> = (args) => (
-	<ButtonLink {...args}>Primary</ButtonLink>
+	<ButtonLink {...args} />
 );
 ButtonLinkStory.storyName = 'ButtonLink';
 ButtonLinkStory.args = {
+	children: 'Button Link',
 	block: false,
 	href: '#',
 	variant: 'primary',
+};
+
+export const ButtonWithIcon: ComponentStory<typeof Button> = (args) => (
+	<Button {...args} />
+);
+ButtonWithIcon.args = {
+	children: 'Button',
+	icon: ExternalLinkIcon,
+};
+
+export const ButtonLinkWithIcon: ComponentStory<typeof ButtonLink> = (args) => (
+	<ButtonLink {...args} />
+);
+ButtonLinkWithIcon.args = {
+	children: 'Button link with icon',
+	icon: ExternalLinkIcon,
 };

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -10,7 +10,8 @@ import { buttonStyles, ButtonSize, ButtonVariant, iconSize } from './styles';
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 	block?: boolean;
-	icon?: ComponentType<IconProps>;
+	iconBefore?: ComponentType<IconProps>;
+	iconAfter?: ComponentType<IconProps>;
 	loading?: boolean;
 	size?: ButtonSize;
 	variant?: ButtonVariant;
@@ -20,7 +21,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 	function Button(
 		{
 			block = false,
-			icon: Icon,
+			iconBefore: IconBefore,
+			iconAfter: IconAfter,
 			children,
 			disabled,
 			size = 'md',
@@ -33,8 +35,13 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		const styles = buttonStyles({ block, size, variant });
 		return (
 			<button ref={ref} disabled={disabled} css={styles} {...props}>
+				{IconBefore ? (
+					<IconBefore size={iconSize[size]} weight="regular" />
+				) : null}
 				{loading ? 'Loading...' : children}
-				{Icon ? <Icon size={iconSize[size]} weight="regular" /> : null}
+				{IconAfter ? (
+					<IconAfter size={iconSize[size]} weight="regular" />
+				) : null}
 			</button>
 		);
 	}
@@ -42,7 +49,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 export type ButtonLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 	block?: boolean;
-	icon?: ComponentType<IconProps>;
+	iconBefore?: ComponentType<IconProps>;
+	iconAfter?: ComponentType<IconProps>;
 	size?: ButtonSize;
 	variant?: ButtonVariant;
 };
@@ -50,7 +58,8 @@ export type ButtonLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 export const ButtonLink = ({
 	children,
 	block = false,
-	icon: Icon,
+	iconBefore: IconBefore,
+	iconAfter: IconAfter,
 	size = 'md',
 	variant = 'primary',
 	...props
@@ -59,8 +68,11 @@ export const ButtonLink = ({
 	const Link = useLinkComponent();
 	return (
 		<Link css={styles} {...props}>
+			{IconBefore ? (
+				<IconBefore size={iconSize[size]} weight="regular" />
+			) : null}
 			{children}
-			{Icon ? <Icon size={iconSize[size]} /> : null}
+			{IconAfter ? <IconAfter size={iconSize[size]} weight="regular" /> : null}
 		</Link>
 	);
 };

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -2,12 +2,15 @@ import React, {
 	forwardRef,
 	ButtonHTMLAttributes,
 	AnchorHTMLAttributes,
+	ComponentType,
 } from 'react';
 import { useLinkComponent } from '@ag.ds-next/core';
-import { buttonStyles, ButtonSize, ButtonVariant } from './styles';
+import { IconProps } from '@ag.ds-next/icon';
+import { buttonStyles, ButtonSize, ButtonVariant, iconSize } from './styles';
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 	block?: boolean;
+	icon?: ComponentType<IconProps>;
 	loading?: boolean;
 	size?: ButtonSize;
 	variant?: ButtonVariant;
@@ -15,13 +18,23 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 	function Button(
-		{ block, children, disabled, size, loading, variant, ...props },
+		{
+			block = false,
+			icon: Icon,
+			children,
+			disabled,
+			size = 'md',
+			loading = false,
+			variant = 'primary',
+			...props
+		},
 		ref
 	) {
 		const styles = buttonStyles({ block, size, variant });
 		return (
 			<button ref={ref} disabled={disabled} css={styles} {...props}>
 				{loading ? 'Loading...' : children}
+				{Icon ? <Icon size={iconSize[size]} weight="regular" /> : null}
 			</button>
 		);
 	}
@@ -29,15 +42,17 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
 export type ButtonLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
 	block?: boolean;
+	icon?: ComponentType<IconProps>;
 	size?: ButtonSize;
 	variant?: ButtonVariant;
 };
 
 export const ButtonLink = ({
 	children,
-	block,
-	size,
-	variant,
+	block = false,
+	icon: Icon,
+	size = 'md',
+	variant = 'primary',
 	...props
 }: ButtonLinkProps) => {
 	const styles = buttonStyles({ block, size, variant });
@@ -45,6 +60,7 @@ export const ButtonLink = ({
 	return (
 		<Link css={styles} {...props}>
 			{children}
+			{Icon ? <Icon size={iconSize[size]} /> : null}
 		</Link>
 	);
 };

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -1,4 +1,10 @@
-import { packs, boxPalette, tokens, mapSpacing } from '@ag.ds-next/core';
+import {
+	packs,
+	boxPalette,
+	tokens,
+	mapSpacing,
+	Spacing,
+} from '@ag.ds-next/core';
 
 const variants = {
 	primary: {
@@ -47,11 +53,13 @@ export type ButtonVariant = keyof typeof variants;
 const sizes = {
 	sm: {
 		...packs.input.sm,
+		gap: mapSpacing(0.25),
 		paddingLeft: mapSpacing(0.75),
 		paddingRight: mapSpacing(0.75),
 	},
 	md: {
 		...packs.input.md,
+		gap: mapSpacing(0.5),
 		paddingLeft: mapSpacing(1.5),
 		paddingRight: mapSpacing(1.5),
 	},
@@ -59,14 +67,19 @@ const sizes = {
 
 export type ButtonSize = keyof typeof sizes;
 
+export const iconSize: Record<ButtonSize, Spacing> = {
+	sm: 1,
+	md: 1.25,
+};
+
 export function buttonStyles({
 	block,
-	variant = 'primary',
-	size = 'md',
+	variant,
+	size,
 }: {
-	block?: boolean;
-	variant?: ButtonVariant;
-	size?: ButtonSize;
+	block: boolean;
+	variant: ButtonVariant;
+	size: ButtonSize;
 }) {
 	return {
 		...variants[variant],

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -69,7 +69,7 @@ export type ButtonSize = keyof typeof sizes;
 
 export const iconSize: Record<ButtonSize, Spacing> = {
 	sm: 1,
-	md: 1.25,
+	md: 1.5,
 };
 
 export function buttonStyles({

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -87,6 +87,7 @@ export function buttonStyles({
 
 		appearance: 'none',
 		display: block ? 'flex' : 'inline-flex',
+		justifyContent: 'space-between',
 		alignItems: 'center',
 		borderWidth: tokens.borderWidth.lg,
 		borderStyle: 'solid',

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -87,8 +87,8 @@ export function buttonStyles({
 
 		appearance: 'none',
 		display: block ? 'flex' : 'inline-flex',
-		justifyContent: 'space-between',
 		alignItems: 'center',
+		justifyContent: 'center',
 		borderWidth: tokens.borderWidth.lg,
 		borderStyle: 'solid',
 		borderRadius: tokens.borderRadius,

--- a/packages/icon/src/index.tsx
+++ b/packages/icon/src/index.tsx
@@ -1,3 +1,5 @@
+import type { IconProps as _IconProps } from './Icon';
+
 export { AlertIcon } from './icons/AlertIcon';
 export { AlertFilledIcon } from './icons/AlertFilledIcon';
 export { ArrowUpIcon } from './icons/ArrowUpIcon';
@@ -18,3 +20,5 @@ export { SearchIcon } from './icons/SearchIcon';
 export { SuccessIcon } from './icons/SuccessIcon';
 export { SuccessFilledIcon } from './icons/SuccessFilledIcon';
 export { ProgressTodoIcon } from './icons/ProgressTodoIcon';
+
+export type IconProps = _IconProps;


### PR DESCRIPTION
## Describe your changes

<img width="839" alt="Screen Shot 2022-03-10 at 1 19 12 pm" src="https://user-images.githubusercontent.com/6265154/157581967-8dd6bb07-0d82-45b8-af08-97f144e093c1.png">

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook