### PR TITLE
Core: Add new `underline` pack

### DIFF
--- a/.changeset/light-taxis-grow.md
+++ b/.changeset/light-taxis-grow.md
@@ -1,0 +1,11 @@
+---
+'@ag.ds-next/box': patch
+'@ag.ds-next/button': patch
+'@ag.ds-next/core': patch
+'@ag.ds-next/header': patch
+'@ag.ds-next/main-nav': patch
+'@ag.ds-next/progress-indicator': patch
+'@ag.ds-next/side-nav': patch
+---
+
+Added `underline` pack and updated usage

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -279,9 +279,8 @@ function paddingStyles({
 
 type LinkProps = Partial<{ link: boolean }>;
 export const linkStyles = {
+	...packs.underline,
 	color: boxPalette.foregroundAction,
-	textDecoration: 'underline',
-	textDecorationSkip: 'auto',
 	cursor: 'pointer',
 
 	'&:hover': {

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -11,7 +11,7 @@ const variants = {
 			background: boxPalette.foregroundText,
 			borderColor: boxPalette.foregroundText,
 			color: boxPalette.backgroundBody,
-			textDecoration: 'underline',
+			...packs.underline,
 		},
 	},
 	secondary: {
@@ -24,14 +24,14 @@ const variants = {
 			background: 'transparent',
 			borderColor: boxPalette.foregroundText,
 			color: boxPalette.foregroundText,
-			textDecoration: 'underline',
+			...packs.underline,
 		},
 	},
 	tertiary: {
 		background: 'transparent',
 		borderColor: 'transparent',
 		color: boxPalette.foregroundAction,
-		textDecoration: 'underline',
+		...packs.underline,
 
 		'&:not(:disabled):hover': {
 			background: 'transparent',

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -36,8 +36,14 @@ const outline = {
 	outlineOffset: 0.5 * tokens.unit,
 };
 
+const underline = {
+	textDecoration: 'underline',
+	textDecorationSkipInk: 'auto',
+} as const;
+
 export const packs = {
-	outline,
 	control,
 	input,
+	outline,
+	underline,
 };

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
-import { useLinkComponent, boxPalette } from '@ag.ds-next/core';
+import { useLinkComponent, boxPalette, packs } from '@ag.ds-next/core';
 
 type HeaderBrandProps = {
 	badgeLabel?: string;
@@ -31,10 +31,7 @@ export function HeaderBrand({
 			alignItems="stretch"
 			css={{
 				textDecoration: 'none',
-				':hover': {
-					textDecoration: 'underline',
-					textDecorationSkipInk: 'auto',
-				},
+				':hover': packs.underline,
 			}}
 		>
 			{logo ? (

--- a/packages/main-nav/src/NavListItem.tsx
+++ b/packages/main-nav/src/NavListItem.tsx
@@ -66,8 +66,7 @@ export function NavListItem({ children, active }: NavItemProps) {
 					},
 
 					'&:hover': {
-						textDecoration: 'underline',
-						textDecorationSkipInk: 'auto',
+						...packs.underline,
 						color: boxPalette.foregroundText,
 						backgroundColor: localPalette.linkHoverBg,
 						'&::after': {

--- a/packages/progress-indicator/src/ProgressIndicatorItem.tsx
+++ b/packages/progress-indicator/src/ProgressIndicatorItem.tsx
@@ -6,7 +6,7 @@ import {
 	ProgressDoneIcon,
 	ProgressTodoIcon,
 } from '@ag.ds-next/icon';
-import { boxPalette, LinkProps } from '@ag.ds-next/core';
+import { boxPalette, LinkProps, packs } from '@ag.ds-next/core';
 
 export type ProgressIndicatorItemStatus = 'doing' | 'todo' | 'done';
 
@@ -79,8 +79,7 @@ const ProgressIndicatorItem = ({
 					borderLeftColor: active ? boxPalette.foregroundAction : 'transparent',
 					textDecoration: 'none',
 					'&:hover': {
-						textDecoration: 'underline',
-						textDecorationSkipInk: 'auto',
+						...packs.underline,
 						backgroundColor: boxPalette.backgroundShade,
 					},
 				}}

--- a/packages/progress-indicator/src/ProgressIndicatorItem.tsx
+++ b/packages/progress-indicator/src/ProgressIndicatorItem.tsx
@@ -79,6 +79,8 @@ const ProgressIndicatorItem = ({
 					borderLeftColor: active ? boxPalette.foregroundAction : 'transparent',
 					textDecoration: 'none',
 					'&:hover': {
+						textDecoration: 'underline',
+						textDecorationSkipInk: 'auto',
 						backgroundColor: boxPalette.backgroundShade,
 					},
 				}}

--- a/packages/side-nav/src/SideNavLink.tsx
+++ b/packages/side-nav/src/SideNavLink.tsx
@@ -50,9 +50,8 @@ export const SideNavLink = ({
 						display: 'block',
 
 						'&:hover': {
+							...packs.underline,
 							color: boxPalette.foregroundText,
-							textDecoration: 'underline',
-							textDecorationSkipInk: 'auto',
 							backgroundColor: localPalette.hover,
 						},
 

--- a/packages/side-nav/src/SideNavTitle.tsx
+++ b/packages/side-nav/src/SideNavTitle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@ag.ds-next/box';
-import { boxPalette, LinkProps, useLinkComponent } from '@ag.ds-next/core';
+import { LinkProps, packs, useLinkComponent } from '@ag.ds-next/core';
 import { VisuallyHidden } from '@ag.ds-next/a11y';
 
 import { localPalette } from './utils';
@@ -28,17 +28,18 @@ export const SideNavTitle = ({
 				lineHeight="heading"
 				display="block"
 				focus
+				borderBottom
+				borderBottomWidth="md"
 				css={{
-					borderBottom: `2px solid ${boxPalette.border}`,
 					textDecoration: 'none',
-
 					'&:hover': {
+						...packs.underline,
 						backgroundColor: localPalette.hover,
-						textDecoration: 'underline',
 					},
 				}}
 			>
 				{children}
+				{/** TODO this should be removed **/}
 				{isCurrentPage ? <VisuallyHidden> Current page</VisuallyHidden> : null}
 			</Box>
 		</Box>


### PR DESCRIPTION
## Describe your changes

Added new underline pack since we use 2 properties for underlines. Fixed some usage where `textDecorationSkipInk` wasn't being used.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file