### PR TITLE
Field: Add `requiredLabel` prop

### DIFF
--- a/.changeset/tender-laws-warn.md
+++ b/.changeset/tender-laws-warn.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/control-input': patch
+'@ag.ds-next/field': patch
+'@ag.ds-next/select': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Added new prop `requiredLabel` which can be used to disable the "(optional)" and "(required)" label text

--- a/packages/control-input/src/ControlGroup.stories.tsx
+++ b/packages/control-input/src/ControlGroup.stories.tsx
@@ -77,3 +77,9 @@ Invalid.args = {
 	block: true,
 	invalid: true,
 };
+
+export const RequiredLabel = Template.bind({});
+RequiredLabel.args = {
+	label: 'Choose your interests',
+	requiredLabel: false,
+};

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -11,6 +11,7 @@ export type ControlGroupProps = PropsWithChildren<{
 	label?: string;
 	message?: string;
 	required?: boolean;
+	requiredLabel?: boolean;
 }>;
 
 export const ControlGroup = ({
@@ -21,15 +22,19 @@ export const ControlGroup = ({
 	label,
 	message,
 	required,
+	requiredLabel,
 }: ControlGroupProps) => (
 	<FieldContainer invalid={invalid}>
 		<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
 			{label ? (
 				<Text as="legend" display="block" fontWeight="bold">
-					{label}{' '}
-					<Text as="span" color="muted">
-						({required ? 'required' : 'optional'})
-					</Text>
+					{label}
+					{requiredLabel ? (
+						<Text as="span" color="muted">
+							{' '}
+							({required ? 'required' : 'optional'})
+						</Text>
+					) : null}
 				</Text>
 			) : null}
 			<Stack gap={0.5} css={{ marginTop: label ? mapSpacing(0.5) : undefined }}>

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -60,3 +60,13 @@ Error messages are used to notify the user when a form field has not passed vali
 	</Field>
 </Stack>
 ```
+
+### Required label
+
+By default, "(optional)" or "(required)" will be appended to labels. To disable this, set the `requiredLabel` prop to `false`.
+
+```jsx live
+<Field label="Start date" requiredLabel={false}>
+	{(a11yProps) => <select {...a11yProps} />}
+</Field>
+```

--- a/packages/field/src/Field.stories.tsx
+++ b/packages/field/src/Field.stories.tsx
@@ -84,3 +84,11 @@ Modular.args = {
 	hint: 'Hint',
 	message: 'Message',
 };
+
+export const RequiredLabel: ComponentStory<typeof Field> = (args) => (
+	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
+);
+RequiredLabel.args = {
+	label: 'Example',
+	requiredLabel: false,
+};

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -14,6 +14,7 @@ export type FieldProps = {
 	label: string;
 	message: string | undefined;
 	required: boolean;
+	requiredLabel?: boolean;
 	valid?: boolean;
 };
 
@@ -25,6 +26,7 @@ export const Field = ({
 	label,
 	message,
 	required,
+	requiredLabel = true,
 	valid,
 }: FieldProps) => {
 	const { fieldId, hintId, messageId } = useFieldIds(id);
@@ -40,10 +42,13 @@ export const Field = ({
 	return (
 		<FieldContainer invalid={invalid}>
 			<FieldLabel htmlFor={fieldId}>
-				{label}{' '}
-				<Text as="span" color="muted">
-					({required ? 'required' : 'optional'})
-				</Text>
+				{label}
+				{requiredLabel ? (
+					<Text as="span" color="muted">
+						{' '}
+						({required ? 'required' : 'optional'})
+					</Text>
+				) : null}
 			</FieldLabel>
 			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
 			{message && (invalid || valid) ? (

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -134,8 +134,9 @@ MaxWidths.args = {
 };
 
 export const Controlled = () => {
-	const [selected, setSelected] =
-		useState<{ label: string; value: string } | undefined>();
+	const [selected, setSelected] = useState<
+		{ label: string; value: string } | undefined
+	>();
 
 	const onChange = (event: ChangeEvent<HTMLSelectElement>) => {
 		const nextSelected = EXAMPLE_OPTIONS.find(

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -134,9 +134,8 @@ MaxWidths.args = {
 };
 
 export const Controlled = () => {
-	const [selected, setSelected] = useState<
-		{ label: string; value: string } | undefined
-	>();
+	const [selected, setSelected] =
+		useState<{ label: string; value: string } | undefined>();
 
 	const onChange = (event: ChangeEvent<HTMLSelectElement>) => {
 		const nextSelected = EXAMPLE_OPTIONS.find(
@@ -180,4 +179,14 @@ GroupedOptions.args = {
 			],
 		},
 	],
+};
+
+export const RequiredLabel: ComponentStory<typeof Select> = (args) => (
+	<Select {...args} />
+);
+RequiredLabel.args = {
+	label: 'Example',
+	placeholder: 'Please select',
+	options: EXAMPLE_OPTIONS,
+	requiredLabel: false,
 };

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -28,6 +28,7 @@ export type Options = (Option | OptionGroup)[];
 export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
 	label: string;
 	required?: boolean;
+	requiredLabel?: boolean;
 	hint?: string;
 	message?: string;
 	invalid?: boolean;
@@ -43,6 +44,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 		{
 			label,
 			required,
+			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -61,6 +63,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 			<Field
 				label={label}
 				required={Boolean(required)}
+				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -101,3 +101,11 @@ Password.args = {
 	type: 'password',
 	required: true,
 };
+
+export const RequiredLabel: ComponentStory<typeof TextInput> = (args) => (
+	<TextInput {...args} />
+);
+RequiredLabel.args = {
+	label: 'Example',
+	requiredLabel: false,
+};

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -11,6 +11,7 @@ import {
 export type TextInputProps = InputHTMLAttributes<HTMLInputElement> & {
 	label: string;
 	required?: boolean;
+	requiredLabel?: boolean;
 	hint?: string;
 	message?: string;
 	invalid?: boolean;
@@ -24,6 +25,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 		{
 			label,
 			required,
+			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -40,6 +42,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			<Field
 				label={label}
 				required={Boolean(required)}
+				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}

--- a/packages/textarea/src/Textarea.stories.tsx
+++ b/packages/textarea/src/Textarea.stories.tsx
@@ -85,3 +85,11 @@ export const MaxWidths: ComponentStory<typeof Textarea> = (args) => (
 	</Stack>
 );
 MaxWidths.args = {};
+
+export const RequiredLabel: ComponentStory<typeof Textarea> = (args) => (
+	<Textarea {...args} />
+);
+RequiredLabel.args = {
+	label: 'Example',
+	requiredLabel: false,
+};

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -5,6 +5,7 @@ import { textInputStyles } from '@ag.ds-next/text-input';
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 	label: string;
 	required?: boolean;
+	requiredLabel?: boolean;
 	hint?: string;
 	message?: string;
 	invalid?: boolean;
@@ -18,6 +19,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 		{
 			label,
 			required,
+			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -41,6 +43,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 			<Field
 				label={label}
 				required={Boolean(required)}
+				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}


### PR DESCRIPTION
## Describe your changes

By default, "(optional)" or "(required)" is appended to all form labels. To disable this, you will now be able to set the new `requiredLabel` prop to `false`.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook
