### PR TITLE
Card: Remove cursor pointer

### DIFF
--- a/.changeset/fifty-doors-fail.md
+++ b/.changeset/fifty-doors-fail.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/card': patch
+---
+
+Remove pointer cursor for clickable mode

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -33,7 +33,6 @@ export const Card = ({
 				overflow: 'hidden',
 
 				...(clickable && {
-					cursor: 'pointer',
 					// If any element inside the card receives focus, add a focus ring around the wrapper card div
 					'&:focus-within': packs.outline,
 				}),


### PR DESCRIPTION
Remove the pointer cursor from Card when clickable is true. Why? Because the pointer appears over CardLink which wraps Card anyway.