### PR TITLE
Field: Add `useScrollToField` hook

### DIFF
--- a/.changeset/dry-bugs-cover.md
+++ b/.changeset/dry-bugs-cover.md
@@ -3,4 +3,4 @@
 '@ag.ds-next/field': patch
 ---
 
-Added `id` prop to `ControlGroup`
+Added `id` prop to `ControlGroup` and `FieldContainer`

--- a/.changeset/dry-bugs-cover.md
+++ b/.changeset/dry-bugs-cover.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/control-input': patch
+'@ag.ds-next/field': patch
+---
+
+Added `id` prop to `ControlGroup`

--- a/.changeset/gold-steaks-travel.md
+++ b/.changeset/gold-steaks-travel.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/example-site': patch
+---
+
+Added new field to single page form and implemented new hook `useScrollToField`

--- a/.changeset/heavy-donkeys-unite.md
+++ b/.changeset/heavy-donkeys-unite.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/field': patch
+---
+
+Added `useScrollToField` hook

--- a/example-site/components/FormExampleSinglePage.tsx
+++ b/example-site/components/FormExampleSinglePage.tsx
@@ -2,7 +2,7 @@ import { useForm, SubmitHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { Button } from '@ag.ds-next/button';
-import { Checkbox } from '@ag.ds-next/control-input';
+import { Checkbox, ControlGroup, Radio } from '@ag.ds-next/control-input';
 import { Body } from '@ag.ds-next/body';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { Fieldset } from '@ag.ds-next/fieldset';
@@ -13,6 +13,7 @@ import { TextInput } from '@ag.ds-next/text-input';
 import { TextLink } from '@ag.ds-next/text';
 import { PageAlert } from '@ag.ds-next/page-alert';
 import { Divider } from './Divider';
+import { useScrollToField } from '@ag.ds-next/field';
 
 const formSchema = yup
 	.object({
@@ -24,7 +25,11 @@ const formSchema = yup
 			.string()
 			.email('Invalid email address')
 			.required('Enter your email address'),
-		mobile: yup.string().required('Enter your postcode'),
+		mobile: yup.string().required('Enter your mobile'),
+		interest: yup
+			.string()
+			.typeError('Select an interest')
+			.required('Select an interest'),
 		message: yup.string(),
 		termsAndConditions: yup
 			.boolean()
@@ -35,6 +40,8 @@ const formSchema = yup
 type FormSchema = yup.InferType<typeof formSchema>;
 
 export const FormExampleSinglePage = () => {
+	const scrollToField = useScrollToField();
+
 	const {
 		register,
 		handleSubmit,
@@ -59,7 +66,9 @@ export const FormExampleSinglePage = () => {
 							<ul>
 								{Object.entries(errors).map(([key, value]) => (
 									<li key={key}>
-										<a href={`#${key}`}>{value.message}</a>
+										<a href={`#${key}`} onClick={scrollToField}>
+											{value.message}
+										</a>
 									</li>
 								))}
 							</ul>
@@ -139,6 +148,16 @@ export const FormExampleSinglePage = () => {
 				</Fieldset>
 				<Divider />
 				<FormStack>
+					<ControlGroup
+						label="Interest"
+						invalid={Boolean(errors.interest?.message)}
+						message={errors.interest?.message}
+						id="interest"
+					>
+						<Radio {...register('interest')}>Art</Radio>
+						<Radio {...register('interest')}>Cooking</Radio>
+						<Radio {...register('interest')}>Reading</Radio>
+					</ControlGroup>
 					<Textarea
 						label="Message"
 						{...register('message')}

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -12,6 +12,7 @@ export type ControlGroupProps = PropsWithChildren<{
 	message?: string;
 	required?: boolean;
 	requiredLabel?: boolean;
+	id?: string;
 }>;
 
 export const ControlGroup = ({
@@ -23,8 +24,9 @@ export const ControlGroup = ({
 	message,
 	required,
 	requiredLabel,
+	id,
 }: ControlGroupProps) => (
-	<FieldContainer invalid={invalid}>
+	<FieldContainer invalid={invalid} id={id}>
 		<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
 			{label ? (
 				<Text as="legend" display="block" fontWeight="bold">

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -70,3 +70,29 @@ By default, "(optional)" or "(required)" will be appended to labels. To disable 
 	{(a11yProps) => <select {...a11yProps} />}
 </Field>
 ```
+
+## Hooks
+
+### `useScrollToField`
+
+By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of
+the screen.
+
+Manually handling the click event, scrolling the question into view and then focussing the element solves this.
+
+```jsx
+function ExampleForm() {
+	const scrollToField = useScrollToField();
+	return (
+		<ul>
+			{Object.entries(errors).map(([id, errorMessage]) => (
+				<li key={id}>
+					<a href={`#${id}`} onClick={scrollToField}>
+						{errorMessage}
+					</a>
+				</li>
+			))}
+		</ul>
+	);
+}
+```

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -76,9 +76,9 @@ By default, "(optional)" or "(required)" will be appended to labels. To disable 
 ### `useScrollToField`
 
 By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of
-the screen.
+the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
 
-Manually handling the click event, scrolling the question into view and then focussing the element solves this.
+Please refer to the [example site single page form example](https://steelthreads.github.io/agds-next/example-site/form-single-page) to see an example of this hook in use.
 
 ```jsx
 function ExampleForm() {

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -75,8 +75,7 @@ By default, "(optional)" or "(required)" will be appended to labels. To disable 
 
 ### `useScrollToField`
 
-By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of
-the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
+By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
 
 Please refer to the [example site single page form example](https://steelthreads.github.io/agds-next/example-site/form-single-page) to see an example of this hook in use.
 

--- a/packages/field/src/FieldContainer.tsx
+++ b/packages/field/src/FieldContainer.tsx
@@ -4,14 +4,20 @@ import { globalPalette } from '@ag.ds-next/core';
 
 export type FieldContainerProps = PropsWithChildren<{
 	invalid?: boolean;
+	id?: string;
 }>;
 
-export const FieldContainer = ({ children, invalid }: FieldContainerProps) => (
+export const FieldContainer = ({
+	children,
+	invalid,
+	id,
+}: FieldContainerProps) => (
 	<Stack
 		gap={0.5}
 		paddingLeft={invalid ? 1 : undefined}
 		borderLeft={invalid}
 		borderLeftWidth="xl"
+		id={id}
 		css={{
 			borderLeftColor: invalid ? globalPalette.error : undefined,
 		}}

--- a/packages/field/src/index.tsx
+++ b/packages/field/src/index.tsx
@@ -4,3 +4,4 @@ export * from './FieldHint';
 export * from './FieldLabel';
 export * from './FieldMessage';
 export * from './fieldMaxWidth';
+export * from './useScrollToField';

--- a/packages/field/src/useScrollToField.ts
+++ b/packages/field/src/useScrollToField.ts
@@ -1,0 +1,43 @@
+import { useCallback, MouseEvent } from 'react';
+
+export function useScrollToField() {
+	return useCallback((event: MouseEvent<HTMLAnchorElement>) => {
+		if (focusTarget(event)) {
+			// Prevent default browser behaviour
+			event.preventDefault();
+		}
+	}, []);
+}
+
+function focusTarget(event: MouseEvent<HTMLAnchorElement>) {
+	const target = event.target;
+	if (!(target instanceof HTMLAnchorElement)) return false;
+	// Atempt to the find target ID from the anchor tag href
+	const targetId = getTargetId(event);
+	if (!targetId) return false;
+	// Attempt to find the target element using the target Id
+	const targetEl = document.getElementById(targetId);
+	if (!targetEl) return false;
+	const targetLabel = document.querySelector("label[for='" + targetId + "']");
+	const targetLabelParent = targetLabel?.parentElement;
+	if (targetEl.tagName.toLowerCase() === 'div') {
+		// If the target element is a div (e.g. a `ControlGroup`), focus the first child input
+		targetEl.querySelector('input')?.focus();
+	} else {
+		// Othwerise, focus the target element
+		targetEl.focus();
+	}
+	// Scroll the field container into view if possible, otherwise fallback to scrolling to the target
+	if (targetLabelParent) {
+		targetLabelParent.scrollIntoView();
+	} else {
+		targetEl.scrollIntoView();
+	}
+	return true;
+}
+
+function getTargetId(event: MouseEvent<HTMLAnchorElement>) {
+	const target = event.target;
+	if (!(target instanceof HTMLAnchorElement)) return;
+	return target.hash.substring(1);
+}


### PR DESCRIPTION
## Describe your changes

By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of
the screen.

Manually handling the click event, scrolling the question into view and then focussing the element solves this.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)


