### PR TITLE
Icon: Move width/height attributes to CSS

### DIFF
--- a/.changeset/olive-files-rhyme.md
+++ b/.changeset/olive-files-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/icon': patch
+---
+
+Move icon width/height to css

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -51,13 +51,13 @@ export const createIcon = (children: ReactNode, name: string) => {
 		return (
 			<svg
 				aria-hidden="true"
-				width={resolvedSize}
-				height={resolvedSize}
 				viewBox="0 0 24 24"
 				clipRule="evenodd"
 				xmlns="http://www.w3.org/2000/svg"
 				focusable="false"
 				css={{
+					width: resolvedSize,
+					height: resolvedSize,
 					fill: 'none',
 					color: color ? iconColors[color] : undefined,
 					stroke: 'currentColor',

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -1,9 +1,4 @@
-import {
-	boxPalette,
-	mapSpacing,
-	mapResponsiveProp,
-	mq,
-} from '@ag.ds-next/core';
+import { boxPalette, mapSpacing } from '@ag.ds-next/core';
 import { foregroundColorMap } from '@ag.ds-next/box';
 import { ReactNode, SVGAttributes } from 'react';
 

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -51,6 +51,8 @@ export const createIcon = (children: ReactNode, name: string) => {
 		return (
 			<svg
 				aria-hidden="true"
+				width="24"
+				height="24"
 				viewBox="0 0 24 24"
 				clipRule="evenodd"
 				xmlns="http://www.w3.org/2000/svg"

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -46,6 +46,7 @@ export const createIcon = (children: ReactNode, name: string) => {
 		return (
 			<svg
 				aria-hidden="true"
+				// Note the width and height attribute is a fallback for older browsers. This may not be required and could potentially be removed.
 				width="24"
 				height="24"
 				viewBox="0 0 24 24"


### PR DESCRIPTION
## Describe your changes

Our Icon components are currently invalid because they use rem units in the width/height attribute. Setting the width/height in CSS fixes this issue.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file