### PR TITLE
CallToAction: Reduced icon size from 1.5rem to 1rem

### DIFF
--- a/.changeset/dry-olives-argue.md
+++ b/.changeset/dry-olives-argue.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/call-to-action': patch
+---
+
+Reduced icon size from 1.5rem to 1rem

--- a/packages/call-to-action/src/CallToAction.tsx
+++ b/packages/call-to-action/src/CallToAction.tsx
@@ -72,7 +72,11 @@ export const CallToAction = ({ as, children, ...props }: CallToActionProps) => {
 				{...props}
 			>
 				{children}
-				<AnimatedChevronRightIcon weight="bold" style={animationStyles} />
+				<AnimatedChevronRightIcon
+					weight="bold"
+					size="sm"
+					style={animationStyles}
+				/>
 			</Flex>
 		</div>
 	);


### PR DESCRIPTION
## Describe your changes

Reduced icon size from 1.5rem to 1rem

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file