### PR TITLE
Modal: Design and documentation improvements

### DIFF
--- a/.changeset/sixty-cherries-fix.md
+++ b/.changeset/sixty-cherries-fix.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/modal': minor
+---
+
+Design improvements

--- a/.changeset/ten-hounds-pump.md
+++ b/.changeset/ten-hounds-pump.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/body': patch
+---
+
+Documentation improvements

--- a/packages/body/README.md
+++ b/packages/body/README.md
@@ -8,6 +8,8 @@ Many sites will have content being generated in a WYSIWIG or HTML field within a
 
 This is also known as a Prose component.
 
+Body component should only be used in the context of a page, to format long-form content. It should not be used inside a 'framing' component like a Card or Modal. Instead, a simple Stack should be used.
+
 ```jsx live
 <Box palette="light" background="body">
 	<Body>

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -2,7 +2,6 @@ import { ComponentMeta } from '@storybook/react';
 import { Modal } from './Modal';
 import { ModalButtonGroup } from './ModalButtonGroup';
 import { ModalTitle } from './ModalTitle';
-import { Body } from '@ag.ds-next/body';
 import { Button } from '@ag.ds-next/button';
 import { Stack } from '@ag.ds-next/box';
 import { useTernaryState } from '@ag.ds-next/core';
@@ -58,19 +57,17 @@ export const Modular = () => {
 							This is the title of the modal dialogue, it can span lines but
 							should not be too long.
 						</ModalTitle>
-						<Body>
-							<p>
-								This is the Modal Body paragraph, it provides detailed
-								instruction and context for the the modal action. It can also
-								span lines but long form content should be avoided.
-							</p>
+						<Text as="p">
+							This is the Modal Body paragraph, it provides detailed instruction
+							and context for the the modal action. It can also span lines but
+							long form content should be avoided.
+						</Text>
 
-							<p>
-								This is the Modal Body paragraph, it provides detailed
-								instruction and context for the the modal action. It can also
-								span lines but long form content should be avoided.
-							</p>
-						</Body>
+						<Text as="p">
+							This is the Modal Body paragraph, it provides detailed instruction
+							and context for the the modal action. It can also span lines but
+							long form content should be avoided.
+						</Text>
 					</Stack>
 					<ModalButtonGroup>
 						<Button onClick={closeModal}>Ok</Button>

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -43,7 +43,6 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 			>
 				<Flex justifyContent="flex-end">
 					<Button
-						size="sm"
 						variant="tertiary"
 						onClick={onDismiss}
 						iconAfter={CloseIcon}

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import FocusLock from 'react-focus-lock';
 import { animated, useSpring } from 'react-spring';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
-import { usePrefersReducedMotion, mapSpacing } from '@ag.ds-next/core';
+import { usePrefersReducedMotion, mapSpacing, tokens } from '@ag.ds-next/core';
 import { CloseIcon } from '@ag.ds-next/icon';
 import { Button } from '@ag.ds-next/button';
 
@@ -34,7 +34,7 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 				aria-labelledby={titleId}
 				rounded
 				padding={1.5}
-				maxWidth="32rem"
+				maxWidth={tokens.maxWidth.bodyText}
 				style={{
 					position: 'relative',
 					margin: `${mapSpacing(6)} auto`,

--- a/packages/modal/src/ModalTitle.tsx
+++ b/packages/modal/src/ModalTitle.tsx
@@ -5,7 +5,7 @@ export type ModalTitleProps = { children: ReactNode; id?: string };
 
 export const ModalTitle = ({ children, id }: ModalTitleProps) => {
 	return (
-		<Text fontSize="lg" fontWeight="bold" lineHeight="heading" id={id}>
+		<Text as="h2" fontSize="lg" fontWeight="bold" lineHeight="heading" id={id}>
 			{children}
 		</Text>
 	);


### PR DESCRIPTION
## Describe your changes
- ModalTitle is now a h2 element
- Modal close button is now medium size (from small)
- The maximum width of the Modal now comes from a token value
- Stories for Modal no longer use the Body component.
- Body: Add documentation to explain where Body usage is appropriate.

<img width="717" alt="image" src="https://user-images.githubusercontent.com/12689383/161651037-5fecac85-476f-40f0-8e70-6ba92d5e5bb1.png">
