### PR TITLE
Modal: Make Title required. Resolve issue with Chrome not reading title in VoiceOver

### DIFF
--- a/.changeset/lucky-cooks-rest.md
+++ b/.changeset/lucky-cooks-rest.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/modal': minor
+---
+
+Resolve issue with Chrome not reading title in VoiceOver

--- a/.changeset/lucky-cooks-rest.md
+++ b/.changeset/lucky-cooks-rest.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/modal': minor
+'@ag.ds-next/modal': major
 ---
 
-Resolve issue with Chrome not reading title in VoiceOver
+Title is required. Also, resolves issue with Chrome not reading title in VoiceOver.

--- a/docs/components/design-system-components.tsx
+++ b/docs/components/design-system-components.tsx
@@ -60,12 +60,7 @@ import {
 	SuccessFilledIcon,
 } from '@ag.ds-next/icon';
 import { InpageNav } from '@ag.ds-next/inpage-nav';
-import {
-	Modal,
-	ModalButtonGroup,
-	ModalCover,
-	ModalTitle,
-} from '@ag.ds-next/modal';
+import { Modal, ModalButtonGroup } from '@ag.ds-next/modal';
 import { Logo as AgLogo } from '@ag.ds-next/ag-branding';
 import { Field } from '@ag.ds-next/field';
 import { Fieldset } from '@ag.ds-next/fieldset';
@@ -151,8 +146,6 @@ export const designSystemComponents = {
 	MainNav,
 	Modal,
 	ModalButtonGroup,
-	ModalCover,
-	ModalTitle,
 	PageAlert,
 	SideNav,
 	SideNavContainer,

--- a/docs/playroom/components.js
+++ b/docs/playroom/components.js
@@ -97,12 +97,7 @@ export { DirectionLink, DirectionButton } from '@ag.ds-next/direction-link';
 export { Tags } from '@ag.ds-next/tags';
 export { FormStack } from '@ag.ds-next/form-stack';
 export { TaskList } from '@ag.ds-next/task-list';
-export {
-	Modal,
-	ModalButtonGroup,
-	ModalCover,
-	ModalTitle,
-} from '@ag.ds-next/modal';
+export { Modal, ModalButtonGroup } from '@ag.ds-next/modal';
 export {
 	Table,
 	TableBody,

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta } from '@storybook/react';
 import { Modal } from './Modal';
 import { ModalButtonGroup } from './ModalButtonGroup';
-import { ModalTitle } from './ModalTitle';
 import { Button } from '@ag.ds-next/button';
 import { Stack } from '@ag.ds-next/box';
 import { useTernaryState } from '@ag.ds-next/core';
@@ -36,48 +35,6 @@ export const Basic = () => {
 						</Button>
 						<Button variant="tertiary" onClick={closeModal}>
 							Tertiary button
-						</Button>
-					</ModalButtonGroup>
-				</Stack>
-			</Modal>
-		</div>
-	);
-};
-
-export const Modular = () => {
-	const [isModalOpen, openModal, closeModal] = useTernaryState(false);
-
-	return (
-		<div>
-			<Button onClick={openModal}>Open modal</Button>
-			<Modal isOpen={isModalOpen} onDismiss={closeModal}>
-				<Stack gap={2}>
-					<Stack gap={1}>
-						<ModalTitle>
-							This is the title of the modal dialogue, it can span lines but
-							should not be too long.
-						</ModalTitle>
-						<Text as="p">
-							This is the Modal Body paragraph, it provides detailed instruction
-							and context for the the modal action. It can also span lines but
-							long form content should be avoided.
-						</Text>
-
-						<Text as="p">
-							This is the Modal Body paragraph, it provides detailed instruction
-							and context for the the modal action. It can also span lines but
-							long form content should be avoided.
-						</Text>
-					</Stack>
-					<ModalButtonGroup>
-						<Button onClick={closeModal}>Ok</Button>
-
-						<Button variant="secondary" onClick={closeModal}>
-							Cancel
-						</Button>
-
-						<Button variant="tertiary" onClick={closeModal}>
-							Cancel
 						</Button>
 					</ModalButtonGroup>
 				</Stack>

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -60,8 +60,8 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 					iconAfter={CloseIcon}
 					css={{
 						position: 'absolute',
-						top: `${mapSpacing(0.5)}`,
-						right: `${mapSpacing(0.5)}`,
+						top: mapSpacing(0.5),
+						right: mapSpacing(0.5),
 					}}
 				>
 					Close

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -11,7 +11,7 @@ import { useModalId } from './utils';
 
 export type ModalPanelProps = PropsWithChildren<{
 	onDismiss: () => void;
-	title?: string;
+	title: string;
 }>;
 
 const AnimatedStack = animated(Stack);
@@ -51,7 +51,7 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 				}}
 				style={animationStyles}
 			>
-				{title && <ModalTitle id={titleId}>{title}</ModalTitle>}
+				<ModalTitle id={titleId}>{title}</ModalTitle>
 				<div>{children}</div>
 
 				<Button

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import FocusLock from 'react-focus-lock';
 import { animated, useSpring } from 'react-spring';
-import { Box, Flex, Stack } from '@ag.ds-next/box';
+import { Stack } from '@ag.ds-next/box';
 import { usePrefersReducedMotion, mapSpacing, tokens } from '@ag.ds-next/core';
 import { CloseIcon } from '@ag.ds-next/icon';
 import { Button } from '@ag.ds-next/button';
@@ -14,7 +14,7 @@ export type ModalPanelProps = PropsWithChildren<{
 	title?: string;
 }>;
 
-const AnimatedBox = animated(Box);
+const AnimatedStack = animated(Stack);
 
 export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 	const { titleId } = useModalId();
@@ -27,7 +27,7 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 
 	return (
 		<FocusLock returnFocus>
-			<AnimatedBox
+			<AnimatedStack
 				role="dialog"
 				aria-modal="true"
 				tabIndex={-1}
@@ -37,6 +37,8 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 				rounded
 				focus
 				padding={1.5}
+				paddingTop={4}
+				gap={1}
 				maxWidth={tokens.maxWidth.bodyText}
 				css={{
 					position: 'relative',
@@ -49,26 +51,22 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 				}}
 				style={animationStyles}
 			>
-				<Flex justifyContent="flex-end">
-					<Button
-						variant="tertiary"
-						onClick={onDismiss}
-						iconAfter={CloseIcon}
-						css={{
-							position: 'relative',
-							top: `-${mapSpacing(1)}`,
-							right: `-${mapSpacing(1)}`,
-						}}
-					>
-						Close
-					</Button>
-				</Flex>
+				{title && <ModalTitle id={titleId}>{title}</ModalTitle>}
+				<div>{children}</div>
 
-				<Stack gap={1}>
-					{title && <ModalTitle id={titleId}>{title}</ModalTitle>}
-					<div>{children}</div>
-				</Stack>
-			</AnimatedBox>
+				<Button
+					variant="tertiary"
+					onClick={onDismiss}
+					iconAfter={CloseIcon}
+					css={{
+						position: 'absolute',
+						top: `${mapSpacing(0.5)}`,
+						right: `${mapSpacing(0.5)}`,
+					}}
+				>
+					Close
+				</Button>
+			</AnimatedStack>
 		</FocusLock>
 	);
 };

--- a/packages/modal/src/index.tsx
+++ b/packages/modal/src/index.tsx
@@ -1,4 +1,2 @@
 export * from './Modal';
 export * from './ModalButtonGroup';
-export * from './ModalCover';
-export * from './ModalTitle';


### PR DESCRIPTION
## Describe your changes
In Apple VoiceOver and Chrome, the Modal title was not being read out when modal is opened. We discovered this was because the title was not the first child of the Modal.

<img width="740" alt="image" src="https://user-images.githubusercontent.com/12689383/161895115-b18959e6-a083-4e48-8ea6-0b81ac005cb0.png">
<img width="775" alt="image" src="https://user-images.githubusercontent.com/12689383/161895129-53676d97-f8d8-4caa-a9fc-472df1391ec2.png">


## Checklist

- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
