### PR TITLE
MainNav: Return focus when modal is closed

### DIFF
--- a/.changeset/hungry-beers-design.md
+++ b/.changeset/hungry-beers-design.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/main-nav': patch
+---
+
+Return focus when modal is closed

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -98,7 +98,7 @@ export function NavContainer({
 					paddingX={{ xs: 0.75, lg: 2 }}
 				>
 					<ToggleButton onClick={open} />
-					<FocusLock disabled={!menuVisiblyOpen}>
+					<FocusLock returnFocus disabled={!menuVisiblyOpen}>
 						<div
 							role={menuVisiblyOpen ? 'dialog' : 'none'}
 							aria-label="Main navigation"


### PR DESCRIPTION
Return focus to the Menu button when the MainNav modal is closed in mobile viewports