### PR TITLE
Modal: Buttons appear at bottom of screen in Mobile view

### DIFF
--- a/.changeset/weak-icons-share.md
+++ b/.changeset/weak-icons-share.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/modal': major
+---
+
+Buttons now appear at bottom of screen in Mobile view. We have achieved this by changing the way buttons are added to a modal - via a 'actions' prop on the Modal.

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -19,23 +19,23 @@ For other uses, other patterns are preferred.
 				isOpen={isModalOpen}
 				onDismiss={closeModal}
 				title="This is the title of the modal dialogue, it can span lines but should not be too long."
-			>
-				<Stack gap={2}>
-					<Text as="p">
-						This is the Modal Body paragraph, it provides detailed instruction
-						and context for the the modal action. It can also span lines but
-						long form content should be avoided.
-					</Text>
+				actions={
 					<ModalButtonGroup>
-						<Button onClick={closeModal}>Ok</Button>
+						<Button onClick={closeModal}>Primary button</Button>
 						<Button variant="secondary" onClick={closeModal}>
-							Cancel
+							Secondary button
 						</Button>
 						<Button variant="tertiary" onClick={closeModal}>
-							Cancel
+							Tertiary button
 						</Button>
 					</ModalButtonGroup>
-				</Stack>
+				}
+			>
+				<Text as="p">
+					This is the Modal Body paragraph, it provides detailed instruction and
+					context for the the modal action. It can also span lines but long form
+					content should be avoided.
+				</Text>
 			</Modal>
 		</div>
 	);

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -2,7 +2,6 @@ import { ComponentMeta } from '@storybook/react';
 import { Modal } from './Modal';
 import { ModalButtonGroup } from './ModalButtonGroup';
 import { Button } from '@ag.ds-next/button';
-import { Stack } from '@ag.ds-next/box';
 import { useTernaryState } from '@ag.ds-next/core';
 import { Text } from '@ag.ds-next/text';
 

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -21,13 +21,7 @@ export const Basic = () => {
 				isOpen={isModalOpen}
 				onDismiss={closeModal}
 				title="This is the title of the modal dialogue, it can span lines but should not be too long."
-			>
-				<Stack gap={2}>
-					<Text as="p">
-						This is the Modal Body paragraph, it provides detailed instruction
-						and context for the the modal action. It can also span lines but
-						long form content should be avoided.
-					</Text>
+				actions={
 					<ModalButtonGroup>
 						<Button onClick={closeModal}>Primary button</Button>
 						<Button variant="secondary" onClick={closeModal}>
@@ -37,7 +31,13 @@ export const Basic = () => {
 							Tertiary button
 						</Button>
 					</ModalButtonGroup>
-				</Stack>
+				}
+			>
+				<Text as="p">
+					This is the Modal Body paragraph, it provides detailed instruction and
+					context for the the modal action. It can also span lines but long form
+					content should be avoided.
+				</Text>
 			</Modal>
 		</div>
 	);

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -10,6 +10,7 @@ export type ModalProps = ModalPanelProps & {
 };
 
 export const Modal: FunctionComponent<ModalProps> = ({
+	actions,
 	children,
 	isOpen,
 	onDismiss,
@@ -33,7 +34,7 @@ export const Modal: FunctionComponent<ModalProps> = ({
 		<Fragment>
 			<LockScroll />
 			<ModalCover onKeyDown={handleEscape}>
-				<ModalPanel onDismiss={onDismiss} title={title}>
+				<ModalPanel onDismiss={onDismiss} title={title} actions={actions}>
 					{children}
 				</ModalPanel>
 			</ModalCover>

--- a/packages/modal/src/ModalButtonGroup.tsx
+++ b/packages/modal/src/ModalButtonGroup.tsx
@@ -5,7 +5,13 @@ export type ModalButtonGroupProps = { children: ReactNode };
 
 export const ModalButtonGroup = ({ children }: ModalButtonGroupProps) => {
 	return (
-		<Stack gap={0.5} flexDirection={{ xs: 'column', sm: 'row' }}>
+		<Stack
+			gap={0.5}
+			flexDirection={{ xs: 'column', sm: 'row' }}
+			css={{
+				marginTop: 'auto',
+			}}
+		>
 			{children}
 		</Stack>
 	);

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -1,7 +1,7 @@
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, ReactNode } from 'react';
 import FocusLock from 'react-focus-lock';
 import { animated, useSpring } from 'react-spring';
-import { Stack } from '@ag.ds-next/box';
+import { Flex, Stack } from '@ag.ds-next/box';
 import { usePrefersReducedMotion, mapSpacing, tokens } from '@ag.ds-next/core';
 import { CloseIcon } from '@ag.ds-next/icon';
 import { Button } from '@ag.ds-next/button';
@@ -10,13 +10,19 @@ import { ModalTitle } from './ModalTitle';
 import { useModalId } from './utils';
 
 export type ModalPanelProps = PropsWithChildren<{
+	actions?: ReactNode;
 	onDismiss: () => void;
 	title: string;
 }>;
 
 const AnimatedStack = animated(Stack);
 
-export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
+export const ModalPanel = ({
+	actions,
+	children,
+	title,
+	onDismiss,
+}: ModalPanelProps) => {
 	const { titleId } = useModalId();
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const animationStyles = useSpring({
@@ -52,7 +58,10 @@ export const ModalPanel = ({ children, title, onDismiss }: ModalPanelProps) => {
 				style={animationStyles}
 			>
 				<ModalTitle id={titleId}>{title}</ModalTitle>
-				<div>{children}</div>
+				<Flex gap={2} flexGrow={1} flexDirection="column">
+					{children}
+					{actions}
+				</Flex>
 
 				<Button
 					variant="tertiary"


### PR DESCRIPTION
## Describe your changes
We've added an 'actions' prop to Modal, which is the new place where Buttons are added to a Modal.

<img width="513" alt="image" src="https://user-images.githubusercontent.com/12689383/161918365-a5e57d3a-c8dd-4d2c-a682-1a33c420296f.png">

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
- [X] Write documentation (README.md)
- [X] Create stories for Storybook