### PR TITLE
Footer: Hide `FooterDivider` from screen readers

### DIFF
--- a/.changeset/little-jeans-brake.md
+++ b/.changeset/little-jeans-brake.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/footer': patch
+---
+
+Hide footer divider from screen readers

--- a/packages/footer/src/FooterDivider.tsx
+++ b/packages/footer/src/FooterDivider.tsx
@@ -3,6 +3,7 @@ import { localPalette } from './localPalette';
 export function FooterDivider() {
 	return (
 		<hr
+			aria-hidden="true"
 			css={{
 				boxSizing: 'content-box',
 				height: 0,


### PR DESCRIPTION
## Describe your changes

From https://www.sarasoueidan.com/blog/horizontal-rules/

> Since horizontal rules are semantic elements announced by screen readers, then unless you’re using a horizontal rule to semantically divide content, you should hide it from screen readers using aria-hidden="true". In other words: use aria-hidden="true" to hide decorational horizontal lines. Do not hide them if they are providing semantic, thematic content breaks.



## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file

