### PR TITLE
MainNav: Hide mobile toggle button if no links are supplied

### DIFF
--- a/.changeset/pretty-elephants-tan.md
+++ b/.changeset/pretty-elephants-tan.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/main-nav': patch
+---
+
+Hide mobile toggle button if no links are supplied

--- a/packages/main-nav/src/MainNav.stories.tsx
+++ b/packages/main-nav/src/MainNav.stories.tsx
@@ -63,34 +63,33 @@ LightAltVariant.args = {
 	variant: 'lightAlt',
 };
 
-export const HeaderRightLink: ComponentStory<typeof MainNav> = (args) => {
-	return (
-		<MainNav
-			{...args}
-			rightContent={
-				<MainNavLink href="#login" label="Sign in" icon={AvatarIcon} />
-			}
-		/>
-	);
-};
+export const HeaderRightLink = Template.bind({});
 HeaderRightLink.args = {
 	...defaultArgs,
+	rightContent: <MainNavLink href="#login" label="Sign in" icon={AvatarIcon} />,
 };
 
-export const HeaderRightButton: ComponentStory<typeof MainNav> = (args) => {
-	return (
-		<MainNav
-			{...args}
-			rightContent={
-				<MainNavButton
-					onClick={() => console.log('Button press')}
-					label="Sign in"
-					icon={AvatarIcon}
-				/>
-			}
-		/>
-	);
-};
+export const HeaderRightButton = Template.bind({});
 HeaderRightButton.args = {
 	...defaultArgs,
+	rightContent: (
+		<MainNavButton
+			onClick={() => console.log('Button press')}
+			label="Sign in"
+			icon={AvatarIcon}
+		/>
+	),
+};
+
+export const NoLinks = Template.bind({});
+NoLinks.args = {
+	...defaultArgs,
+	links: undefined,
+	rightContent: (
+		<MainNavButton
+			onClick={() => console.log('Button press')}
+			label="Sign in"
+			icon={AvatarIcon}
+		/>
+	),
 };

--- a/packages/main-nav/src/MainNav.tsx
+++ b/packages/main-nav/src/MainNav.tsx
@@ -21,7 +21,7 @@ export function MainNav({
 	id,
 	'aria-label': ariaLabel = 'main',
 }: MainNavProps) {
-	const bestMatch = links ? findBestMatch(links, activePath) : undefined;
+	const bestMatch = findBestMatch(links, activePath);
 	return (
 		<NavContainer
 			variant={variant}

--- a/packages/main-nav/src/MainNav.tsx
+++ b/packages/main-nav/src/MainNav.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { NavContainer, NavContainerProps } from './NavContainer';
+import { NavContainer, NavContainerVariant } from './NavContainer';
 import { NavList, NavListLink } from './NavList';
 
 import { findBestMatch } from './utils';
@@ -8,9 +8,9 @@ export type MainNavProps = React.PropsWithChildren<{
 	activePath?: string;
 	'aria-label'?: string;
 	id?: string;
-	links: NavListLink[];
+	links?: NavListLink[];
 	rightContent?: ReactNode;
-	variant: NavContainerProps['variant'];
+	variant: NavContainerVariant;
 }>;
 
 export function MainNav({
@@ -21,13 +21,14 @@ export function MainNav({
 	id,
 	'aria-label': ariaLabel = 'main',
 }: MainNavProps) {
-	const bestMatch = findBestMatch(links, activePath);
+	const bestMatch = links ? findBestMatch(links, activePath) : undefined;
 	return (
 		<NavContainer
 			variant={variant}
 			id={id}
 			aria-label={ariaLabel}
 			rightContent={rightContent}
+			links={links}
 		>
 			<NavList links={links} activePath={bestMatch} />
 		</NavContainer>

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren, ReactNode } from 'react';
 import FocusLock from 'react-focus-lock';
+import { Global } from '@emotion/react';
 import { Box, Flex, backgroundColorMap } from '@ag.ds-next/box';
 import {
 	boxPalette,
@@ -12,7 +13,7 @@ import {
 
 import { localPalette, localPaletteVars } from './utils';
 import { CloseButton, ToggleButton } from './MenuButtons';
-import { Global } from '@emotion/react';
+import { NavListLink } from './NavList';
 
 const variantMap = {
 	light: {
@@ -47,11 +48,14 @@ const variantMap = {
 	},
 } as const;
 
+export type NavContainerVariant = keyof typeof variantMap;
+
 export type NavContainerProps = PropsWithChildren<{
 	id?: string;
 	'aria-label': string;
 	rightContent?: ReactNode;
-	variant: keyof typeof variantMap;
+	variant: NavContainerVariant;
+	links?: NavListLink[];
 }>;
 
 export function NavContainer({
@@ -60,6 +64,7 @@ export function NavContainer({
 	'aria-label': ariaLabel,
 	children,
 	variant,
+	links,
 }: NavContainerProps) {
 	const { background, bottomBar, hover, palette } = variantMap[variant];
 
@@ -97,7 +102,7 @@ export function NavContainer({
 					width="100%"
 					paddingX={{ xs: 0.75, lg: 2 }}
 				>
-					<ToggleButton onClick={open} />
+					{links && links.length > 0 ? <ToggleButton onClick={open} /> : null}
 					<FocusLock returnFocus disabled={!menuVisiblyOpen}>
 						<div
 							role={menuVisiblyOpen ? 'dialog' : 'none'}

--- a/packages/main-nav/src/NavList.tsx
+++ b/packages/main-nav/src/NavList.tsx
@@ -14,7 +14,7 @@ export type NavListLink = Omit<LinkProps, 'children'> & {
 };
 
 export type NavListProps = {
-	links: NavListLink[];
+	links?: NavListLink[];
 	activePath?: string;
 };
 
@@ -36,7 +36,7 @@ export function NavList({ links, activePath }: NavListProps) {
 				},
 			}}
 		>
-			{links.map(({ href, label, ...props }, index) => {
+			{links?.map(({ href, label, ...props }, index) => {
 				const active = href === activePath;
 				return (
 					<NavListItem key={index} active={active}>

--- a/packages/main-nav/src/utils.ts
+++ b/packages/main-nav/src/utils.ts
@@ -11,8 +11,11 @@ export const localPalette = {
 	bottomBar: `var(${localPaletteVars.bottomBar})`,
 };
 
-export function findBestMatch(links: NavListLink[], activePath?: string) {
-	if (!activePath) return '';
+export function findBestMatch(
+	links: NavListLink[] | undefined,
+	activePath?: string
+) {
+	if (!activePath || !links) return '';
 	let bestMatch = '';
 
 	for (const link of links) {


### PR DESCRIPTION
## Describe your changes

Hide mobile toggle button if no links are supplied. Fixes an issue that can be seen here `https://steelthreads.github.io/export-landing/`

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file