### PR TITLE
Remove `(required)` from field labels

### DIFF
--- a/.changeset/blue-moles-prove.md
+++ b/.changeset/blue-moles-prove.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/field': patch
+---
+
+Added `secondaryLabel` prop

--- a/.changeset/blue-moles-prove.md
+++ b/.changeset/blue-moles-prove.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/field': patch
+'@ag.ds-next/field': minor
 ---
 
 Added `secondaryLabel` prop

--- a/.changeset/chilly-chefs-remember.md
+++ b/.changeset/chilly-chefs-remember.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/date-picker': minor
+---
+
+Added date format to label

--- a/.changeset/metal-eels-argue.md
+++ b/.changeset/metal-eels-argue.md
@@ -1,0 +1,10 @@
+---
+'@ag.ds-next/control-input': minor
+'@ag.ds-next/date-picker': minor
+'@ag.ds-next/field': minor
+'@ag.ds-next/select': minor
+'@ag.ds-next/text-input': minor
+'@ag.ds-next/textarea': minor
+---
+
+Removed `requiredLabel` prop

--- a/packages/control-input/src/ControlGroup.stories.tsx
+++ b/packages/control-input/src/ControlGroup.stories.tsx
@@ -88,9 +88,3 @@ Invalid.args = {
 	block: true,
 	invalid: true,
 };
-
-export const RequiredLabel = Template.bind({});
-RequiredLabel.args = {
-	label: 'Choose your interests',
-	requiredLabel: false,
-};

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -1,13 +1,11 @@
 import { PropsWithChildren } from 'react';
 import { Flex, Stack } from '@ag.ds-next/box';
-import { Text } from '@ag.ds-next/text';
 import { mapSpacing } from '@ag.ds-next/core';
 import {
 	FieldContainer,
 	FieldHint,
 	FieldLabel,
 	FieldMessage,
-	FieldSecondaryLabel,
 } from '@ag.ds-next/field';
 
 export type ControlGroupProps = PropsWithChildren<{
@@ -27,6 +25,7 @@ export const ControlGroup = ({
 	hint,
 	invalid,
 	label,
+	secondaryLabel,
 	message,
 	required,
 	id,
@@ -34,7 +33,11 @@ export const ControlGroup = ({
 	<FieldContainer invalid={invalid} id={id}>
 		<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
 			{label ? (
-				<FieldLabel as="legend" required={required}>
+				<FieldLabel
+					as="legend"
+					required={required}
+					secondaryLabel={secondaryLabel}
+				>
 					{label}
 				</FieldLabel>
 			) : null}

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -2,16 +2,22 @@ import { PropsWithChildren } from 'react';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { mapSpacing } from '@ag.ds-next/core';
-import { FieldContainer, FieldHint, FieldMessage } from '@ag.ds-next/field';
+import {
+	FieldContainer,
+	FieldHint,
+	FieldLabel,
+	FieldMessage,
+	FieldSecondaryLabel,
+} from '@ag.ds-next/field';
 
 export type ControlGroupProps = PropsWithChildren<{
 	block?: boolean;
 	hint?: string;
 	invalid?: boolean;
 	label?: string;
+	secondaryLabel?: string;
 	message?: string;
 	required?: boolean;
-	requiredLabel?: boolean;
 	id?: string;
 }>;
 
@@ -23,21 +29,14 @@ export const ControlGroup = ({
 	label,
 	message,
 	required,
-	requiredLabel,
 	id,
 }: ControlGroupProps) => (
 	<FieldContainer invalid={invalid} id={id}>
 		<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
 			{label ? (
-				<Text as="legend" display="block" fontWeight="bold">
+				<FieldLabel as="legend" required={required}>
 					{label}
-					{requiredLabel ? (
-						<Text as="span" color="muted">
-							{' '}
-							({required ? 'required' : 'optional'})
-						</Text>
-					) : null}
-				</Text>
+				</FieldLabel>
 			) : null}
 			<Stack gap={0.5} css={{ marginTop: label ? mapSpacing(0.5) : undefined }}>
 				{hint ? <FieldHint>{hint}</FieldHint> : null}

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -30,28 +30,6 @@ Use the `block` prop to expand the component to fill the available space.
 };
 ```
 
-### Required
-
-The `DatePicker` component will always append `(optional)` or `(required)` to the label based on the `required` prop.
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<Stack gap={1}>
-			<DatePicker label="Default" value={value} onChange={setValue} />
-			<DatePicker label="Required" value={value} onChange={setValue} required />
-			<DatePicker
-				label="Optional"
-				value={value}
-				onChange={setValue}
-				required={false}
-			/>
-		</Stack>
-	);
-};
-```
-
 ### Valid and invalid inputs
 
 Use the `invalid` and `valid` props to indicate whether user input is valid (validates according to the elements settings) or invalid (does not validate according to the elements settings).

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -116,7 +116,6 @@ Disabled input elements are unusable and can not be clicked. This prevents a use
 			onChange={setValue}
 			fromLabel="From"
 			toLabel="To"
-			requiredLabel={false}
 		/>
 	);
 };

--- a/packages/date-picker/src/DatePicker.stories.tsx
+++ b/packages/date-picker/src/DatePicker.stories.tsx
@@ -65,12 +65,6 @@ Block.args = {
 	label: 'Block',
 };
 
-export const RequiredLabel = Template.bind({});
-RequiredLabel.args = {
-	label: 'Example',
-	requiredLabel: false,
-};
-
 export const ScrollExample: ComponentStory<typeof DatePicker> = (args) => (
 	<Box>
 		<Box height="1000px"></Box>

--- a/packages/date-picker/src/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput.tsx
@@ -56,6 +56,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 		return (
 			<Field
 				label={label}
+				secondaryLabel="(dd/mm/yyyy)"
 				required={Boolean(required)}
 				requiredLabel={requiredLabel}
 				hint={hint}

--- a/packages/date-picker/src/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput.tsx
@@ -22,7 +22,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 		{
 			label,
 			required,
-			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -58,7 +57,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 				label={label}
 				secondaryLabel="(dd/mm/yyyy)"
 				required={Boolean(required)}
-				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}

--- a/packages/date-picker/src/DateRangePicker.stories.tsx
+++ b/packages/date-picker/src/DateRangePicker.stories.tsx
@@ -45,9 +45,6 @@ Labels.args = {
 	toLabel: 'To',
 };
 
-export const RequiredLabel = Template.bind({});
-RequiredLabel.args = { requiredLabel: false };
-
 export const FiltersExample = () => {
 	const [option, setOption] = useState<string>();
 

--- a/packages/date-picker/src/DateRangePicker.tsx
+++ b/packages/date-picker/src/DateRangePicker.tsx
@@ -30,7 +30,6 @@ export type DateRangePickerProps = CalendarProps & {
 	fromLabel?: string;
 	toLabel?: string;
 	required?: boolean;
-	requiredLabel?: boolean;
 	placeholder?: string;
 };
 
@@ -41,7 +40,6 @@ export const DateRangePicker = ({
 	fromLabel = 'Start date',
 	toLabel = 'End date',
 	required,
-	requiredLabel,
 }: DateRangePickerProps) => {
 	const calendarRef = useRef<CalendarRef>(null);
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
@@ -169,7 +167,6 @@ export const DateRangePicker = ({
 					buttonOnClick={onFromTriggerClick}
 					disabled={disabled}
 					required={required}
-					requiredLabel={requiredLabel}
 				/>
 				<DateInput
 					label={toLabel}
@@ -179,7 +176,6 @@ export const DateRangePicker = ({
 					buttonOnClick={onToTriggerClick}
 					disabled={disabled}
 					required={required}
-					requiredLabel={requiredLabel}
 				/>
 			</Flex>
 			{isCalendarOpen ? (

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -61,12 +61,12 @@ Error messages are used to notify the user when a form field has not passed vali
 </Stack>
 ```
 
-### Required label
+### Required
 
-By default, "(optional)" or "(required)" will be appended to labels. To disable this, set the `requiredLabel` prop to `false`.
+The `Field` component will always append `(optional)` to the label based on the `required` prop.
 
 ```jsx live
-<Field label="Start date" requiredLabel={false}>
+<Field label="Start date" required={false}>
 	{(a11yProps) => <select {...a11yProps} />}
 </Field>
 ```

--- a/packages/field/src/Field.stories.tsx
+++ b/packages/field/src/Field.stories.tsx
@@ -55,11 +55,21 @@ Valid.args = {
 	valid: true,
 };
 
+export const SecondaryLabel: ComponentStory<typeof Field> = (args) => (
+	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
+);
+SecondaryLabel.args = {
+	label: 'Valid',
+	secondaryLabel: '(dd/mm/yyy)',
+};
+
 export const Modular: ComponentStory<typeof Field> = ({
 	label,
+	secondaryLabel,
 	hint,
 	message,
 	invalid,
+	required,
 }) => {
 	const { fieldId, messageId, hintId } = useFieldIds();
 	const a11yProps = useFieldA11yProps({
@@ -72,7 +82,13 @@ export const Modular: ComponentStory<typeof Field> = ({
 	});
 	return (
 		<FieldContainer invalid={invalid}>
-			<FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
+			<FieldLabel
+				htmlFor={fieldId}
+				required={required}
+				secondaryLabel={secondaryLabel}
+			>
+				{label}
+			</FieldLabel>
 			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
 			{message ? <FieldMessage id={messageId}>{message}</FieldMessage> : null}
 			<input {...a11yProps} />

--- a/packages/field/src/Field.stories.tsx
+++ b/packages/field/src/Field.stories.tsx
@@ -84,11 +84,3 @@ Modular.args = {
 	hint: 'Hint',
 	message: 'Message',
 };
-
-export const RequiredLabel: ComponentStory<typeof Field> = (args) => (
-	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
-);
-RequiredLabel.args = {
-	label: 'Example',
-	requiredLabel: false,
-};

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -1,10 +1,9 @@
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
+import { useId } from '@reach/auto-id';
 import { FieldContainer } from './FieldContainer';
-import { FieldLabel } from './FieldLabel';
+import { FieldLabel, FieldSecondaryLabel } from './FieldLabel';
 import { FieldHint } from './FieldHint';
 import { FieldMessage } from './FieldMessage';
-import { Text } from '@ag.ds-next/text';
-import { useId } from '@reach/auto-id';
 
 export type FieldProps = {
 	children: ((allyProps: A11yProps) => ReactNode) | ReactNode;
@@ -12,9 +11,12 @@ export type FieldProps = {
 	id?: string;
 	invalid?: boolean;
 	label: string;
+	secondaryLabel?: string;
+
 	message: string | undefined;
 	required: boolean;
 	requiredLabel?: boolean;
+
 	valid?: boolean;
 };
 
@@ -24,12 +26,13 @@ export const Field = ({
 	id,
 	invalid,
 	label,
+	secondaryLabel: secondaryLabelProp,
 	message,
 	required,
-	requiredLabel = true,
 	valid,
 }: FieldProps) => {
 	const { fieldId, hintId, messageId } = useFieldIds(id);
+
 	const a11yProps = useFieldA11yProps({
 		required,
 		fieldId,
@@ -39,15 +42,18 @@ export const Field = ({
 		hintId,
 		invalid,
 	});
+
+	const secondaryLabel = useMemo(() => {
+		if (secondaryLabelProp) return secondaryLabelProp;
+		if (!required) return `(optional)`;
+	}, [required, secondaryLabelProp]);
+
 	return (
 		<FieldContainer invalid={invalid}>
 			<FieldLabel htmlFor={fieldId}>
 				{label}
-				{requiredLabel ? (
-					<Text as="span" color="muted">
-						{' '}
-						({required ? 'required' : 'optional'})
-					</Text>
+				{secondaryLabel ? (
+					<FieldSecondaryLabel>{secondaryLabel}</FieldSecondaryLabel>
 				) : null}
 			</FieldLabel>
 			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -1,7 +1,7 @@
-import { ReactNode, useMemo } from 'react';
+import { ReactNode } from 'react';
 import { useId } from '@reach/auto-id';
 import { FieldContainer } from './FieldContainer';
-import { FieldLabel, FieldSecondaryLabel } from './FieldLabel';
+import { FieldLabel } from './FieldLabel';
 import { FieldHint } from './FieldHint';
 import { FieldMessage } from './FieldMessage';
 
@@ -12,11 +12,8 @@ export type FieldProps = {
 	invalid?: boolean;
 	label: string;
 	secondaryLabel?: string;
-
 	message: string | undefined;
 	required: boolean;
-	requiredLabel?: boolean;
-
 	valid?: boolean;
 };
 
@@ -26,7 +23,7 @@ export const Field = ({
 	id,
 	invalid,
 	label,
-	secondaryLabel: secondaryLabelProp,
+	secondaryLabel,
 	message,
 	required,
 	valid,
@@ -43,18 +40,14 @@ export const Field = ({
 		invalid,
 	});
 
-	const secondaryLabel = useMemo(() => {
-		if (secondaryLabelProp) return secondaryLabelProp;
-		if (!required) return `(optional)`;
-	}, [required, secondaryLabelProp]);
-
 	return (
 		<FieldContainer invalid={invalid}>
-			<FieldLabel htmlFor={fieldId}>
+			<FieldLabel
+				htmlFor={fieldId}
+				secondaryLabel={secondaryLabel}
+				required={required}
+			>
 				{label}
-				{secondaryLabel ? (
-					<FieldSecondaryLabel>{secondaryLabel}</FieldSecondaryLabel>
-				) : null}
 			</FieldLabel>
 			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
 			{message && (invalid || valid) ? (

--- a/packages/field/src/FieldLabel.tsx
+++ b/packages/field/src/FieldLabel.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 import { Text } from '@ag.ds-next/text';
 
 export type FieldLabelProps = PropsWithChildren<{
@@ -6,7 +6,19 @@ export type FieldLabelProps = PropsWithChildren<{
 }>;
 
 export const FieldLabel = ({ children, htmlFor }: FieldLabelProps) => (
-	<Text as="label" htmlFor={htmlFor} display="block" fontWeight="bold">
+	<Text
+		as="label"
+		htmlFor={htmlFor}
+		display="flex"
+		gap={0.25}
+		fontWeight="bold"
+	>
 		{children}
 	</Text>
+);
+
+export type FieldSecondaryLabelProps = { children: ReactNode };
+
+export const FieldSecondaryLabel = ({ children }: FieldSecondaryLabelProps) => (
+	<Text color="muted">{children}</Text>
 );

--- a/packages/field/src/FieldLabel.tsx
+++ b/packages/field/src/FieldLabel.tsx
@@ -1,24 +1,28 @@
-import type { PropsWithChildren, ReactNode } from 'react';
+import { ElementType, PropsWithChildren, useMemo } from 'react';
 import { Text } from '@ag.ds-next/text';
 
 export type FieldLabelProps = PropsWithChildren<{
-	htmlFor: string;
+	as?: ElementType;
+	htmlFor?: string;
+	required?: boolean;
+	secondaryLabel?: string;
 }>;
 
-export const FieldLabel = ({ children, htmlFor }: FieldLabelProps) => (
-	<Text
-		as="label"
-		htmlFor={htmlFor}
-		display="flex"
-		gap={0.25}
-		fontWeight="bold"
-	>
-		{children}
-	</Text>
-);
-
-export type FieldSecondaryLabelProps = { children: ReactNode };
-
-export const FieldSecondaryLabel = ({ children }: FieldSecondaryLabelProps) => (
-	<Text color="muted">{children}</Text>
-);
+export const FieldLabel = ({
+	as = 'label',
+	children,
+	htmlFor,
+	required,
+	secondaryLabel: secondaryLabelProp,
+}: FieldLabelProps) => {
+	const secondaryLabel = useMemo(() => {
+		if (secondaryLabelProp) return secondaryLabelProp;
+		if (!required) return `(optional)`;
+	}, [required, secondaryLabelProp]);
+	return (
+		<Text as={as} htmlFor={htmlFor} display="flex" gap={0.25} fontWeight="bold">
+			{children}
+			{secondaryLabel ? <Text color="muted">{secondaryLabel}</Text> : null}
+		</Text>
+	);
+};

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -41,7 +41,7 @@ Use the `block` prop to expand the component to fill the available space.
 
 ### Required
 
-The `Select` component will always append `(optional)` or `(required)` to the label based on the `required` prop.
+The `Select` component will always append `(optional)` to the label based on the `required` prop.
 
 ```jsx live
 <Stack gap={1}>

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -181,13 +181,3 @@ GroupedOptions.args = {
 		},
 	],
 };
-
-export const RequiredLabel: ComponentStory<typeof Select> = (args) => (
-	<Select {...args} />
-);
-RequiredLabel.args = {
-	label: 'Example',
-	placeholder: 'Please select',
-	options: EXAMPLE_OPTIONS,
-	requiredLabel: false,
-};

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -28,7 +28,6 @@ export type Options = (Option | OptionGroup)[];
 export type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
 	label: string;
 	required?: boolean;
-	requiredLabel?: boolean;
 	hint?: string;
 	message?: string;
 	invalid?: boolean;
@@ -44,7 +43,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 		{
 			label,
 			required,
-			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -63,7 +61,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 			<Field
 				label={label}
 				required={Boolean(required)}
-				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -22,7 +22,7 @@ Use the `block` prop to expand the component to fill the available space.
 
 ### Required
 
-The `TextInput` component will always append `(optional)` or `(required)` to the label based on the `required` prop.
+The `TextInput` component will always append `(optional)` to the label based on the `required` prop.
 
 ```jsx live
 <Stack gap={1}>

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -101,11 +101,3 @@ Password.args = {
 	type: 'password',
 	required: true,
 };
-
-export const RequiredLabel: ComponentStory<typeof TextInput> = (args) => (
-	<TextInput {...args} />
-);
-RequiredLabel.args = {
-	label: 'Example',
-	requiredLabel: false,
-};

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -11,7 +11,6 @@ import {
 export type TextInputProps = InputHTMLAttributes<HTMLInputElement> & {
 	label: string;
 	required?: boolean;
-	requiredLabel?: boolean;
 	hint?: string;
 	message?: string;
 	invalid?: boolean;
@@ -25,7 +24,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 		{
 			label,
 			required,
-			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -42,7 +40,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			<Field
 				label={label}
 				required={Boolean(required)}
-				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -22,7 +22,7 @@ Use the `block` prop to expand the component to fill the available space.
 
 ### Required
 
-The `Textarea` component will always append `(optional)` or `(required)` to the label based on the `required` prop.
+The `Textarea` component will always append `(optional)` to the label based on the `required` prop.
 
 ```jsx live
 <Stack gap={1}>

--- a/packages/textarea/src/Textarea.stories.tsx
+++ b/packages/textarea/src/Textarea.stories.tsx
@@ -85,11 +85,3 @@ export const MaxWidths: ComponentStory<typeof Textarea> = (args) => (
 	</Stack>
 );
 MaxWidths.args = {};
-
-export const RequiredLabel: ComponentStory<typeof Textarea> = (args) => (
-	<Textarea {...args} />
-);
-RequiredLabel.args = {
-	label: 'Example',
-	requiredLabel: false,
-};

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -5,7 +5,6 @@ import { textInputStyles } from '@ag.ds-next/text-input';
 export type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 	label: string;
 	required?: boolean;
-	requiredLabel?: boolean;
 	hint?: string;
 	message?: string;
 	invalid?: boolean;
@@ -19,7 +18,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 		{
 			label,
 			required,
-			requiredLabel,
 			hint,
 			message,
 			invalid,
@@ -43,7 +41,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 			<Field
 				label={label}
 				required={Boolean(required)}
-				requiredLabel={requiredLabel}
 				hint={hint}
 				message={message}
 				invalid={invalid}


### PR DESCRIPTION
## Describe your changes

- Only append `(optional)` to field labels
- Allow the secondary label to be overridden, for components like the date picker
- Show date format in the date picker component label

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file