### PR TITLE
HeroBanner: Reverse gradient direction

### DIFF
--- a/.changeset/lucky-moose-flow.md
+++ b/.changeset/lucky-moose-flow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/hero-banner': patch
+---
+
+Reverse gradient direction to fix image not getting covered by gradient

--- a/packages/hero-banner/src/HeroBannerBackground.tsx
+++ b/packages/hero-banner/src/HeroBannerBackground.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
-import { boxPalette, mq } from '@ag.ds-next/core';
+import { boxPalette, mq, tokens } from '@ag.ds-next/core';
 import { HeroBannerVariant, variantMap } from './utils';
 
 export type HeroBannerBackgroundProps = PropsWithChildren<{
@@ -18,17 +18,21 @@ export const HeroBannerBackground = ({
 		<Box
 			width="100%"
 			height="100%"
-			css={
-				backgroundImageSrc
-					? mq({
-							background: [
-								null,
-								`linear-gradient(90deg, ${boxPalette[backgroundVar]} 0%, ${boxPalette[backgroundVar]} 60%, transparent 100%), no-repeat center right url(${backgroundImageSrc});`,
-							],
-							backgroundSize: [null, 'auto 100%'],
-					  })
-					: undefined
-			}
+			css={{
+				[tokens.mediaQuery.min.sm]: {
+					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 240px), no-repeat center right url(${backgroundImageSrc})`,
+					backgroundSize: 'auto 100%',
+				},
+				[tokens.mediaQuery.min.md]: {
+					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 320px), no-repeat center right url(${backgroundImageSrc})`,
+				},
+				[tokens.mediaQuery.min.lg]: {
+					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 380px), no-repeat center right url(${backgroundImageSrc})`,
+				},
+				[tokens.mediaQuery.min.xl]: {
+					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 580px), no-repeat center right url(${backgroundImageSrc})`,
+				},
+			}}
 		>
 			{children}
 		</Box>

--- a/packages/hero-banner/src/HeroBannerBackground.tsx
+++ b/packages/hero-banner/src/HeroBannerBackground.tsx
@@ -25,12 +25,15 @@ export const HeroBannerBackground = ({
 				},
 				[tokens.mediaQuery.min.md]: {
 					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 320px), no-repeat center right url(${backgroundImageSrc})`,
+					backgroundSize: 'auto 100%',
 				},
 				[tokens.mediaQuery.min.lg]: {
 					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 380px), no-repeat center right url(${backgroundImageSrc})`,
+					backgroundSize: 'auto 100%',
 				},
 				[tokens.mediaQuery.min.xl]: {
 					background: `linear-gradient(270deg, transparent 0px, ${boxPalette[backgroundVar]} 580px), no-repeat center right url(${backgroundImageSrc})`,
+					backgroundSize: 'auto 100%',
 				},
 			}}
 		>


### PR DESCRIPTION
## Describe your changes

Fixes an issue where the image does not get covered by the gradient, as pictured in the screenshot below.

<img width="1908" alt="Screen Shot 2022-04-29 at 3 00 03 pm" src="https://user-images.githubusercontent.com/6265154/165887494-1d0cd50f-c4dc-4850-98aa-c6b523110bee.png">


## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file