### PR TITLE
Docs: Add storybook links to docs pages

### DIFF
--- a/.changeset/cyan-glasses-vanish.md
+++ b/.changeset/cyan-glasses-vanish.md
@@ -1,0 +1,46 @@
+---
+'@ag.ds-next/docs': patch
+'@ag.ds-next/a11y': patch
+'@ag.ds-next/accordion': patch
+'@ag.ds-next/ag-branding': patch
+'@ag.ds-next/body': patch
+'@ag.ds-next/box': patch
+'@ag.ds-next/breadcrumbs': patch
+'@ag.ds-next/button': patch
+'@ag.ds-next/call-to-action': patch
+'@ag.ds-next/callout': patch
+'@ag.ds-next/card': patch
+'@ag.ds-next/columns': patch
+'@ag.ds-next/control-input': patch
+'@ag.ds-next/core': patch
+'@ag.ds-next/date-picker': patch
+'@ag.ds-next/direction-link': patch
+'@ag.ds-next/field': patch
+'@ag.ds-next/fieldset': patch
+'@ag.ds-next/file-upload': patch
+'@ag.ds-next/footer': patch
+'@ag.ds-next/header': patch
+'@ag.ds-next/heading': patch
+'@ag.ds-next/hero-banner': patch
+'@ag.ds-next/icon': patch
+'@ag.ds-next/inpage-nav': patch
+'@ag.ds-next/keyword-list': patch
+'@ag.ds-next/link-list': patch
+'@ag.ds-next/loading': patch
+'@ag.ds-next/main-nav': patch
+'@ag.ds-next/modal': patch
+'@ag.ds-next/page-alert': patch
+'@ag.ds-next/progress-indicator': patch
+'@ag.ds-next/search-box': patch
+'@ag.ds-next/select': patch
+'@ag.ds-next/side-nav': patch
+'@ag.ds-next/skip-link': patch
+'@ag.ds-next/table': patch
+'@ag.ds-next/tags': patch
+'@ag.ds-next/task-list': patch
+'@ag.ds-next/text': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Add Storybook links to docs site

--- a/docs/lib/mdxUtils.ts
+++ b/docs/lib/mdxUtils.ts
@@ -59,7 +59,7 @@ export async function getPkg(slug: string) {
 		name: name as string,
 		version: version as string,
 		title: (data.title ?? slug) as string,
-		storybookPath: data.storybookPath,
+		storybookPath: data.storybookPath as string,
 	};
 }
 

--- a/docs/lib/mdxUtils.ts
+++ b/docs/lib/mdxUtils.ts
@@ -59,7 +59,7 @@ export async function getPkg(slug: string) {
 		name: name as string,
 		version: version as string,
 		title: (data.title ?? slug) as string,
-		storybookPath: data.storybookPath as string,
+		storybookPath: (data.storybookPath ?? null) as string | null,
 	};
 }
 

--- a/docs/lib/mdxUtils.ts
+++ b/docs/lib/mdxUtils.ts
@@ -59,6 +59,7 @@ export async function getPkg(slug: string) {
 		name: name as string,
 		version: version as string,
 		title: (data.title ?? slug) as string,
+		storybookPath: data.storybookPath,
 	};
 }
 

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -23,7 +23,6 @@ import { PageLayout } from '../../../components/PageLayout';
 export default function Packages({
 	pkg,
 	navLinks,
-	storybookPath,
 	breadcrumbs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
@@ -40,7 +39,7 @@ export default function Packages({
 					breadcrumbs={breadcrumbs}
 				>
 					<Stack as="main" gap={1}>
-						<Flex alignItems="flex-start" flexDirection="column" gap={0.25}>
+						<Flex flexDirection="column" gap={0.25}>
 							<Text fontSize="sm" color="muted">
 								v{pkg.version}
 							</Text>
@@ -48,17 +47,19 @@ export default function Packages({
 							{pkg.data.description && (
 								<Text fontSize="lg">{pkg.data.description}</Text>
 							)}
-							{storybookPath && (
+						</Flex>
+						{pkg.storybookPath && (
+							<div>
 								<ButtonLink
 									target="_blank"
 									iconAfter={ExternalLinkIcon}
 									variant="secondary"
-									href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${storybookPath}`}
+									href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${pkg.storybookPath}`}
 								>
-									Open in Storybook
+									View in Storybook
 								</ButtonLink>
-							)}
-						</Flex>
+							</div>
+						)}
 						<Box
 							palette="light"
 							rounded
@@ -87,12 +88,11 @@ export const getStaticProps: GetStaticProps<
 	{
 		pkg: Pkg;
 		navLinks: Awaited<ReturnType<typeof getPkgNavLinks>>;
-		storybookPath: string | undefined;
 		breadcrumbs: Awaited<ReturnType<typeof getPkgBreadcrumbs>>;
 	},
 	{ slug: string; group: string }
 > = async ({ params }) => {
-	const { slug, group, storybookPath } = params ?? {};
+	const { slug, group } = params ?? {};
 	const pkg = slug ? await getPkg(slug) : undefined;
 
 	if (!(slug && group && pkg)) {
@@ -106,7 +106,6 @@ export const getStaticProps: GetStaticProps<
 		props: {
 			pkg,
 			navLinks,
-			storybookPath: storybookPath || undefined,
 			breadcrumbs,
 		},
 	};

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -4,6 +4,8 @@ import { H1 } from '@ag.ds-next/heading';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { Body } from '@ag.ds-next/body';
+import { ButtonLink } from '@ag.ds-next/button';
+import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
 import {
 	getPkgList,
@@ -21,6 +23,7 @@ import { PageLayout } from '../../../components/PageLayout';
 export default function Packages({
 	pkg,
 	navLinks,
+	storybookPath,
 	breadcrumbs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
@@ -37,13 +40,23 @@ export default function Packages({
 					breadcrumbs={breadcrumbs}
 				>
 					<Stack as="main" gap={1}>
-						<Flex flexDirection="column" gap={0.25}>
+						<Flex alignItems="flex-start" flexDirection="column" gap={0.25}>
 							<Text fontSize="sm" color="muted">
 								v{pkg.version}
 							</Text>
 							<H1>{pkg.data.title}</H1>
 							{pkg.data.description && (
 								<Text fontSize="lg">{pkg.data.description}</Text>
+							)}
+							{storybookPath && (
+								<ButtonLink
+									target="_blank"
+									iconAfter={ExternalLinkIcon}
+									variant="secondary"
+									href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${storybookPath}`}
+								>
+									Open in Storybook
+								</ButtonLink>
 							)}
 						</Flex>
 						<Box
@@ -74,11 +87,12 @@ export const getStaticProps: GetStaticProps<
 	{
 		pkg: Pkg;
 		navLinks: Awaited<ReturnType<typeof getPkgNavLinks>>;
+		storybookPath: string | undefined;
 		breadcrumbs: Awaited<ReturnType<typeof getPkgBreadcrumbs>>;
 	},
 	{ slug: string; group: string }
 > = async ({ params }) => {
-	const { slug, group } = params ?? {};
+	const { slug, group, storybookPath } = params ?? {};
 	const pkg = slug ? await getPkg(slug) : undefined;
 
 	if (!(slug && group && pkg)) {
@@ -92,6 +106,7 @@ export const getStaticProps: GetStaticProps<
 		props: {
 			pkg,
 			navLinks,
+			storybookPath: storybookPath || undefined,
 			breadcrumbs,
 		},
 	};

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -2,6 +2,7 @@
 title: A11y
 description: Utilities for improving accessibility.
 group: Foundations
+storybookPath: /story/foundations-a11y-visuallyhidden--basic
 ---
 
 ### Visually Hidden

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -2,6 +2,7 @@
 title: Accordion
 description: Accordions help users see only the content they need, by expanding and collapsing sections of content.
 group: Layout
+storybookPath: /story/layout-accordion--on-light
 ---
 
 A singular method of expanding and collapsing a piece of content with a title.

--- a/packages/ag-branding/README.md
+++ b/packages/ag-branding/README.md
@@ -2,6 +2,7 @@
 title: AG Branding
 description: A colour palette and logo set for Agriculture
 group: Brand
+storybookPath: /story/brand-ag-branding-logo--on-light
 ---
 
 ## Agriculture theme

--- a/packages/body/README.md
+++ b/packages/body/README.md
@@ -2,6 +2,7 @@
 title: Body
 description: Provides correct styling for Markdown or CMS content.
 group: Content
+storybookPath: /story/content-body--on-light
 ---
 
 Many sites will have content being generated in a WYSIWIG or HTML field within a content management system. This content is inherently difficult to style as developers often times have limited control over the markup being generated in these editors. `Body` is designed to apply styling to make CMS content look ok.

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -2,6 +2,7 @@
 title: Box
 description: A set of primitive layout components
 group: Foundations
+storybookPath: /story/foundations-box--light-box
 ---
 
 This package includes the components `<Box />`, `<Flex />` and `<Stack />`.

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -2,6 +2,7 @@
 title: Breadcrumbs
 description: Breadcrumbs are a navigational aid that display a user's location on a website as a row of links, usually located at the top of the page.
 group: Navigation
+storybookPath: /story/navigation-breadcrumbs--on-light
 ---
 
 Breadcrumbs show users where they are in the website hierarchy and how to navigate back/up to previous levels or content.

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -2,6 +2,7 @@
 title: Button
 description: Buttons make common actions more obvious and help users more easily perform them. Buttons use labels and sometimes icons to communicate the action that will occur when the user touches them.
 group: Forms
+storybookPath: /story/forms-button--on-light
 ---
 
 ## Props

--- a/packages/call-to-action/README.md
+++ b/packages/call-to-action/README.md
@@ -2,6 +2,7 @@
 title: Call to action
 description: Call to action links are visually distinct instructions to users designed to provoke an immediate response using verbs such as 'call now' or 'find out more'.
 group: Content
+storybookPath: /story/content-calltoactionlink--on-light
 ---
 
 A simple and clear link to direct users to a preferred action.

--- a/packages/callout/README.md
+++ b/packages/callout/README.md
@@ -2,6 +2,7 @@
 title: Callout
 description: Callouts are an excerpt of text or an article that has been pulled out and used as a visual clue to draw the eye to the text. They are used to help direct a user's attention to important pieces of information.
 group: Content
+storybookPath: /story/layout-callout--on-light
 ---
 
 ## Default

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -2,6 +2,7 @@
 title: Card
 description: The card component is used to provide a brief summary of content or a task, often with a link to more detail. Cards are frequently displayed alongside other cards to group related content or tasks.
 group: Layout
+storybookPath: /story/layout-card--on-light
 ---
 
 ## Basic card

--- a/packages/columns/README.md
+++ b/packages/columns/README.md
@@ -2,6 +2,7 @@
 title: Columns
 description: A grid consists of a framework of cells laid out and aligned vertically and horizontally. It helps users read and visually navigate website content more easily, using a responsive, scrollable column structure.
 group: Layout
+storybookPath: /story/layout-columns--basic
 ---
 
 This package includes the components `<Columns />` and `<Column />`.

--- a/packages/control-input/README.md
+++ b/packages/control-input/README.md
@@ -2,6 +2,7 @@
 title: Control input
 description: Control inputs help users input one or more selections from multiple options. Our control inputs consist of checkboxes and radio buttons.
 group: Forms
+storybookPath: /story/forms-checkbox--on-light
 ---
 
 ### Checkbox

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,6 +2,7 @@
 title: Core
 description: Core includes a range of styles, variables and code that form the foundation of how the Design System works, including colour, typography and spacing.
 group: Foundations
+storybookPath: /story/foundations-core--usage
 ---
 
 The `Core` component should wrap your entire application, which will enable our CSS variables reset styles.

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -2,6 +2,7 @@
 title: Date Picker
 description: Allow users to select a single date or a range of dates.
 group: forms
+storybookPath: /story/foundations-core--usage
 ---
 
 ## Date Picker

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -2,7 +2,7 @@
 title: Date Picker
 description: Allow users to select a single date or a range of dates.
 group: forms
-storybookPath: /story/foundations-core--usage
+storybookPath: /story/forms-datepicker-datepicker--on-light
 ---
 
 ## Date Picker

--- a/packages/direction-link/README.md
+++ b/packages/direction-link/README.md
@@ -2,6 +2,7 @@
 title: Direction link
 description: Direction links are accompanied by arrows to help users move quickly to other parts of the page or through a process.
 group: Navigation
+storybookPath: /story/navigation-directionlink--on-light
 ---
 
 Use direction links to indicate a physical direction, such as:

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -2,6 +2,7 @@
 title: Field
 description: The field package exposes the elements around form inputs, and an API to compose them.
 group: Forms
+storybookPath: /story/forms-field--on-light
 ---
 
 ### Field

--- a/packages/fieldset/README.md
+++ b/packages/fieldset/README.md
@@ -2,6 +2,7 @@
 title: Fieldset
 description: Use the fieldset component to group related form inputs.
 group: Forms
+storybookPath: /story/forms-fieldset--on-light
 ---
 
 Fieldset is used to associate a number of related form fields as well as labels within a form. The legend provides an association and caption for the form fields in the fieldset.

--- a/packages/file-upload/README.md
+++ b/packages/file-upload/README.md
@@ -2,6 +2,7 @@
 title: FileUpload
 description: Allows a user to insert a file into a form, via drag-and-drop or using the system file browser.
 group: Forms
+storybookPath: /story/forms-fileupload--on-light
 ---
 
 ```jsx live

--- a/packages/footer/README.md
+++ b/packages/footer/README.md
@@ -2,6 +2,7 @@
 title: Footer
 group: Layout
 description: Footers help users find what they need after scrolling to the bottom of a page. They provide supplementary information such as copyright, ABN details, contact information, links to other pages within the website, and email and social media links.
+storybookPath: /story/layout-footer--agriculture-variant
 ---
 
 ## Main

--- a/packages/header/README.md
+++ b/packages/header/README.md
@@ -2,6 +2,7 @@
 title: Header
 group: Layout
 description: The masthead of our applications, Header incorporates our AWE brand, and provides a user context on where they are.
+storybookPath: /story/layout-header--dark-variant
 ---
 
 ```jsx live

--- a/packages/heading/README.md
+++ b/packages/heading/README.md
@@ -2,6 +2,7 @@
 title: Headings
 description: A primitive typographic component for constrained heading styles. Headings help to structure content on a page using relative visual prominence.
 group: Content
+storybookPath: /story/content-heading--basic
 ---
 
 Headings use the `fontGrid` function to make the font-size and line-height snap to grid.

--- a/packages/hero-banner/README.md
+++ b/packages/hero-banner/README.md
@@ -2,6 +2,7 @@
 title: Hero Banner
 description: Hero banner are used to grab a user’s attention.
 group: Layout
+storybookPath: /story/layout-herobanner--light-variant
 ---
 
 ```jsx live

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -2,6 +2,7 @@
 title: Icon
 description: The Agriculture Design System supports the use of universal system icons. The icon component is used to apply our set of universal icons to more complex components of the system.
 group: Foundations
+storybookPath: /story/foundations-icon--all-icons
 ---
 
 ```jsx live

--- a/packages/inpage-nav/README.md
+++ b/packages/inpage-nav/README.md
@@ -2,6 +2,7 @@
 title: Inpage nav
 description: Inpage nav links helps users scan the contents of a page and navigate to different sections of the page.
 group: Navigation
+storybookPath: /story/navigation-inpagenav--on-light
 ---
 
 The inpage nav (or page contents) is placed above sections of a page and provides navigation to individual anchor links located in those sections.

--- a/packages/keyword-list/README.md
+++ b/packages/keyword-list/README.md
@@ -2,6 +2,7 @@
 title: Keyword List
 description: The keyword list style helps to emphasise and draw the user's eye to phrases that are repeated in a list.
 group: Content
+storybookPath: /story/content-keywordlist--on-light
 ---
 
 A key and value pair used to display a small subtitle above a larger title.

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -2,6 +2,7 @@
 title: LinkList
 description: The link list style is a simple list of vertical or horizontal links used for site navigation. It is used to order information for users.
 group: Navigation
+storybookPath: /story/navigation-linklist--on-light
 ---
 
 The default link list component removes the normal bullets and spacing associated with a list.

--- a/packages/loading/README.md
+++ b/packages/loading/README.md
@@ -2,6 +2,7 @@
 title: Loading
 description: Loading indicators inform users that their action is being processed.
 group: Content
+storybookPath: /story/content-loading-loadingblanket--on-light
 ---
 
 ## Loading Blanket

--- a/packages/main-nav/README.md
+++ b/packages/main-nav/README.md
@@ -2,6 +2,7 @@
 title: MainNav
 description: A horizontal list of links to key areas on the website. Typically placed in the header.
 group: Navigation
+storybookPath: /story/navigation-mainnav--agriculture-variant
 ---
 
 The main navigation component is intended to be used as the primary means of navigation around the website. It typically accommodates the top level of the information architecture.

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -2,6 +2,7 @@
 title: Modal
 description: Modal is a window that appears in front of the current page, to focus user attention on one action or piece of information
 group: Content
+storybookPath: /story/content-modal--basic
 ---
 
 Modals are ideal for prompting a user to confirm a destructive action.

--- a/packages/page-alert/README.md
+++ b/packages/page-alert/README.md
@@ -2,6 +2,7 @@
 title: Page alert
 description: Page alerts are used to notify users of important information or changes on a page, in a way that attracts the user's attention without interrupting the current task.
 group: Content
+storybookPath: /story/content-page-alert--on-light
 ---
 
 Typically Page Alerts appear at the top of a page following a submit action.

--- a/packages/progress-indicator/README.md
+++ b/packages/progress-indicator/README.md
@@ -2,6 +2,7 @@
 title: Progress indicator
 description: Progress indicators provide visual feedback to users to let them know and understand their current context at any given time and be assured that they are progressing through the system.
 group: Forms
+storybookPath: /story/forms-progressindicator--on-light
 ---
 
 Our design system provides a progress indicator for larger tasks that can be completed out of order and returned to at a later date, like doing a tax return or applying for a driver’s licence.

--- a/packages/search-box/README.md
+++ b/packages/search-box/README.md
@@ -2,6 +2,7 @@
 title: Search Box
 description: An input that allows users to enter a keyword to filter content on the website.
 group: Forms
+storybookPath: /story/forms-searchbox--on-light
 ---
 
 ### Default

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -2,6 +2,7 @@
 title: Select
 description: Select provides a means to select a single item from a collapsible list. Use of select helps to reduce input errors and screen space. It's commonly used to help users enter a value into a form field.
 group: Forms
+storybookPath: /story/forms-select--on-light
 ---
 
 ### Default

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -2,6 +2,7 @@
 title: SideNav
 description: A vertical list of links for site navigation typically placed next to the body content.
 group: Navigation
+storybookPath: /story/navigation-sidenav--light-variant
 ---
 
 The side navigation allows users to find other pages which share a similar topic or section. By default it supports three levels of nesting along with an accompanying heading.

--- a/packages/skip-link/README.md
+++ b/packages/skip-link/README.md
@@ -2,6 +2,7 @@
 title: Skip link
 description: Skip links are internal page links that aid navigation around a page. They are detected by screen readers and help users quickly jump to and over content on the page.
 group: Navigation
+storybookPath: /story/navigation-skiplinks--basic
 ---
 
 Skip links are not visual until they receive focus. Include skip links after the opening of the `<body>` tag.

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -2,6 +2,7 @@
 title: Table
 description: Used to display tabular data.
 group: Content
+storybookPath: /story/content-table--on-light
 ---
 
 For data tables with a small amount of rows use the default table. Align text columns and corresponding data cells to the left. When comparing numbers in a column, align data cells and column headers to the right.

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -2,6 +2,7 @@
 title: Tags
 description: Tags are a means of classifying content, typically using keywords or labels. They are added to a web page, an asset or other content to help users search for and find related content quickly and easily.
 group: Content
+storybookPath: /story/content-tags--on-light
 ---
 
 ### Tags with links

--- a/packages/task-list/README.md
+++ b/packages/task-list/README.md
@@ -2,6 +2,7 @@
 title: Task List
 description:
 group: Forms
+storybookPath: /story/forms-tasklist--on-light
 ---
 
 The individual tasks or steps are shown as either:

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -2,6 +2,7 @@
 title: Text Input
 description: Text inputs are input fields typically used in forms that allow the user to enter text data in a structured format.
 group: Forms
+storybookPath: /story/forms-textinput--on-light
 ---
 
 ### Default

--- a/packages/text/README.md
+++ b/packages/text/README.md
@@ -2,6 +2,7 @@
 title: Text
 description: A primitive typographic component for constrained text styles
 group: Foundations
+storybookPath: /story/foundations-text--basic
 ---
 
 This package includes the components `<Text />` and `<TextLink />`.

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -2,6 +2,7 @@
 title: Textarea
 description: Textarea is a long form text input and can be scaled up or down in size by the user.
 group: Forms
+storybookPath: /story/forms-textarea--on-light
 ---
 
 ### Default


### PR DESCRIPTION
Add a link to a components story from the relevant docs page.

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/12689383/166413966-291f594a-470e-41b2-9508-a7d224ba67d7.png">

## Checklist

- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
- [X] Write documentation (README.md)