### PR TITLE
Docs: Open in playroom should open in a new tab 

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -13,6 +13,7 @@ import copy from 'clipboard-copy';
 import { globalPalette, mapSpacing, tokens } from '@ag.ds-next/core';
 import { Box, Flex } from '@ag.ds-next/box';
 import { Button, ButtonLink } from '@ag.ds-next/button';
+import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
 import { designSystemComponents } from './design-system-components';
 import { prismTheme } from './prism-theme';
@@ -111,7 +112,14 @@ const LiveCode = withLive((props: unknown) => {
 				<Button size="sm" variant="secondary" onClick={copyLiveCode}>
 					Copy
 				</Button>
-				<ButtonLink size="sm" variant="tertiary" href={playroomUrl}>
+				<ButtonLink
+					href={playroomUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					size="sm"
+					variant="tertiary"
+					iconAfter={ExternalLinkIcon}
+				>
 					Open in Playroom
 				</ButtonLink>
 			</Flex>

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -52,9 +52,10 @@ export default function Packages({
 							<div>
 								<ButtonLink
 									target="_blank"
-									iconAfter={ExternalLinkIcon}
-									variant="secondary"
 									href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${pkg.storybookPath}`}
+									rel="noopener noreferrer"
+									variant="secondary"
+									iconAfter={ExternalLinkIcon}
 								>
 									View in Storybook
 								</ButtonLink>


### PR DESCRIPTION
## Describe your changes

Keeps the behaviour and UI consistent with the new `Open in Storybook` button