### PR TITLE
Docs/Body: Prevent body styles from being inherited in live code examples

### DIFF
--- a/.changeset/afraid-bulldogs-enjoy.md
+++ b/.changeset/afraid-bulldogs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+Updated code theme to match body styles

--- a/.changeset/fluffy-hornets-greet.md
+++ b/.changeset/fluffy-hornets-greet.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/docs': patch
+'@ag.ds-next/docs': minor
 ---
 
 Prevent body styles from being inherited in live code examples

--- a/.changeset/fluffy-hornets-greet.md
+++ b/.changeset/fluffy-hornets-greet.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+Prevent body styles from being inherited in live code examples

--- a/.changeset/warm-days-bow.md
+++ b/.changeset/warm-days-bow.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/body': minor
+---
+
+Update `bodyStyles` from an object to a function so it can accept a `notSelector` argument
+

--- a/.changeset/warm-days-bow.md
+++ b/.changeset/warm-days-bow.md
@@ -2,5 +2,4 @@
 '@ag.ds-next/body': minor
 ---
 
-Update `bodyStyles` from an object to a function so it can accept a `notSelector` argument
-
+Added ability to stop body styles from being inherited on specific elements using `unsetBodyStylesClassname`

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -12,7 +12,7 @@ import copy from 'clipboard-copy';
 
 import { globalPalette, mapSpacing, tokens } from '@ag.ds-next/core';
 import { Box, Flex } from '@ag.ds-next/box';
-import { excludeBodyStylesClassname } from '@ag.ds-next/body';
+import { unsetBodyStylesClassname } from '@ag.ds-next/body';
 import { Button, ButtonLink } from '@ag.ds-next/button';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
@@ -70,7 +70,7 @@ const LiveCode = withLive((props: unknown) => {
 			<Box padding={1}>
 				<LivePreview
 					// Prevents body styles from being inherited in live code examples
-					className={excludeBodyStylesClassname}
+					className={unsetBodyStylesClassname}
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
 						// applies some weirdness here. This resets back to normal things

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -12,6 +12,7 @@ import copy from 'clipboard-copy';
 
 import { globalPalette, mapSpacing, tokens } from '@ag.ds-next/core';
 import { Box, Flex } from '@ag.ds-next/box';
+import { excludeBodyStylesClassname } from '@ag.ds-next/body';
 import { Button, ButtonLink } from '@ag.ds-next/button';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
@@ -72,7 +73,8 @@ const LiveCode = withLive((props: unknown) => {
 		>
 			<Box padding={1}>
 				<LivePreview
-					className="code-live-preview"
+					// Prevents body styles from being inherited in live code examples
+					className={excludeBodyStylesClassname}
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
 						// applies some weirdness here. This resets back to normal things

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, Fragment } from 'react';
+import { useRouter } from 'next/router';
 import {
 	LiveProvider,
 	LiveEditor,
@@ -34,6 +35,8 @@ const PlaceholderImage = () => (
 );
 
 const LiveCode = withLive((props: unknown) => {
+	const { query } = useRouter();
+
 	// The types on `withLive` are kind of useless.
 	const { live } = props as {
 		live: {
@@ -66,15 +69,13 @@ const LiveCode = withLive((props: unknown) => {
 	});
 
 	return (
-		<Box
-			css={{
-				boxShadow: `0 0 1px ${globalPalette.lightBorder}`,
-			}}
-		>
+		<Box css={{ boxShadow: `0 0 1px ${globalPalette.lightBorder}` }}>
 			<Box padding={1}>
 				<LivePreview
-					// Prevents body styles from being inherited in live code examples
-					className={excludeBodyStylesClassname}
+					// Prevents body styles from being inherited in live code examples that are not the `body` component
+					className={
+						query.slug === 'body' ? undefined : excludeBodyStylesClassname
+					}
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
 						// applies some weirdness here. This resets back to normal things

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, Fragment } from 'react';
-import { useRouter } from 'next/router';
 import {
 	LiveProvider,
 	LiveEditor,
@@ -35,8 +34,6 @@ const PlaceholderImage = () => (
 );
 
 const LiveCode = withLive((props: unknown) => {
-	const { query } = useRouter();
-
 	// The types on `withLive` are kind of useless.
 	const { live } = props as {
 		live: {
@@ -72,10 +69,8 @@ const LiveCode = withLive((props: unknown) => {
 		<Box css={{ boxShadow: `0 0 1px ${globalPalette.lightBorder}` }}>
 			<Box padding={1}>
 				<LivePreview
-					// Prevents body styles from being inherited in live code examples that are not the `body` component
-					className={
-						query.slug === 'body' ? undefined : excludeBodyStylesClassname
-					}
+					// Prevents body styles from being inherited in live code examples
+					className={excludeBodyStylesClassname}
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
 						// applies some weirdness here. This resets back to normal things

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, Fragment } from 'react';
+import { useRouter } from 'next/router';
 import {
 	LiveProvider,
 	LiveEditor,
@@ -34,6 +35,8 @@ const PlaceholderImage = () => (
 );
 
 const LiveCode = withLive((props: unknown) => {
+	const { query } = useRouter();
+
 	// The types on `withLive` are kind of useless.
 	const { live } = props as {
 		live: {
@@ -66,11 +69,18 @@ const LiveCode = withLive((props: unknown) => {
 	});
 
 	return (
-		<Box css={{ boxShadow: `0 0 1px ${globalPalette.lightBorder}` }}>
+		<Box
+			css={{
+				boxShadow: `0 0 1px ${globalPalette.lightBorder}`,
+				marginTop: mapSpacing(1.5),
+			}}
+		>
 			<Box padding={1}>
 				<LivePreview
-					// Prevents body styles from being inherited in live code examples
-					className={unsetBodyStylesClassname}
+					// Prevents body styles from being inherited in live code examples (except for the body example)
+					className={
+						query.slug === 'body' ? undefined : unsetBodyStylesClassname
+					}
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
 						// applies some weirdness here. This resets back to normal things
@@ -137,6 +147,12 @@ const StaticCode = ({
 		<Box
 			css={{
 				boxShadow: `0 0 1px ${globalPalette.lightBorder}`,
+				marginTop: mapSpacing(1.5),
+
+				'textarea, pre': {
+					padding: `${mapSpacing(1)} !important`,
+				},
+
 				'& ::selection': {
 					color: globalPalette.darkBackgroundBody,
 					backgroundColor: globalPalette.darkForegroundAction,

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -72,6 +72,7 @@ const LiveCode = withLive((props: unknown) => {
 		>
 			<Box padding={1}>
 				<LivePreview
+					className="code-live-preview"
 					css={{
 						// The mdx codeblock transform wraps the code component in a pre which
 						// applies some weirdness here. This resets back to normal things

--- a/docs/components/design-system-components.tsx
+++ b/docs/components/design-system-components.tsx
@@ -6,7 +6,7 @@ import {
 import { Logo } from '@ag.ds-next/ag-branding';
 import { Button, ButtonLink } from '@ag.ds-next/button';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
-import { Body, excludeBodyStylesClassname } from '@ag.ds-next/body';
+import { Body, unsetBodyStylesClassname } from '@ag.ds-next/body';
 import { useTernaryState, tokens } from '@ag.ds-next/core';
 import { Text, TextLink } from '@ag.ds-next/text';
 import { Heading, H1, H2, H3, H4, H5, H6 } from '@ag.ds-next/heading';
@@ -122,7 +122,7 @@ export const designSystemComponents = {
 	Column,
 	Stack,
 	Body,
-	excludeBodyStylesClassname,
+	unsetBodyStylesClassname,
 	FileUpload,
 	Table,
 	TableBody,

--- a/docs/components/design-system-components.tsx
+++ b/docs/components/design-system-components.tsx
@@ -6,7 +6,7 @@ import {
 import { Logo } from '@ag.ds-next/ag-branding';
 import { Button, ButtonLink } from '@ag.ds-next/button';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
-import { Body } from '@ag.ds-next/body';
+import { Body, excludeBodyStylesClassname } from '@ag.ds-next/body';
 import { useTernaryState, tokens } from '@ag.ds-next/core';
 import { Text, TextLink } from '@ag.ds-next/text';
 import { Heading, H1, H2, H3, H4, H5, H6 } from '@ag.ds-next/heading';
@@ -122,6 +122,7 @@ export const designSystemComponents = {
 	Column,
 	Stack,
 	Body,
+	excludeBodyStylesClassname,
 	FileUpload,
 	Table,
 	TableBody,

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -1,8 +1,10 @@
 import { PrismTheme } from 'prism-react-renderer';
-import { globalPalette } from '@ag.ds-next/core';
+import { globalPalette, tokens, fontGrid } from '@ag.ds-next/core';
 
 export const prismTheme: PrismTheme = {
 	plain: {
+		fontFamily: tokens.font.monospace,
+		...fontGrid('xs', 'default'),
 		color: globalPalette.lightForegroundText,
 		backgroundColor: globalPalette.lightBackgroundShade,
 	},

--- a/docs/components/utils.tsx
+++ b/docs/components/utils.tsx
@@ -2,6 +2,8 @@ import { Fragment } from 'react';
 import { Code } from './Code';
 
 export const mdxComponents = {
+	// avoid wrapping live examples in pre tag
+	pre: Fragment,
 	code: Code,
 	Fragment,
 };

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -3,7 +3,7 @@ import { MDXRemote } from 'next-mdx-remote';
 import { H1 } from '@ag.ds-next/heading';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
-import { bodyStyles } from '@ag.ds-next/body';
+import { Body } from '@ag.ds-next/body';
 import { ButtonLink } from '@ag.ds-next/button';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
@@ -75,14 +75,9 @@ export default function Packages({
 								</code>
 							</pre>
 						</Box>
-						<Box
-							css={bodyStyles({
-								// Prevents body styles from being inherited in live code examples
-								notSelector: ':not([class]):not(.code-live-preview *)',
-							})}
-						>
+						<Body>
 							<MDXRemote {...pkg.source} components={mdxComponents} />
-						</Box>
+						</Body>
 					</Stack>
 				</PageLayout>
 			</AppLayout>

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -3,7 +3,7 @@ import { MDXRemote } from 'next-mdx-remote';
 import { H1 } from '@ag.ds-next/heading';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
-import { Body } from '@ag.ds-next/body';
+import { Body, bodyClass, bodyStyles } from '@ag.ds-next/body';
 import { ButtonLink } from '@ag.ds-next/button';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
@@ -75,9 +75,14 @@ export default function Packages({
 								</code>
 							</pre>
 						</Box>
-						<Body>
+						<Box
+							css={bodyStyles({
+								// Prevents body styles from being inherited in live code examples
+								notSelector: ':not([class]):not(.live-code *)',
+							})}
+						>
 							<MDXRemote {...pkg.source} components={mdxComponents} />
-						</Body>
+						</Box>
 					</Stack>
 				</PageLayout>
 			</AppLayout>

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -1,7 +1,7 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
 import { H1 } from '@ag.ds-next/heading';
-import { Box, Flex, Stack } from '@ag.ds-next/box';
+import { Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { Body } from '@ag.ds-next/body';
 import { ButtonLink } from '@ag.ds-next/button';
@@ -61,20 +61,13 @@ export default function Packages({
 								</ButtonLink>
 							</div>
 						)}
-						<Box
-							palette="light"
-							rounded
-							background="shade"
-							paddingX={1}
-							fontSize="sm"
-							color="text"
-						>
+						<Body>
 							<pre>
 								<code>
 									yarn add {pkg.name}@{pkg.version}
 								</code>
 							</pre>
-						</Box>
+						</Body>
 						<Body>
 							<MDXRemote {...pkg.source} components={mdxComponents} />
 						</Body>

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -3,7 +3,7 @@ import { MDXRemote } from 'next-mdx-remote';
 import { H1 } from '@ag.ds-next/heading';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
-import { Body, bodyClass, bodyStyles } from '@ag.ds-next/body';
+import { bodyStyles } from '@ag.ds-next/body';
 import { ButtonLink } from '@ag.ds-next/button';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -78,7 +78,7 @@ export default function Packages({
 						<Box
 							css={bodyStyles({
 								// Prevents body styles from being inherited in live code examples
-								notSelector: ':not([class]):not(.live-code *)',
+								notSelector: ':not([class]):not(.code-live-preview *)',
 							})}
 						>
 							<MDXRemote {...pkg.source} components={mdxComponents} />

--- a/packages/body/README.md
+++ b/packages/body/README.md
@@ -9,155 +9,21 @@ Many sites will have content being generated in a WYSIWIG or HTML field within a
 
 This is also known as a Prose component.
 
-Body component should only be used in the context of a page, to format long-form content. It should not be used inside a 'framing' component like a Card or Modal. Instead, a simple Stack should be used.
+Body component should only be used in the context of a page, to format long-form content. It should not be used inside a 'framing' component like a `Card` or `Modal`. Instead, a simple `Stack` should be used.
 
-```jsx live
-<Box palette="light" background="body">
-	<Body>
-		<h1>Heading</h1>
-		<p>
-			This is an opening paragraph, that{' '}
-			<a href="/site">contains an internal link</a>.
-		</p>
-		<h2>Heading level 2</h2>
-		<h3>Heading level 3, proceeding H2</h3>
-		<p>
-			The purpose of the <kbd>Tab</kbd> character is indentation; conversely,
-			using the <kbd>Space</kbd> character for indentation carries no semantic
-			meaning—if you code this way your indentation schema may as well be a form
-			of{' '}
-			<abbr title="American Standard Code for Information Interchange">
-				ASCII
-			</abbr>{' '}
-			art. ;-)
-		</p>
-		<h3>Heading level 3</h3>
-		<p>
-			The <del>slow </del>quick brown fox jumped over the lazy dog. The{' '}
-			<ins>ins (insert)</ins> element, unlike the dog cannot jump over anything,
-			so it cannot span cross paragraph boundaries.
-		</p>
+```jsx
+<Body>{{ html }}</Body>
+```
 
-		<p>
-			This paragraph contains <s>outdated information</s> as well as current
-			information.
-		</p>
-		<dl>
-			<dt>Definition term</dt>
-			<dd>
-				A definition description: important information.{' '}
-				<small>Less important information.</small>
-			</dd>
-			<dd>
-				A second definition description.{' '}
-				<small>
-					Did you know?—a single definition term can have multiple definition
-					(descriptions).
-				</small>
-			</dd>
-			<dt>Single room</dt>
-			<dd>
-				$199{' '}
-				<small>
-					breakfast included, <abbr title="Goods and Services Tax">GST</abbr>{' '}
-					inclusive
-				</small>
-			</dd>
-			<dt>Double room</dt>
-			<dd>
-				$239{' '}
-				<small>
-					breakfast included, <abbr title="Goods and Services Tax">GST</abbr>{' '}
-					inclusive
-				</small>
-			</dd>
-		</dl>
-		<p>
-			We can also have single definitions, used for terms upon their first
-			occurence in a document:
-		</p>
-		<h5>Heading level 5</h5>
-		<p>
-			While they are essential reading material for our job, the{' '}
-			<dfn>
-				<abbr title="World Wide Web Consortium">W3C</abbr>
-			</dfn>{' '}
-			specifications are not exactly George R. R. Martin-level reading material.
-		</p>
-		<p>
-			Now to the <code>mark</code> element. This has a few useful applications:
-		</p>
-		<ul>
-			<li>
-				useful for marking up interesting things in quotations (without altering
-				the styling of text, eg to italic)
-			</li>
-			<li>
-				drawing attention to specific parts of pre-formatted text (eg code
-				snippets)
-			</li>
-			<li>for marking up search results (eg that match a given query)</li>
-		</ul>
-		<h6>Heading level 6</h6>
-		<p>
-			I also have some <mark>kitten</mark>s who are visiting me these days.
-			They’re really cute. I think they like my garden! Maybe I should adopt a{' '}
-			<mark>kitten</mark>.
-		</p>
-		<p>
-			How to install this component <code>npm i @gov.au/body</code>
-		</p>
-		<p>The highlighted part below is where the error lies:</p>
-		<pre>
-			<code>
-				var i: Integer; begin i := <mark>1.1</mark>; end.
-			</code>
-		</pre>
-		<figure>
-			<blockquote cite="https://www.huxley.net/bnw/four.html">
-				<p>
-					Words can be like X-rays, if you use them properly—they’ll go through
-					anything. You read and you’re pierced.
-				</p>
-			</blockquote>
-			<figcaption>
-				—Aldous Huxley, <cite>Brave New World</cite>
-			</figcaption>
-		</figure>
+### Excluding styles
 
-		<figure>
-			<img
-				src="/agds-next/img/placeholder/600X260.png"
-				alt="Placeholder image"
-			/>
-			<figcaption>Placeholder caption</figcaption>
-		</figure>
+In some cases you may want to prevent the body styles styles from being inherited on specific elements. This can be achieved by adding the `excludeBodyStylesClassname` to any child of the `Body` component.
 
-		<p>An unordered list containing an ordered list:</p>
-		<ul>
-			<li>Canberra office</li>
-			<li>Sydney office</li>
-			<li>
-				Foo item, with sub-items:
-				<ol>
-					<li>one</li>
-					<li>two</li>
-					<li>three</li>
-				</ol>
-			</li>
-			<li>Bar</li>
-			<li>Baz</li>
-		</ul>
-		<p>A simple ordered list:</p>
-		<ol>
-			<li>Discovery</li>
-			<li>Alpha</li>
-			<li>Beta</li>
-			<li>Live</li>
-		</ol>
-		<p>Back to a paragraph.</p>
-		<hr />
-		<p>And that's a wrap.</p>
-	</Body>
-</Box>
+```jsx
+<Body>
+	<h1>Styled heading</h1>
+	<div className={excludeBodyStylesClassname}>
+		<h1>Unstyled heading</h1>
+	</div>
+</Body>
 ```

--- a/packages/body/README.md
+++ b/packages/body/README.md
@@ -11,8 +11,222 @@ This is also known as a Prose component.
 
 Body component should only be used in the context of a page, to format long-form content. It should not be used inside a 'framing' component like a `Card` or `Modal`. Instead, a simple `Stack` should be used.
 
-```jsx
-<Body>{{ html }}</Body>
+```jsx live
+<Body>
+	<h1>Heading level 1. Page heading</h1>
+	<h2>Heading level 2, proceeding H1</h2>
+
+	<p>
+		This is an opening paragraph, that{' '}
+		<a href="/site">contains an internal link</a>.
+	</p>
+
+	<p>
+		Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ad expedita
+		tenetur blanditiis in libero distinctio inventore porro quaerat, eum
+		aspernatur{' '}
+		<a
+			href="https://more.domain.tld/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path/more/path"
+			rel="external"
+		>
+			and one that has a line break
+		</a>{' '}
+		dolorum animi a perferendis, obcaecati, accusantium dignissimos atque,
+		voluptates veniam!
+	</p>
+
+	<h2>Heading level 2</h2>
+	<h3>Heading level 3, proceeding H2</h3>
+	<p>
+		The purpose of the <kbd>Tab</kbd> character is indentation; conversely,
+		using the <kbd>Space</kbd> character for indentation carries no semantic
+		meaning—if you code this way your indentation schema may as well be a form
+		of{' '}
+		<abbr title="American Standard Code for Information Interchange">
+			ASCII
+		</abbr>{' '}
+		art. ;-)
+	</p>
+
+	<h3>Heading level 3</h3>
+	<p>
+		The <del>slow </del>quick brown fox jumped over the lazy dog. The{' '}
+		<ins>ins (insert)</ins> element, unlike the dog cannot jump over anything,
+		so it cannot span cross paragraph boundaries.
+	</p>
+
+	<p>
+		This paragraph contains <s>outdated information</s> as well as current
+		information.
+	</p>
+
+	<h4>Heading level 4</h4>
+	<p>
+		The coordinate of the <var>j</var>th point is (
+		<var>
+			x
+			<sub>
+				<var>j</var>
+			</sub>
+		</var>
+		, <var>
+			y
+			<sub>
+				<var>j</var>
+			</sub>
+		</var>
+		). For example, the 10th point has coordinate (
+		<var>
+			x<sub>10</sub>
+		</var>
+		, <var>
+			y<sub>10</sub>
+		</var>
+		).
+	</p>
+
+	<p>
+		<var>E</var>=<var>m</var>
+		<var>c</var>
+		<sup>2</sup>f(<var>x</var>, <var>n</var>) = log<sub>4</sub>
+		<var>x</var>
+		<sup>
+			<var>n</var>
+		</sup>
+	</p>
+
+	<main id="content">
+		<dl>
+			<dt>Definition term</dt>
+			<dd>
+				A definition description: important information.{' '}
+				<small>Less important information.</small>
+			</dd>
+			<dd>
+				A second definition description.{' '}
+				<small>
+					Did you know?—a single definition term can have multiple definition
+					(descriptions).
+				</small>
+			</dd>
+			<dt>Single room</dt>
+			<dd>
+				$199{' '}
+				<small>
+					breakfast included, <abbr title="Goods and Services Tax">GST</abbr>{' '}
+					inclusive
+				</small>
+			</dd>
+			<dt>Double room</dt>
+			<dd>
+				$239{' '}
+				<small>
+					breakfast included, <abbr title="Goods and Services Tax">GST</abbr>{' '}
+					inclusive
+				</small>
+			</dd>
+		</dl>
+
+		<p>
+			We can also have single definitions, used for terms upon their first
+			occurence in a document:
+		</p>
+
+		<h5>Heading level 5</h5>
+		<p>
+			While they are essential reading material for our job, the{' '}
+			<dfn>
+				<abbr title="World Wide Web Consortium">W3C</abbr>
+			</dfn>{' '}
+			specifications are not exactly George R. R. Martin-level reading material.
+		</p>
+
+		<p>
+			Now to the <code>mark</code> element. This has a few useful applications:
+		</p>
+
+		<ul>
+			<li>
+				useful for marking up interesting things in quotations (without altering
+				the styling of text, eg to italic)
+			</li>
+			<li>
+				drawing attention to specific parts of pre-formatted text (eg code
+				snippets)
+			</li>
+			<li>for marking up search results (eg that match a given query)</li>
+		</ul>
+
+		<h6>Heading level 6</h6>
+		<p>
+			I also have some <mark>kitten</mark>s who are visiting me these days.
+			They&rsquo;re really cute. I think they like my garden! Maybe I should
+			adopt a <mark>kitten</mark>.
+		</p>
+
+		<p>
+			How to install this component <code>npm i @gov.au/body</code>
+		</p>
+
+		<p>The highlighted part below is where the error lies:</p>
+
+		<pre>
+			<code>
+				var i: Integer; begin i := <mark>1.1</mark>; end.
+			</code>
+		</pre>
+
+		<figure>
+			<blockquote cite="https://www.huxley.net/bnw/four.html">
+				<p>
+					Words can be like X-rays, if you use them properly—they&rsquo;ll go
+					through anything. You read and you&rsquo;re pierced.
+				</p>
+			</blockquote>
+			<figcaption>
+				—Aldous Huxley, <cite>Brave New World</cite>
+			</figcaption>
+		</figure>
+
+		<figure>
+			<img
+				src="/agds-next/img/placeholder/600X260.png"
+				alt="Placeholder image"
+			/>
+			<figcaption>Placeholder caption</figcaption>
+		</figure>
+
+		<p>An unordered list containing an ordered list:</p>
+		<ul>
+			<li>Canberra office</li>
+			<li>Sydney office</li>
+			<li>
+				Foo item, with sub-items:
+				<ol>
+					<li>one</li>
+					<li>two</li>
+					<li>three</li>
+				</ol>
+			</li>
+			<li>Bar</li>
+			<li>Baz</li>
+		</ul>
+
+		<p>A simple ordered list:</p>
+		<ol>
+			<li>Discovery</li>
+			<li>Alpha</li>
+			<li>Beta</li>
+			<li>Live</li>
+		</ol>
+
+		<p>Back to a paragraph.</p>
+	</main>
+
+	<hr />
+
+	<p>And that&apos;s a wrap.</p>
+</Body>
 ```
 
 ### Unsetting styles

--- a/packages/body/README.md
+++ b/packages/body/README.md
@@ -15,14 +15,14 @@ Body component should only be used in the context of a page, to format long-form
 <Body>{{ html }}</Body>
 ```
 
-### Excluding styles
+### Unsetting styles
 
-In some cases you may want to prevent the body styles styles from being inherited on specific elements. This can be achieved by adding the `excludeBodyStylesClassname` to any child of the `Body` component.
+In some cases you may want to prevent the body styles from being inherited on specific elements. This can be achieved by adding the `unsetBodyStylesClassname` to any child of the `Body` component. This is similar to the CSS property `unset: all`.
 
 ```jsx
 <Body>
 	<h1>Styled heading</h1>
-	<div className={excludeBodyStylesClassname}>
+	<div className={unsetBodyStylesClassname}>
 		<h1>Unstyled heading</h1>
 	</div>
 </Body>

--- a/packages/body/README.md
+++ b/packages/body/README.md
@@ -95,7 +95,7 @@ Body component should only be used in the context of a page, to format long-form
 		</sup>
 	</p>
 
-	<main id="content">
+	<main>
 		<dl>
 			<dt>Definition term</dt>
 			<dd>

--- a/packages/body/src/Body.stories.tsx
+++ b/packages/body/src/Body.stories.tsx
@@ -93,7 +93,7 @@ const Template = () => (
 			</sup>
 		</p>
 
-		<main id="content">
+		<main>
 			<dl>
 				<dt>Definition term</dt>
 				<dd>
@@ -160,8 +160,8 @@ const Template = () => (
 			<h6>Heading level 6</h6>
 			<p>
 				I also have some <mark>kitten</mark>s who are visiting me these days.
-				They’re really cute. I think they like my garden! Maybe I should adopt a{' '}
-				<mark>kitten</mark>.
+				They&rsquo;re really cute. I think they like my garden! Maybe I should
+				adopt a <mark>kitten</mark>.
 			</p>
 
 			<p>
@@ -179,8 +179,8 @@ const Template = () => (
 			<figure>
 				<blockquote cite="https://www.huxley.net/bnw/four.html">
 					<p>
-						Words can be like X-rays, if you use them properly—they’ll go
-						through anything. You read and you’re pierced.
+						Words can be like X-rays, if you use them properly—they&rsquo;ll go
+						through anything. You read and you&rsquo;re pierced.
 					</p>
 				</blockquote>
 				<figcaption>
@@ -225,7 +225,7 @@ const Template = () => (
 
 		<hr />
 
-		<p>And that's a wrap.</p>
+		<p>And that&apos;s a wrap.</p>
 	</>
 );
 

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -13,323 +13,324 @@ export const Body = forwardRefWithAs<'div', BoxProps>(function Body(
 	props,
 	ref
 ) {
-	const styles = bodyStyles({ notSelector: ':not([class])' });
-	return <Box ref={ref} css={styles} {...props} />;
+	return <Box ref={ref} css={bodyClass} {...props} />;
 });
 
-export function bodyStyles({ notSelector }: { notSelector: string }) {
-	return css({
+export const excludeBodyStylesClassname = 'agds-body-reset';
+
+const notSelector = `:not([class]):not(.${excludeBodyStylesClassname})`;
+
+export const bodyClass = css({
+	margin: 0,
+	textSizeAdjust: '100%',
+	color: boxPalette.foregroundText,
+
+	// Font grid
+	fontFamily: tokens.font.body,
+	...fontGrid('sm', 'default'),
+
+	[`a${notSelector}`]: [linkStyles, focusStyles],
+
+	/**
+	 * Highlighting in-page sections that are in focus
+	 */
+	'[tabindex="0"]:focus, :target': packs.outline,
+
+	/**
+	 * `mark` styling.
+	 */
+	mark: {
+		color: boxPalette.backgroundBody,
+		backgroundColor: boxPalette.foregroundAction,
+	},
+
+	/**
+	 * Text selection styling
+	 */
+	'& ::selection': {
+		color: boxPalette.backgroundBody,
+		backgroundColor: boxPalette.foregroundAction,
+	},
+
+	img: {
+		maxWidth: '100%',
+	},
+
+	/**
+	 * Vertical spacing of common text elements.
+	 */
+	[`p${notSelector}`]: {
+		maxWidth: tokens.maxWidth.bodyText,
 		margin: 0,
-		textSizeAdjust: '100%',
-		color: boxPalette.foregroundText,
+	},
 
-		// Font grid
-		fontFamily: tokens.font.body,
-		...fontGrid('sm', 'default'),
+	[`* + p${notSelector}`]: {
+		marginTop: mapSpacing(1.5),
+	},
 
-		[`a${notSelector}`]: [linkStyles, focusStyles],
+	[`ul${notSelector},ol${notSelector},dl${notSelector},pre`]: {
+		margin: 0, //reset defaults
+	},
 
-		/**
-		 * Highlighting in-page sections that are in focus
-		 */
-		'[tabindex="0"]:focus, :target': packs.outline,
-
-		/**
-		 * `mark` styling.
-		 */
-		mark: {
-			color: boxPalette.backgroundBody,
-			backgroundColor: boxPalette.foregroundAction,
-		},
-
-		/**
-		 * Text selection styling
-		 */
-		'& ::selection': {
-			color: boxPalette.backgroundBody,
-			backgroundColor: boxPalette.foregroundAction,
-		},
-
-		img: {
-			maxWidth: '100%',
-		},
-
-		/**
-		 * Vertical spacing of common text elements.
-		 */
-		[`p${notSelector}`]: {
-			maxWidth: tokens.maxWidth.bodyText,
-			margin: 0,
-		},
-
-		[`* + p${notSelector}`]: {
+	[`* + ul${notSelector}, * + ol${notSelector}, * + dl${notSelector}, * + pre`]:
+		{
 			marginTop: mapSpacing(1.5),
 		},
 
-		[`ul${notSelector},ol${notSelector},dl${notSelector},pre`]: {
-			margin: 0, //reset defaults
-		},
+	[`ul${notSelector}, ol${notSelector}`]: {
+		'> li': {
+			marginTop: mapSpacing(0.5),
 
-		[`* + ul${notSelector}, * + ol${notSelector}, * + dl${notSelector}, * + pre`]:
-			{
-				marginTop: mapSpacing(1.5),
-			},
-
-		[`ul${notSelector}, ol${notSelector}`]: {
-			'> li': {
+			[`> ul${notSelector}, > ol${notSelector}`]: {
 				marginTop: mapSpacing(0.5),
-
-				[`> ul${notSelector}, > ol${notSelector}`]: {
-					marginTop: mapSpacing(0.5),
-				},
-			},
-
-			[`> ul${notSelector}`]: {
-				listStyleType: 'disc',
 			},
 		},
 
-		[`dl${notSelector}`]: {
-			'> dd': {
-				marginTop: mapSpacing(0.5),
-				paddingLeft: mapSpacing(0.5),
-				marginLeft: 0,
-				borderLeftWidth: tokens.borderWidth.sm,
-				borderLeftStyle: 'solid',
-				borderLeftColor: boxPalette.border,
-			},
-
-			'> dt': {
-				marginTop: mapSpacing(1.5),
-				fontWeight: 'bold',
-
-				'&:first-of-type': {
-					marginTop: 0,
-				},
-			},
+		[`> ul${notSelector}`]: {
+			listStyleType: 'disc',
 		},
+	},
 
-		[`h1${notSelector}`]: {
-			...fontGrid('xxl', 'heading'),
-			marginTop: 0,
-			marginBottom: 0,
-		},
-		[`h2${notSelector}`]: {
-			...fontGrid('xl', 'heading'),
-			marginTop: 0,
-			marginBottom: 0,
-		},
-		[`h3${notSelector}`]: {
-			...fontGrid('lg', 'heading'),
-			marginTop: 0,
-			marginBottom: 0,
-		},
-		[`h4${notSelector}`]: {
-			...fontGrid('md', 'heading'),
-			marginTop: 0,
-			marginBottom: 0,
-		},
-		[`h5${notSelector}`]: {
-			...fontGrid('sm', 'heading'),
-			marginTop: 0,
-			marginBottom: 0,
-		},
-		[`h6${notSelector}`]: {
-			...fontGrid('xs', 'heading'),
-			marginTop: 0,
-			marginBottom: 0,
-		},
-
-		[`* + h1${notSelector}`]: { marginTop: mapSpacing(3) },
-		[`* + h2${notSelector}`]: { marginTop: mapSpacing(3) },
-		[`* + h3${notSelector}`]: { marginTop: mapSpacing(1.5) },
-		[`* + h4${notSelector}`]: { marginTop: mapSpacing(1.5) },
-		[`* + h5${notSelector}`]: { marginTop: mapSpacing(1.5) },
-		[`* + h6${notSelector}`]: { marginTop: mapSpacing(1.5) },
-
-		// Override for sequential headings
-		[`h1 + h2${notSelector}`]: { marginTop: mapSpacing(1.5) },
-		[`h2 + h3${notSelector}`]: { marginTop: mapSpacing(1.5) },
-
-		/**
-		 * Emphasis and alt. voice/mood/diff. from prose text.
-		 */
-		'em,i': {
-			fontStyle: 'italic',
-		},
-
-		/**
-		 * Stong emphasis.
-		 */
-		'strong,b': {
-			fontWeight: 'bold',
-		},
-
-		/**
-		 * `small`: for less important information (not stylistic purposes).
-		 */
-		small: {
-			...fontGrid('xs', 'default'),
-		},
-
-		/**
-		 * `s`: represents contents no longer accurate/relevant.
-		 * del` & `ins`: editorial markup.
-		 */
-		's,del': {
-			textDecoration: 'line-through',
-		},
-
-		ins: {
-			textDecorationLine: 'underline',
-			textDecorationStyle: 'dashed', //Waiting on Chrome.
-			textDecorationSkipInk: 'auto',
-		},
-
-		/**
-		 * Defining definition of a term.
-		 *
-		 * The paragraph, description list group, or section that is the nearest
-		 * ancestor of the `dfn` element must also contain the definition(s) for the term
-		 * given by the `dfn` element.
-		 *
-		 * Note: `abbr` can be nested inside `dfn`.
-		 */
-		dfn: {
-			fontStyle: 'normal',
-		},
-
-		/**
-		 * Abbreviations/acronyms.
-		 */
-		'abbr,abbr[title]': {
-			borderBottom: 'none',
-			textDecoration: 'underline dotted',
-		},
-
-		'abbr[title]': {
-			cursor: 'help',
-		},
-
-		'a abbr': {
-			paddingBottom: 1,
-		},
-
-		/**
-		 * Variables, eg. as used in mathematical expressions.
-		 *
-		 * We also provide semantic support for nested vars, and things like indices.
-		 */
-		var: {
-			padding: '0 1px',
-			fontStyle: 'italic',
-			fontFamily: 'serif', //We want mathematical notation to use serif vars per convention.
-
-			'sup,sub': {
-				fontFamily: tokens.font.body,
-				fontStyle: 'normal',
-				padding: '0 1px',
-			},
-		},
-
-		/**
-		 * Prevent `sub` and `sup` elements from affecting the line height in
-		 * all browsers.
-		 * https://github.com/necolas/normalize.css/blob/master/normalize.css#L174
-		 */
-		'sub,sup': {
-			...fontGrid('xs', 'nospace'),
-			position: 'relative',
-			verticalAlign: 'baseline',
-		},
-
-		sub: {
-			bottom: '-0.25em',
-		},
-
-		sup: {
-			top: '-0.5em',
-		},
-
-		[`figure${notSelector}`]: {
-			marginTop: mapSpacing(1.5),
-			marginBottom: 0,
+	[`dl${notSelector}`]: {
+		'> dd': {
+			marginTop: mapSpacing(0.5),
+			paddingLeft: mapSpacing(0.5),
 			marginLeft: 0,
-			marginRight: 0,
-		},
-
-		[`blockquote${notSelector}`]: {
-			marginTop: mapSpacing(1.5),
-			marginBottom: mapSpacing(1),
-			marginLeft: 0,
-			marginRight: 0,
-			padding: mapSpacing(2),
-			borderLeftWidth: tokens.borderWidth.xl,
+			borderLeftWidth: tokens.borderWidth.sm,
 			borderLeftStyle: 'solid',
-			borderColor: boxPalette.border,
-			background: boxPalette.backgroundShade,
+			borderLeftColor: boxPalette.border,
 		},
 
-		/**
-		 * Keyboard strokes.
-		 * Code snippets and code blocks.
-		 */
-		[`kbd${notSelector},code${notSelector},samp${notSelector}`]: {
-			...fontGrid('xs', 'default'),
-			padding: mapSpacing(0.25),
-			fontFamily: tokens.font.monospace,
-			display: 'inline-block',
-			borderRadius: tokens.borderRadius,
-			backgroundColor: boxPalette.backgroundShade, // TODO: Check this did't break Docs code rendering
-			color: boxPalette.foregroundText,
-		},
-
-		'pre${notSelector}': {
-			fontFamily: tokens.font.monospace,
-		},
-
-		'pre code': {
-			display: 'block',
-			tabSize: 4,
-		},
-
-		/**
-		 * Horizontal rule, used for paragraph-level thematic breaks.
-		 */
-		[`hr${notSelector}`]: {
-			boxSizing: 'content-box',
-			height: 0,
-			overflow: 'visible',
-			border: 'none',
-			borderTopWidth: tokens.borderWidth.sm,
-			borderTopStyle: 'solid',
-			borderColor: boxPalette.border,
-			marginBottom: mapSpacing(1.5),
-		},
-
-		[`* + hr${notSelector}`]: {
+		'> dt': {
 			marginTop: mapSpacing(1.5),
-		},
+			fontWeight: 'bold',
 
-		/**
-		 * Print styles
-		 */
-		'@media print': {
-			// Display link URLs
-			[`a${notSelector}[href]:after`]: {
-				content: '" (" attr(href) ")" !important',
-			},
-			// Expand abbreviations
-			'abbr[title]:after': {
-				content: '" (" attr(title) ")"',
-			},
-			// Page breaks
-			'pre, blockquote, tr, img': {
-				pageBreakInside: 'avoid',
-			},
-			'h2, h3 ': {
-				pageBreakAfter: 'avoid',
+			'&:first-of-type': {
+				marginTop: 0,
 			},
 		},
-	});
-}
+	},
+
+	[`h1${notSelector}`]: {
+		...fontGrid('xxl', 'heading'),
+		marginTop: 0,
+		marginBottom: 0,
+	},
+	[`h2${notSelector}`]: {
+		...fontGrid('xl', 'heading'),
+		marginTop: 0,
+		marginBottom: 0,
+	},
+	[`h3${notSelector}`]: {
+		...fontGrid('lg', 'heading'),
+		marginTop: 0,
+		marginBottom: 0,
+	},
+	[`h4${notSelector}`]: {
+		...fontGrid('md', 'heading'),
+		marginTop: 0,
+		marginBottom: 0,
+	},
+	[`h5${notSelector}`]: {
+		...fontGrid('sm', 'heading'),
+		marginTop: 0,
+		marginBottom: 0,
+	},
+	[`h6${notSelector}`]: {
+		...fontGrid('xs', 'heading'),
+		marginTop: 0,
+		marginBottom: 0,
+	},
+
+	[`* + h1${notSelector}`]: { marginTop: mapSpacing(3) },
+	[`* + h2${notSelector}`]: { marginTop: mapSpacing(3) },
+	[`* + h3${notSelector}`]: { marginTop: mapSpacing(1.5) },
+	[`* + h4${notSelector}`]: { marginTop: mapSpacing(1.5) },
+	[`* + h5${notSelector}`]: { marginTop: mapSpacing(1.5) },
+	[`* + h6${notSelector}`]: { marginTop: mapSpacing(1.5) },
+
+	// Override for sequential headings
+	[`h1 + h2${notSelector}`]: { marginTop: mapSpacing(1.5) },
+	[`h2 + h3${notSelector}`]: { marginTop: mapSpacing(1.5) },
+
+	/**
+	 * Emphasis and alt. voice/mood/diff. from prose text.
+	 */
+	'em,i': {
+		fontStyle: 'italic',
+	},
+
+	/**
+	 * Stong emphasis.
+	 */
+	'strong,b': {
+		fontWeight: 'bold',
+	},
+
+	/**
+	 * `small`: for less important information (not stylistic purposes).
+	 */
+	small: {
+		...fontGrid('xs', 'default'),
+	},
+
+	/**
+	 * `s`: represents contents no longer accurate/relevant.
+	 * del` & `ins`: editorial markup.
+	 */
+	's,del': {
+		textDecoration: 'line-through',
+	},
+
+	ins: {
+		textDecorationLine: 'underline',
+		textDecorationStyle: 'dashed', //Waiting on Chrome.
+		textDecorationSkipInk: 'auto',
+	},
+
+	/**
+	 * Defining definition of a term.
+	 *
+	 * The paragraph, description list group, or section that is the nearest
+	 * ancestor of the `dfn` element must also contain the definition(s) for the term
+	 * given by the `dfn` element.
+	 *
+	 * Note: `abbr` can be nested inside `dfn`.
+	 */
+	dfn: {
+		fontStyle: 'normal',
+	},
+
+	/**
+	 * Abbreviations/acronyms.
+	 */
+	'abbr,abbr[title]': {
+		borderBottom: 'none',
+		textDecoration: 'underline dotted',
+	},
+
+	'abbr[title]': {
+		cursor: 'help',
+	},
+
+	'a abbr': {
+		paddingBottom: 1,
+	},
+
+	/**
+	 * Variables, eg. as used in mathematical expressions.
+	 *
+	 * We also provide semantic support for nested vars, and things like indices.
+	 */
+	var: {
+		padding: '0 1px',
+		fontStyle: 'italic',
+		fontFamily: 'serif', //We want mathematical notation to use serif vars per convention.
+
+		'sup,sub': {
+			fontFamily: tokens.font.body,
+			fontStyle: 'normal',
+			padding: '0 1px',
+		},
+	},
+
+	/**
+	 * Prevent `sub` and `sup` elements from affecting the line height in
+	 * all browsers.
+	 * https://github.com/necolas/normalize.css/blob/master/normalize.css#L174
+	 */
+	'sub,sup': {
+		...fontGrid('xs', 'nospace'),
+		position: 'relative',
+		verticalAlign: 'baseline',
+	},
+
+	sub: {
+		bottom: '-0.25em',
+	},
+
+	sup: {
+		top: '-0.5em',
+	},
+
+	[`figure${notSelector}`]: {
+		marginTop: mapSpacing(1.5),
+		marginBottom: 0,
+		marginLeft: 0,
+		marginRight: 0,
+	},
+
+	[`blockquote${notSelector}`]: {
+		marginTop: mapSpacing(1.5),
+		marginBottom: mapSpacing(1),
+		marginLeft: 0,
+		marginRight: 0,
+		padding: mapSpacing(2),
+		borderLeftWidth: tokens.borderWidth.xl,
+		borderLeftStyle: 'solid',
+		borderColor: boxPalette.border,
+		background: boxPalette.backgroundShade,
+	},
+
+	/**
+	 * Keyboard strokes.
+	 * Code snippets and code blocks.
+	 */
+	[`kbd${notSelector},code${notSelector},samp${notSelector}`]: {
+		...fontGrid('xs', 'default'),
+		padding: mapSpacing(0.25),
+		fontFamily: tokens.font.monospace,
+		display: 'inline-block',
+		borderRadius: tokens.borderRadius,
+		backgroundColor: boxPalette.backgroundShade, // TODO: Check this did't break Docs code rendering
+		color: boxPalette.foregroundText,
+	},
+
+	'pre${notSelector}': {
+		fontFamily: tokens.font.monospace,
+	},
+
+	'pre code': {
+		display: 'block',
+		tabSize: 4,
+	},
+
+	/**
+	 * Horizontal rule, used for paragraph-level thematic breaks.
+	 */
+	[`hr${notSelector}`]: {
+		boxSizing: 'content-box',
+		height: 0,
+		overflow: 'visible',
+		border: 'none',
+		borderTopWidth: tokens.borderWidth.sm,
+		borderTopStyle: 'solid',
+		borderColor: boxPalette.border,
+		marginBottom: mapSpacing(1.5),
+	},
+
+	[`* + hr${notSelector}`]: {
+		marginTop: mapSpacing(1.5),
+	},
+
+	/**
+	 * Print styles
+	 */
+	'@media print': {
+		// Display link URLs
+		[`a${notSelector}[href]:after`]: {
+			content: '" (" attr(href) ")" !important',
+		},
+		// Expand abbreviations
+		'abbr[title]:after': {
+			content: '" (" attr(title) ")"',
+		},
+		// Page breaks
+		'pre, blockquote, tr, img': {
+			pageBreakInside: 'avoid',
+		},
+		'h2, h3 ': {
+			pageBreakAfter: 'avoid',
+		},
+	},
+});

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -16,19 +16,28 @@ export const Body = forwardRefWithAs<'div', BoxProps>(function Body(
 	return <Box ref={ref} css={bodyClass} {...props} />;
 });
 
+// Allow consumers to exclude body styles from being inherited on specific elements
 export const excludeBodyStylesClassname = 'agds-body-reset';
 
-const notSelector = `:not([class]):not(.${excludeBodyStylesClassname})`;
+// Exclude tags which contain a class (generated from the CSS prop) or are a child of the excluded class
+const notSelector = `:not([class]):not(.${excludeBodyStylesClassname} *)`;
 
 export const bodyClass = css({
-	margin: 0,
-	textSizeAdjust: '100%',
-	color: boxPalette.foregroundText,
+	/**
+	 * Styles applied to the `Box` container
+	 */
+	[`&:not(.${excludeBodyStylesClassname} *)`]: {
+		margin: 0,
+		textSizeAdjust: '100%',
+		color: boxPalette.foregroundText,
+		// Font grid
+		fontFamily: tokens.font.body,
+		...fontGrid('sm', 'default'),
+	},
 
-	// Font grid
-	fontFamily: tokens.font.body,
-	...fontGrid('sm', 'default'),
-
+	/**
+	 * Link styles
+	 */
 	[`a${notSelector}`]: [linkStyles, focusStyles],
 
 	/**
@@ -39,7 +48,7 @@ export const bodyClass = css({
 	/**
 	 * `mark` styling.
 	 */
-	mark: {
+	[`mark${notSelector}`]: {
 		color: boxPalette.backgroundBody,
 		backgroundColor: boxPalette.foregroundAction,
 	},
@@ -52,7 +61,7 @@ export const bodyClass = css({
 		backgroundColor: boxPalette.foregroundAction,
 	},
 
-	img: {
+	[`img${notSelector}`]: {
 		maxWidth: '100%',
 	},
 
@@ -156,21 +165,21 @@ export const bodyClass = css({
 	/**
 	 * Emphasis and alt. voice/mood/diff. from prose text.
 	 */
-	'em,i': {
+	[`em${notSelector}, i${notSelector}`]: {
 		fontStyle: 'italic',
 	},
 
 	/**
 	 * Stong emphasis.
 	 */
-	'strong,b': {
+	[`strong${notSelector}, b${notSelector}`]: {
 		fontWeight: 'bold',
 	},
 
 	/**
 	 * `small`: for less important information (not stylistic purposes).
 	 */
-	small: {
+	[`small:${notSelector}`]: {
 		...fontGrid('xs', 'default'),
 	},
 
@@ -178,11 +187,11 @@ export const bodyClass = css({
 	 * `s`: represents contents no longer accurate/relevant.
 	 * del` & `ins`: editorial markup.
 	 */
-	's,del': {
+	[`s${notSelector}, del${notSelector}`]: {
 		textDecoration: 'line-through',
 	},
 
-	ins: {
+	[`ins${notSelector}`]: {
 		textDecorationLine: 'underline',
 		textDecorationStyle: 'dashed', //Waiting on Chrome.
 		textDecorationSkipInk: 'auto',
@@ -197,23 +206,23 @@ export const bodyClass = css({
 	 *
 	 * Note: `abbr` can be nested inside `dfn`.
 	 */
-	dfn: {
+	[`dfn${notSelector}`]: {
 		fontStyle: 'normal',
 	},
 
 	/**
 	 * Abbreviations/acronyms.
 	 */
-	'abbr,abbr[title]': {
+	[`abbr,abbr[title]${notSelector}`]: {
 		borderBottom: 'none',
 		textDecoration: 'underline dotted',
 	},
 
-	'abbr[title]': {
+	[`abbr[title]${notSelector}`]: {
 		cursor: 'help',
 	},
 
-	'a abbr': {
+	[`a abbr${notSelector}`]: {
 		paddingBottom: 1,
 	},
 
@@ -222,10 +231,10 @@ export const bodyClass = css({
 	 *
 	 * We also provide semantic support for nested vars, and things like indices.
 	 */
-	var: {
+	[`var${notSelector}`]: {
 		padding: '0 1px',
 		fontStyle: 'italic',
-		fontFamily: 'serif', //We want mathematical notation to use serif vars per convention.
+		fontFamily: 'serif', // We want mathematical notation to use serif vars per convention.
 
 		'sup,sub': {
 			fontFamily: tokens.font.body,
@@ -239,17 +248,17 @@ export const bodyClass = css({
 	 * all browsers.
 	 * https://github.com/necolas/normalize.css/blob/master/normalize.css#L174
 	 */
-	'sub,sup': {
+	[`sub${notSelector}, sup${notSelector}`]: {
 		...fontGrid('xs', 'nospace'),
 		position: 'relative',
 		verticalAlign: 'baseline',
 	},
 
-	sub: {
+	[`sub${notSelector}`]: {
 		bottom: '-0.25em',
 	},
 
-	sup: {
+	[`sup${notSelector}`]: {
 		top: '-0.5em',
 	},
 
@@ -276,7 +285,14 @@ export const bodyClass = css({
 	 * Keyboard strokes.
 	 * Code snippets and code blocks.
 	 */
-	[`kbd${notSelector},code${notSelector},samp${notSelector}`]: {
+
+	[`pre code${notSelector}`]: {
+		display: 'block',
+		tabSize: 4,
+		padding: mapSpacing(1),
+	},
+
+	[`kbd${notSelector}, code${notSelector}, samp${notSelector}`]: {
 		...fontGrid('xs', 'default'),
 		padding: mapSpacing(0.25),
 		fontFamily: tokens.font.monospace,
@@ -286,13 +302,8 @@ export const bodyClass = css({
 		color: boxPalette.foregroundText,
 	},
 
-	'pre${notSelector}': {
+	[`pre${notSelector}`]: {
 		fontFamily: tokens.font.monospace,
-	},
-
-	'pre code': {
-		display: 'block',
-		tabSize: 4,
 	},
 
 	/**

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -329,7 +329,7 @@ export const bodyClass = css({
 	 */
 	'@media print': {
 		// Display link URLs
-		[`a[href]:after`]: {
+		'a[href]:after': {
 			content: '" (" attr(href) ")" !important',
 		},
 		// Expand abbreviations

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -329,7 +329,7 @@ export const bodyClass = css({
 	 */
 	'@media print': {
 		// Display link URLs
-		[`a${notSelector}[href]:after`]: {
+		[`a[href]:after`]: {
 			content: '" (" attr(href) ")" !important',
 		},
 		// Expand abbreviations

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -16,17 +16,17 @@ export const Body = forwardRefWithAs<'div', BoxProps>(function Body(
 	return <Box ref={ref} css={bodyClass} {...props} />;
 });
 
-// Allow consumers to exclude body styles from being inherited on specific elements
-export const excludeBodyStylesClassname = 'agds-body-reset';
+// Allow consumers to unset body styles from being inherited on specific elements
+export const unsetBodyStylesClassname = 'unset-agds-body-styles';
 
-// Exclude tags which contain a class (generated from the CSS prop) or are a child of the excluded class
-const notSelector = `:not([class]):not(.${excludeBodyStylesClassname} *)`;
+// Exclude tags which contain a className (generated from the CSS prop) or are a child of the unset class
+const notSelector = `:not([class]):not(.${unsetBodyStylesClassname} *)`;
 
 export const bodyClass = css({
 	/**
 	 * Styles applied to the `Box` container
 	 */
-	[`&:not(.${excludeBodyStylesClassname} *)`]: {
+	[`&:not(.${unsetBodyStylesClassname} *)`]: {
 		margin: 0,
 		textSizeAdjust: '100%',
 		color: boxPalette.foregroundText,

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -5,6 +5,7 @@ import {
 	boxPalette,
 	mapSpacing,
 	fontGrid,
+	packs,
 } from '@ag.ds-next/core';
 import { Box, BoxProps, linkStyles, focusStyles } from '@ag.ds-next/box';
 
@@ -12,321 +13,323 @@ export const Body = forwardRefWithAs<'div', BoxProps>(function Body(
 	props,
 	ref
 ) {
-	return <Box ref={ref} css={bodyClass} {...props} />;
+	const styles = bodyStyles({ notSelector: ':not([class])' });
+	return <Box ref={ref} css={styles} {...props} />;
 });
 
-export const bodyClass = css({
-	margin: 0,
-	textSizeAdjust: '100%',
-	color: boxPalette.foregroundText,
-
-	// Font grid
-	fontFamily: tokens.font.body,
-	...fontGrid('sm', 'default'),
-
-	'a:not([class])': [linkStyles, focusStyles],
-
-	/**
-	 * Highlighting in-page sections that are in focus
-	 */
-	'[tabindex="0"]:focus, :target': {
-		// @include AU-outline();
-	},
-
-	/**
-	 * `mark` styling.
-	 */
-	mark: {
-		color: boxPalette.backgroundBody,
-		backgroundColor: boxPalette.foregroundAction,
-	},
-
-	/**
-	 * Text selection styling
-	 */
-	'& ::selection': {
-		color: boxPalette.backgroundBody,
-		backgroundColor: boxPalette.foregroundAction,
-	},
-
-	img: {
-		maxWidth: '100%',
-	},
-
-	/**
-	 * Vertical spacing of common text elements.
-	 */
-	'p:not([class])': {
-		maxWidth: tokens.maxWidth.bodyText,
+export function bodyStyles({ notSelector }: { notSelector: string }) {
+	return css({
 		margin: 0,
-	},
-
-	'* + p:not([class])': {
-		marginTop: mapSpacing(1.5),
-	},
-
-	'ul:not([class]),ol:not([class]),dl:not([class]),pre': {
-		margin: 0, //reset defaults
-	},
-
-	'* + ul:not([class]), * + ol:not([class]), * + dl:not([class]), * + pre': {
-		marginTop: mapSpacing(1.5),
-	},
-
-	'ul:not([class]), ol:not([class])': {
-		'> li': {
-			marginTop: mapSpacing(0.5),
-
-			'> ul:not([class]), > ol:not([class])': {
-				marginTop: mapSpacing(0.5),
-			},
-		},
-
-		'> ul:not([class])': {
-			listStyleType: 'disc',
-		},
-	},
-
-	'dl:not([class])': {
-		'> dd': {
-			marginTop: mapSpacing(0.5),
-			paddingLeft: mapSpacing(0.5),
-			marginLeft: 0,
-			borderLeftWidth: tokens.borderWidth.sm,
-			borderLeftStyle: 'solid',
-			borderLeftColor: boxPalette.border,
-		},
-
-		'> dt': {
-			marginTop: mapSpacing(1.5),
-			fontWeight: 'bold',
-
-			'&:first-of-type': {
-				marginTop: 0,
-			},
-		},
-	},
-
-	'h1:not([class])': {
-		...fontGrid('xxl', 'heading'),
-		marginTop: 0,
-		marginBottom: 0,
-	},
-	'h2:not([class])': {
-		...fontGrid('xl', 'heading'),
-		marginTop: 0,
-		marginBottom: 0,
-	},
-	'h3:not([class])': {
-		...fontGrid('lg', 'heading'),
-		marginTop: 0,
-		marginBottom: 0,
-	},
-	'h4:not([class])': {
-		...fontGrid('md', 'heading'),
-		marginTop: 0,
-		marginBottom: 0,
-	},
-	'h5:not([class])': {
-		...fontGrid('sm', 'heading'),
-		marginTop: 0,
-		marginBottom: 0,
-	},
-	'h6:not([class])': {
-		...fontGrid('xs', 'heading'),
-		marginTop: 0,
-		marginBottom: 0,
-	},
-
-	'* + h1:not([class])': { marginTop: mapSpacing(3) },
-	'* + h2:not([class])': { marginTop: mapSpacing(3) },
-	'* + h3:not([class])': { marginTop: mapSpacing(1.5) },
-	'* + h4:not([class])': { marginTop: mapSpacing(1.5) },
-	'* + h5:not([class])': { marginTop: mapSpacing(1.5) },
-	'* + h6:not([class])': { marginTop: mapSpacing(1.5) },
-
-	// Override for sequential headings
-	'h1 + h2:not([class])': { marginTop: mapSpacing(1.5) },
-	'h2 + h3:not([class])': { marginTop: mapSpacing(1.5) },
-
-	/**
-	 * Emphasis and alt. voice/mood/diff. from prose text.
-	 */
-	'em,i': {
-		fontStyle: 'italic',
-	},
-
-	/**
-	 * Stong emphasis.
-	 */
-	'strong,b': {
-		fontWeight: 'bold',
-	},
-
-	/**
-	 * `small`: for less important information (not stylistic purposes).
-	 */
-	small: {
-		...fontGrid('xs', 'default'),
-	},
-
-	/**
-	 * `s`: represents contents no longer accurate/relevant.
-	 * del` & `ins`: editorial markup.
-	 */
-	's,del': {
-		textDecoration: 'line-through',
-	},
-
-	ins: {
-		textDecorationLine: 'underline',
-		textDecorationStyle: 'dashed', //Waiting on Chrome.
-		textDecorationSkipInk: 'auto',
-	},
-
-	/**
-	 * Defining definition of a term.
-	 *
-	 * The paragraph, description list group, or section that is the nearest
-	 * ancestor of the `dfn` element must also contain the definition(s) for the term
-	 * given by the `dfn` element.
-	 *
-	 * Note: `abbr` can be nested inside `dfn`.
-	 */
-	dfn: {
-		fontStyle: 'normal',
-	},
-
-	/**
-	 * Abbreviations/acronyms.
-	 */
-	'abbr,abbr[title]': {
-		borderBottom: 'none',
-		textDecoration: 'underline dotted',
-	},
-
-	'abbr[title]': {
-		cursor: 'help',
-	},
-
-	'a abbr': {
-		paddingBottom: 1,
-	},
-
-	/**
-	 * Variables, eg. as used in mathematical expressions.
-	 *
-	 * We also provide semantic support for nested vars, and things like indices.
-	 */
-	var: {
-		padding: '0 1px',
-		fontStyle: 'italic',
-		fontFamily: 'serif', //We want mathematical notation to use serif vars per convention.
-
-		'sup,sub': {
-			fontFamily: tokens.font.body,
-			fontStyle: 'normal',
-			padding: '0 1px',
-		},
-	},
-
-	/**
-	 * Prevent `sub` and `sup` elements from affecting the line height in
-	 * all browsers.
-	 * https://github.com/necolas/normalize.css/blob/master/normalize.css#L174
-	 */
-	'sub,sup': {
-		...fontGrid('xs', 'nospace'),
-		position: 'relative',
-		verticalAlign: 'baseline',
-	},
-
-	sub: {
-		bottom: '-0.25em',
-	},
-
-	sup: {
-		top: '-0.5em',
-	},
-
-	'figure:not([class])': {
-		marginTop: mapSpacing(1.5),
-		marginBottom: 0,
-		marginLeft: 0,
-		marginRight: 0,
-	},
-
-	'blockquote:not([class])': {
-		marginTop: mapSpacing(1.5),
-		marginBottom: mapSpacing(1),
-		marginLeft: 0,
-		marginRight: 0,
-		padding: mapSpacing(2),
-		borderLeftWidth: tokens.borderWidth.xl,
-		borderLeftStyle: 'solid',
-		borderColor: boxPalette.border,
-		background: boxPalette.backgroundShade,
-	},
-
-	/**
-	 * Keyboard strokes.
-	 * Code snippets and code blocks.
-	 */
-	'kbd:not([class]),code:not([class]),samp:not([class])': {
-		...fontGrid('xs', 'default'),
-		padding: mapSpacing(0.25),
-		fontFamily: tokens.font.monospace,
-		display: 'inline-block',
-		borderRadius: tokens.borderRadius,
-		backgroundColor: boxPalette.backgroundShade, // TODO: Check this did't break Docs code rendering
+		textSizeAdjust: '100%',
 		color: boxPalette.foregroundText,
-	},
 
-	'pre:not([class])': {
-		fontFamily: tokens.font.monospace,
-	},
+		// Font grid
+		fontFamily: tokens.font.body,
+		...fontGrid('sm', 'default'),
 
-	'pre code': {
-		display: 'block',
-		tabSize: 4,
-	},
+		[`a${notSelector}`]: [linkStyles, focusStyles],
 
-	/**
-	 * Horizontal rule, used for paragraph-level thematic breaks.
-	 */
-	'hr:not([class])': {
-		boxSizing: 'content-box',
-		height: 0,
-		overflow: 'visible',
-		border: 'none',
-		borderTopWidth: tokens.borderWidth.sm,
-		borderTopStyle: 'solid',
-		borderColor: boxPalette.border,
-		marginBottom: mapSpacing(1.5),
-	},
+		/**
+		 * Highlighting in-page sections that are in focus
+		 */
+		'[tabindex="0"]:focus, :target': packs.outline,
 
-	'* + hr:not([class])': {
-		marginTop: mapSpacing(1.5),
-	},
-
-	/**
-	 * Print styles
-	 */
-	'@media print': {
-		// Display link URLs
-		'a:not([class])[href]:after': {
-			content: '" (" attr(href) ")" !important',
+		/**
+		 * `mark` styling.
+		 */
+		mark: {
+			color: boxPalette.backgroundBody,
+			backgroundColor: boxPalette.foregroundAction,
 		},
-		// Expand abbreviations
-		'abbr[title]:after': {
-			content: '" (" attr(title) ")"',
+
+		/**
+		 * Text selection styling
+		 */
+		'& ::selection': {
+			color: boxPalette.backgroundBody,
+			backgroundColor: boxPalette.foregroundAction,
 		},
-		// Page breaks
-		'pre, blockquote, tr, img': {
-			pageBreakInside: 'avoid',
+
+		img: {
+			maxWidth: '100%',
 		},
-		'h2, h3 ': {
-			pageBreakAfter: 'avoid',
+
+		/**
+		 * Vertical spacing of common text elements.
+		 */
+		[`p${notSelector}`]: {
+			maxWidth: tokens.maxWidth.bodyText,
+			margin: 0,
 		},
-	},
-});
+
+		[`* + p${notSelector}`]: {
+			marginTop: mapSpacing(1.5),
+		},
+
+		[`ul${notSelector},ol${notSelector},dl${notSelector},pre`]: {
+			margin: 0, //reset defaults
+		},
+
+		[`* + ul${notSelector}, * + ol${notSelector}, * + dl${notSelector}, * + pre`]:
+			{
+				marginTop: mapSpacing(1.5),
+			},
+
+		[`ul${notSelector}, ol${notSelector}`]: {
+			'> li': {
+				marginTop: mapSpacing(0.5),
+
+				[`> ul${notSelector}, > ol${notSelector}`]: {
+					marginTop: mapSpacing(0.5),
+				},
+			},
+
+			[`> ul${notSelector}`]: {
+				listStyleType: 'disc',
+			},
+		},
+
+		[`dl${notSelector}`]: {
+			'> dd': {
+				marginTop: mapSpacing(0.5),
+				paddingLeft: mapSpacing(0.5),
+				marginLeft: 0,
+				borderLeftWidth: tokens.borderWidth.sm,
+				borderLeftStyle: 'solid',
+				borderLeftColor: boxPalette.border,
+			},
+
+			'> dt': {
+				marginTop: mapSpacing(1.5),
+				fontWeight: 'bold',
+
+				'&:first-of-type': {
+					marginTop: 0,
+				},
+			},
+		},
+
+		[`h1${notSelector}`]: {
+			...fontGrid('xxl', 'heading'),
+			marginTop: 0,
+			marginBottom: 0,
+		},
+		[`h2${notSelector}`]: {
+			...fontGrid('xl', 'heading'),
+			marginTop: 0,
+			marginBottom: 0,
+		},
+		[`h3${notSelector}`]: {
+			...fontGrid('lg', 'heading'),
+			marginTop: 0,
+			marginBottom: 0,
+		},
+		[`h4${notSelector}`]: {
+			...fontGrid('md', 'heading'),
+			marginTop: 0,
+			marginBottom: 0,
+		},
+		[`h5${notSelector}`]: {
+			...fontGrid('sm', 'heading'),
+			marginTop: 0,
+			marginBottom: 0,
+		},
+		[`h6${notSelector}`]: {
+			...fontGrid('xs', 'heading'),
+			marginTop: 0,
+			marginBottom: 0,
+		},
+
+		[`* + h1${notSelector}`]: { marginTop: mapSpacing(3) },
+		[`* + h2${notSelector}`]: { marginTop: mapSpacing(3) },
+		[`* + h3${notSelector}`]: { marginTop: mapSpacing(1.5) },
+		[`* + h4${notSelector}`]: { marginTop: mapSpacing(1.5) },
+		[`* + h5${notSelector}`]: { marginTop: mapSpacing(1.5) },
+		[`* + h6${notSelector}`]: { marginTop: mapSpacing(1.5) },
+
+		// Override for sequential headings
+		[`h1 + h2${notSelector}`]: { marginTop: mapSpacing(1.5) },
+		[`h2 + h3${notSelector}`]: { marginTop: mapSpacing(1.5) },
+
+		/**
+		 * Emphasis and alt. voice/mood/diff. from prose text.
+		 */
+		'em,i': {
+			fontStyle: 'italic',
+		},
+
+		/**
+		 * Stong emphasis.
+		 */
+		'strong,b': {
+			fontWeight: 'bold',
+		},
+
+		/**
+		 * `small`: for less important information (not stylistic purposes).
+		 */
+		small: {
+			...fontGrid('xs', 'default'),
+		},
+
+		/**
+		 * `s`: represents contents no longer accurate/relevant.
+		 * del` & `ins`: editorial markup.
+		 */
+		's,del': {
+			textDecoration: 'line-through',
+		},
+
+		ins: {
+			textDecorationLine: 'underline',
+			textDecorationStyle: 'dashed', //Waiting on Chrome.
+			textDecorationSkipInk: 'auto',
+		},
+
+		/**
+		 * Defining definition of a term.
+		 *
+		 * The paragraph, description list group, or section that is the nearest
+		 * ancestor of the `dfn` element must also contain the definition(s) for the term
+		 * given by the `dfn` element.
+		 *
+		 * Note: `abbr` can be nested inside `dfn`.
+		 */
+		dfn: {
+			fontStyle: 'normal',
+		},
+
+		/**
+		 * Abbreviations/acronyms.
+		 */
+		'abbr,abbr[title]': {
+			borderBottom: 'none',
+			textDecoration: 'underline dotted',
+		},
+
+		'abbr[title]': {
+			cursor: 'help',
+		},
+
+		'a abbr': {
+			paddingBottom: 1,
+		},
+
+		/**
+		 * Variables, eg. as used in mathematical expressions.
+		 *
+		 * We also provide semantic support for nested vars, and things like indices.
+		 */
+		var: {
+			padding: '0 1px',
+			fontStyle: 'italic',
+			fontFamily: 'serif', //We want mathematical notation to use serif vars per convention.
+
+			'sup,sub': {
+				fontFamily: tokens.font.body,
+				fontStyle: 'normal',
+				padding: '0 1px',
+			},
+		},
+
+		/**
+		 * Prevent `sub` and `sup` elements from affecting the line height in
+		 * all browsers.
+		 * https://github.com/necolas/normalize.css/blob/master/normalize.css#L174
+		 */
+		'sub,sup': {
+			...fontGrid('xs', 'nospace'),
+			position: 'relative',
+			verticalAlign: 'baseline',
+		},
+
+		sub: {
+			bottom: '-0.25em',
+		},
+
+		sup: {
+			top: '-0.5em',
+		},
+
+		[`figure${notSelector}`]: {
+			marginTop: mapSpacing(1.5),
+			marginBottom: 0,
+			marginLeft: 0,
+			marginRight: 0,
+		},
+
+		[`blockquote${notSelector}`]: {
+			marginTop: mapSpacing(1.5),
+			marginBottom: mapSpacing(1),
+			marginLeft: 0,
+			marginRight: 0,
+			padding: mapSpacing(2),
+			borderLeftWidth: tokens.borderWidth.xl,
+			borderLeftStyle: 'solid',
+			borderColor: boxPalette.border,
+			background: boxPalette.backgroundShade,
+		},
+
+		/**
+		 * Keyboard strokes.
+		 * Code snippets and code blocks.
+		 */
+		[`kbd${notSelector},code${notSelector},samp${notSelector}`]: {
+			...fontGrid('xs', 'default'),
+			padding: mapSpacing(0.25),
+			fontFamily: tokens.font.monospace,
+			display: 'inline-block',
+			borderRadius: tokens.borderRadius,
+			backgroundColor: boxPalette.backgroundShade, // TODO: Check this did't break Docs code rendering
+			color: boxPalette.foregroundText,
+		},
+
+		'pre${notSelector}': {
+			fontFamily: tokens.font.monospace,
+		},
+
+		'pre code': {
+			display: 'block',
+			tabSize: 4,
+		},
+
+		/**
+		 * Horizontal rule, used for paragraph-level thematic breaks.
+		 */
+		[`hr${notSelector}`]: {
+			boxSizing: 'content-box',
+			height: 0,
+			overflow: 'visible',
+			border: 'none',
+			borderTopWidth: tokens.borderWidth.sm,
+			borderTopStyle: 'solid',
+			borderColor: boxPalette.border,
+			marginBottom: mapSpacing(1.5),
+		},
+
+		[`* + hr${notSelector}`]: {
+			marginTop: mapSpacing(1.5),
+		},
+
+		/**
+		 * Print styles
+		 */
+		'@media print': {
+			// Display link URLs
+			[`a${notSelector}[href]:after`]: {
+				content: '" (" attr(href) ")" !important',
+			},
+			// Expand abbreviations
+			'abbr[title]:after': {
+				content: '" (" attr(title) ")"',
+			},
+			// Page breaks
+			'pre, blockquote, tr, img': {
+				pageBreakInside: 'avoid',
+			},
+			'h2, h3 ': {
+				pageBreakAfter: 'avoid',
+			},
+		},
+	});
+}


### PR DESCRIPTION
## Describe your changes

At the moment all MDX content on our component pages (i.e https://steelthreads.github.io/agds-next/packages/navigation/main-nav) is wrapped a `Body` component which provides default styles to all child HTML elements. 

This works well, but is causing issue in our live code previews as unwanted body styles are being inherited. This PR fixes this by having a configurable `notSelector`, so the documentation can unset body styles for live code examples.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file