### PR TITLE
Breadcrumbs: Update size of `BreadcrumbsDivider`

### DIFF
--- a/.changeset/hot-pugs-remain.md
+++ b/.changeset/hot-pugs-remain.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+---
+
+Updated size of `BreadcrumbsDivider`

--- a/packages/breadcrumbs/src/BreadcrumbsDivider.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsDivider.tsx
@@ -1,5 +1,9 @@
 import { ChevronRightIcon } from '@ag.ds-next/icon';
 
 export const BreadcrumbsDivider = () => (
-	<ChevronRightIcon size="sm" color="border" css={{ flexShrink: 0 }} />
+	<ChevronRightIcon
+		color="border"
+		weight="bold"
+		css={{ flexShrink: 0, width: 10, height: 10 }}
+	/>
 );


### PR DESCRIPTION
## Describe your changes

Updated size from `16px` to `10px` as per design feedback. We have decided not to add this new size to the design system `Icon` component, but instead just inline this size for now.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file