### PR TITLE
Modal: Fix bug with Voiceover. ModalTitle is auto-focused

### DIFF
--- a/.changeset/gold-bears-invent.md
+++ b/.changeset/gold-bears-invent.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/modal': minor
+---
+
+Fix bug with screenreaders. ModalTitle is now auto-focused

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -19,7 +19,7 @@ export const Basic = () => {
 			<Modal
 				isOpen={isModalOpen}
 				onDismiss={closeModal}
-				title="Modal title"
+				title="This is the title of the modal dialogue, it can span lines but should not be too long."
 				actions={
 					<ModalButtonGroup>
 						<Button onClick={closeModal}>Primary button</Button>

--- a/packages/modal/src/Modal.stories.tsx
+++ b/packages/modal/src/Modal.stories.tsx
@@ -19,7 +19,7 @@ export const Basic = () => {
 			<Modal
 				isOpen={isModalOpen}
 				onDismiss={closeModal}
-				title="This is the title of the modal dialogue, it can span lines but should not be too long."
+				title="Modal title"
 				actions={
 					<ModalButtonGroup>
 						<Button onClick={closeModal}>Primary button</Button>

--- a/packages/modal/src/ModalButtonGroup.tsx
+++ b/packages/modal/src/ModalButtonGroup.tsx
@@ -8,6 +8,7 @@ export const ModalButtonGroup = ({ children }: ModalButtonGroupProps) => {
 		<Stack
 			gap={0.5}
 			flexDirection={{ xs: 'column', sm: 'row' }}
+			paddingTop={1}
 			css={{
 				marginTop: 'auto',
 			}}

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -57,7 +57,7 @@ export const ModalPanel = ({
 			>
 				<ModalTitle id={titleId}>{title}</ModalTitle>
 				<Box>{children}</Box>
-				{actions ? <Box paddingTop={1}>{actions}</Box> : null}
+				{actions}
 
 				<Button
 					variant="tertiary"

--- a/packages/modal/src/ModalPanel.tsx
+++ b/packages/modal/src/ModalPanel.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren, ReactNode } from 'react';
 import FocusLock from 'react-focus-lock';
 import { animated, useSpring } from '@react-spring/web';
-import { Flex, Stack } from '@ag.ds-next/box';
+import { Box, Stack } from '@ag.ds-next/box';
 import { usePrefersReducedMotion, mapSpacing, tokens } from '@ag.ds-next/core';
 import { CloseIcon } from '@ag.ds-next/icon';
 import { Button } from '@ag.ds-next/button';
@@ -36,8 +36,6 @@ export const ModalPanel = ({
 			<AnimatedStack
 				role="dialog"
 				aria-modal="true"
-				tabIndex={-1}
-				data-autofocus
 				background="body"
 				aria-labelledby={titleId}
 				rounded
@@ -58,10 +56,8 @@ export const ModalPanel = ({
 				style={animationStyles}
 			>
 				<ModalTitle id={titleId}>{title}</ModalTitle>
-				<Flex gap={2} flexGrow={1} flexDirection="column">
-					{children}
-					{actions}
-				</Flex>
+				<Box>{children}</Box>
+				{actions ? <Box paddingTop={1}>{actions}</Box> : null}
 
 				<Button
 					variant="tertiary"

--- a/packages/modal/src/ModalTitle.tsx
+++ b/packages/modal/src/ModalTitle.tsx
@@ -5,7 +5,16 @@ export type ModalTitleProps = { children: ReactNode; id?: string };
 
 export const ModalTitle = ({ children, id }: ModalTitleProps) => {
 	return (
-		<Text as="h2" fontSize="lg" fontWeight="bold" lineHeight="heading" id={id}>
+		<Text
+			as="h2"
+			fontSize="lg"
+			fontWeight="bold"
+			lineHeight="heading"
+			id={id}
+			data-autofocus
+			focus
+			tabIndex={-1}
+		>
 			{children}
 		</Text>
 	);


### PR DESCRIPTION
There have been some bugs while testing VoiceOver with Safari and Chrome, which stop a user from being able to navigate the contents of the modal. We found the issue was due to the ModalPanel being focused. Shifting focus to the ModalTitle instead seems to have solved the problem.

## Checklist

- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file