### PR TITLE
Breadcrumbs: Improve center alignment of breadcrumbs

### DIFF
--- a/.changeset/witty-penguins-itch.md
+++ b/.changeset/witty-penguins-itch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+---
+
+Improve center aligninment of breadcrumbs

--- a/.changeset/witty-penguins-itch.md
+++ b/.changeset/witty-penguins-itch.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/breadcrumbs': patch
 ---
 
-Improve center aligninment of breadcrumbs
+Improve center alignment of breadcrumbs

--- a/packages/breadcrumbs/src/BreadcrumbsDivider.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsDivider.tsx
@@ -4,6 +4,14 @@ export const BreadcrumbsDivider = () => (
 	<ChevronRightIcon
 		color="border"
 		weight="bold"
-		css={{ flexShrink: 0, width: 10, height: 10 }}
+		css={{
+			flexShrink: 0,
+			// We are using a custom size here which should be avoided in most cases. Instead, use the `size` prop
+			width: 10,
+			height: 10,
+			// Ensure this aligns nicely the line height of `BreadcrumbsItem`
+			position: 'relative',
+			top: 1,
+		}}
 	/>
 );


### PR DESCRIPTION
## Describe your changes

Currently the `BreadcrumbsDivider` and `BreadcrumbsItem` are slightly misaligned due to the line height of our links and the bounding box of the chevron icon. We can fix this by nudging the divider icon down by 1px.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file