### PR TITLE
MainNav: Add aria labels to MainNav buttons

### DIFF
--- a/.changeset/twenty-ravens-exercise.md
+++ b/.changeset/twenty-ravens-exercise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/main-nav': minor
+---
+
+Add aria labels to MainNav buttons

--- a/packages/main-nav/src/MenuButtons.tsx
+++ b/packages/main-nav/src/MenuButtons.tsx
@@ -4,11 +4,11 @@ import { boxPalette } from '@ag.ds-next/core';
 
 import { localPalette } from './utils';
 
-export type MenuButtonProps = PropsWithChildren<{
+export type MainNavButtonProps = PropsWithChildren<{
 	onClick: MouseEventHandler<HTMLButtonElement>;
 }>;
 
-function MenuButton({ onClick, children }: MenuButtonProps) {
+function MainNavButton({ onClick, children, ...props }: MainNavButtonProps) {
 	return (
 		<Box paddingBottom={0.5} display={{ xs: 'block', lg: 'none' }}>
 			<Flex
@@ -34,6 +34,7 @@ function MenuButton({ onClick, children }: MenuButtonProps) {
 					},
 				}}
 				onClick={onClick}
+				{...props}
 			>
 				{children}
 			</Flex>
@@ -41,9 +42,14 @@ function MenuButton({ onClick, children }: MenuButtonProps) {
 	);
 }
 
-export function ToggleButton({ onClick }: MenuButtonProps) {
+export function OpenButton({ onClick }: MainNavButtonProps) {
 	return (
-		<MenuButton onClick={onClick}>
+		<MainNavButton
+			onClick={onClick}
+			aria-controls="main-nav-dialog"
+			aria-expanded="false"
+			aria-label="Open main navigation"
+		>
 			<svg
 				width="24"
 				height="24"
@@ -57,20 +63,27 @@ export function ToggleButton({ onClick }: MenuButtonProps) {
 				<rect x="4" y="11" width="16" height="2" />
 				<rect x="4" y="6" width="16" height="2" />
 			</svg>
-			<span>Menu</span>
-		</MenuButton>
+			Menu
+		</MainNavButton>
 	);
 }
 
-export function CloseButton({ onClick }: MenuButtonProps) {
+export function CloseButton({ onClick }: MainNavButtonProps) {
 	return (
-		<MenuButton onClick={onClick}>
+		<MainNavButton
+			onClick={onClick}
+			aria-controls="main-nav-dialog"
+			aria-expanded="true"
+			aria-label="Close main navigation"
+		>
 			<svg
 				width="24"
 				height="24"
 				viewBox="0 0 24 24"
 				fill="currentcolor"
 				xmlns="http://www.w3.org/2000/svg"
+				aria-hidden="true"
+				focusable="false"
 			>
 				<rect
 					x="6"
@@ -87,7 +100,7 @@ export function CloseButton({ onClick }: MenuButtonProps) {
 					transform="rotate(45 7.41406 6)"
 				/>
 			</svg>
-			<span>Close</span>
-		</MenuButton>
+			Close
+		</MainNavButton>
 	);
 }

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -13,7 +13,7 @@ import {
 } from '@ag.ds-next/core';
 
 import { localPalette, localPaletteVars } from './utils';
-import { CloseButton, ToggleButton } from './MenuButtons';
+import { CloseButton, OpenButton } from './MenuButtons';
 import { NavListLink } from './NavList';
 
 const variantMap = {
@@ -103,12 +103,13 @@ export function NavContainer({
 					width="100%"
 					paddingX={{ xs: 0.75, lg: 2 }}
 				>
-					{links && links.length > 0 ? <ToggleButton onClick={open} /> : null}
+					{links && links.length > 0 ? <OpenButton onClick={open} /> : null}
 					<FocusLock returnFocus disabled={!menuVisiblyOpen}>
 						<div
 							role={menuVisiblyOpen ? 'dialog' : 'none'}
 							aria-label="Main navigation"
 							aria-modal={menuVisiblyOpen ? 'true' : 'false'}
+							id="main-nav-dialog"
 							css={{
 								[tokens.mediaQuery.max.md]: {
 									zIndex: 200,


### PR DESCRIPTION
## Describe your changes

Adding enhancements to the open/close buttons in the MainNav, to improve how the screen reader reads out the page.

**Open button**
Before: "Menu, button, main, navigation"
After: "Open main navigation, collapsed, button, main, navigation"

**Close button**
Before:"Close, button, group, main navigation, dialog"
After: "Close main navigation, expanded, button, main navigation, dialog."

## Checklist

- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
