### PR TITLE
Core: Update control border size

### DIFF
--- a/.changeset/cyan-meals-dress.md
+++ b/.changeset/cyan-meals-dress.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/core': minor
+---
+
+Increased control (checkboxes, radio buttons) border widths from `2px` to `3px`

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -8,12 +8,12 @@ const control = {
 	sm: {
 		width: mapSpacing(1.5),
 		height: mapSpacing(1.5),
-		borderWidth: tokens.borderWidth.md,
+		borderWidth: tokens.borderWidth.lg,
 	},
 	md: {
 		width: mapSpacing(2),
 		height: mapSpacing(2),
-		borderWidth: tokens.borderWidth.md,
+		borderWidth: tokens.borderWidth.lg,
 	},
 };
 


### PR DESCRIPTION
## Describe your changes

Increased control (checkboxes, radio buttons) border widths from `2px` to `3px`.

## Checklist

- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file