### PR TITLE
secondary-nav: Updating wrapping behaviour 

### DIFF
--- a/.changeset/red-phones-end.md
+++ b/.changeset/red-phones-end.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/secondary-nav': minor
+---
+
+Updating wrapping behaviour

--- a/packages/secondary-nav/src/SecondaryNav.stories.tsx
+++ b/packages/secondary-nav/src/SecondaryNav.stories.tsx
@@ -44,22 +44,3 @@ DarkAltVariant.args = {
 	activePath: '#code',
 	links: exampleLinks,
 };
-
-export const Overflow = Template.bind({});
-Overflow.args = {
-	activePath: '#accessibility',
-	links: [
-		{ href: '#', label: 'Usage' },
-		{ href: '#', label: 'Code' },
-		{ href: '#', label: 'Content' },
-		{ href: '#accessibility', label: 'Accessibility' },
-		{ href: '#', label: 'Usage' },
-		{ href: '#', label: 'Code' },
-		{ href: '#', label: 'Content' },
-		{ href: '', label: 'Accessibility' },
-		{ href: '#', label: 'Usage' },
-		{ href: '#', label: 'Code' },
-		{ href: '#', label: 'Content' },
-		{ href: '', label: 'Accessibility' },
-	],
-};

--- a/packages/secondary-nav/src/SecondaryNavContainer.tsx
+++ b/packages/secondary-nav/src/SecondaryNavContainer.tsx
@@ -54,7 +54,6 @@ export function SecondaryNavContainer({
 			aria-label={ariaLabel}
 			css={{
 				position: 'relative',
-				overflowX: 'auto',
 				[localPaletteVars.linkHoverBg]: backgroundColorMap[hover],
 				[localPaletteVars.bottomBar]: bottomBar,
 				...packs.print.hidden,

--- a/packages/secondary-nav/src/SecondaryNavList.tsx
+++ b/packages/secondary-nav/src/SecondaryNavList.tsx
@@ -19,6 +19,7 @@ export function SecondaryNavList({ links, activePath }: SecondaryNavListProps) {
 		<Flex
 			as="ul"
 			flexDirection={['column', 'row']}
+			flexWrap="wrap"
 			css={{ position: 'relative', zIndex: 1 }}
 		>
 			{links.map(({ href, label, ...props }, index) => {


### PR DESCRIPTION
## Describe your changes

This PR replaces horizontal scrolling with flex wrapping, as discussed with the design team.

Screenshot

<img width="797" alt="Screen Shot 2022-05-18 at 3 46 23 pm" src="https://user-images.githubusercontent.com/6265154/168966487-b6bbd696-0b51-42ea-a0f6-1fe4ecc5c89e.png">


## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file