### PR TITLE
Breadcumbs: Read out 'current page' in active item

### DIFF
--- a/.changeset/neat-kings-learn.md
+++ b/.changeset/neat-kings-learn.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+---
+
+Read out 'current page' for active item

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -5,6 +5,7 @@
 	"module": "dist/ag.ds-next-breadcrumbs.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
+		"@ag.ds-next/a11y": "1.0.2",
 		"@ag.ds-next/box": "5.0.0",
 		"@ag.ds-next/core": "2.2.0",
 		"@ag.ds-next/icon": "7.0.0",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -14,6 +14,7 @@
 		"react": "^16.14.0 || ^17.0.0"
 	},
 	"devDependencies": {
+		"@ag.ds-next/a11y": "*",
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/core": "*",
 		"@ag.ds-next/icon": "*",

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -20,7 +20,7 @@ export const Breadcrumbs = ({
 				<BreadcrumbsItem {...props}>
 					{label}
 					{index === links.length - 1 ? (
-						<VisuallyHidden>(Current page)</VisuallyHidden>
+						<VisuallyHidden>{' (Current page)'}</VisuallyHidden>
 					) : null}
 				</BreadcrumbsItem>
 			</Fragment>

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -20,7 +20,7 @@ export const Breadcrumbs = ({
 				<BreadcrumbsItem {...props}>
 					{label}
 					{index === links.length - 1 ? (
-						<VisuallyHidden>{' '}(current page)</VisuallyHidden>
+						<VisuallyHidden> (current page)</VisuallyHidden>
 					) : null}
 				</BreadcrumbsItem>
 			</Fragment>

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { Fragment, ReactNode } from 'react';
+import { VisuallyHidden } from '@ag.ds-next/a11y';
 import { BreadcrumbsDivider } from './BreadcrumbsDivider';
 import { BreadcrumbsContainer } from './BreadcrumbsContainer';
 import { BreadcrumbsItem, BreadcrumbsItemProps } from './BreadcrumbsItem';
@@ -16,7 +17,12 @@ export const Breadcrumbs = ({
 		{links.map(({ label, ...props }, index) => (
 			<Fragment key={index}>
 				{index == 0 ? null : <BreadcrumbsDivider />}
-				<BreadcrumbsItem {...props}>{label}</BreadcrumbsItem>
+				<BreadcrumbsItem {...props}>
+					{label}
+					{index === links.length - 1 ? (
+						<VisuallyHidden>(Current page)</VisuallyHidden>
+					) : null}
+				</BreadcrumbsItem>
 			</Fragment>
 		))}
 	</BreadcrumbsContainer>

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -20,7 +20,7 @@ export const Breadcrumbs = ({
 				<BreadcrumbsItem {...props}>
 					{label}
 					{index === links.length - 1 ? (
-						<VisuallyHidden>{' (Current page)'}</VisuallyHidden>
+						<VisuallyHidden>{' '}(current page)</VisuallyHidden>
 					) : null}
 				</BreadcrumbsItem>
 			</Fragment>


### PR DESCRIPTION
## Describe your changes

In Voiceover, the active page will be read out as 'Page title (current page)', thanks to our VisuallyHidden component

## Checklist

- [X] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
