### PR TITLE
Text: Create TextLinkExternal and ExternalLinkCallout

### DIFF
--- a/.changeset/lemon-planes-report.md
+++ b/.changeset/lemon-planes-report.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/a11y': major
+'@ag.ds-next/a11y': minor
 ---
 
 Create ExternalLinkCallout component

--- a/.changeset/lemon-planes-report.md
+++ b/.changeset/lemon-planes-report.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/a11y': major
+---
+
+Create ExternalLinkCallout component

--- a/.changeset/three-bees-listen.md
+++ b/.changeset/three-bees-listen.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text': major
+---
+
+Create TextLinkExternal component

--- a/.changeset/three-bees-listen.md
+++ b/.changeset/three-bees-listen.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/text': major
+'@ag.ds-next/text': minor
 ---
 
 Create TextLinkExternal component

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -12,6 +12,7 @@ import { Language } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
 import { useId } from '@reach/auto-id';
 
+import { ExternalLinkCallout } from '@ag.ds-next/a11y';
 import {
 	globalPalette,
 	mapSpacing,
@@ -141,6 +142,7 @@ const LiveCode = withLive((props: unknown) => {
 					aria-label="Open code snippet in Playroom"
 				>
 					Open in Playroom
+					<ExternalLinkCallout />
 				</ButtonLink>
 			</Flex>
 			<Box

--- a/docs/components/EditPage.tsx
+++ b/docs/components/EditPage.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@ag.ds-next/box';
+import { TextLinkExternal } from '@ag.ds-next/text';
 
 const ORG = 'steelthreads';
 const REPO = 'agds-next';
@@ -6,18 +6,10 @@ const BRANCH = 'main';
 
 export function EditPage({ path = '' }) {
 	return (
-		<Box
-			as="a"
-			display="inline-block"
+		<TextLinkExternal
 			href={`https://github.com/${ORG}/${REPO}/edit/${BRANCH}${path}`}
-			target="_blank"
-			rel="noopener noreferrer"
-			color="action"
-			fontSize="sm"
-			fontFamily="body"
-			focus
 		>
 			Edit this page
-		</Box>
+		</TextLinkExternal>
 	);
 }

--- a/docs/components/SiteHeader.tsx
+++ b/docs/components/SiteHeader.tsx
@@ -4,6 +4,7 @@ import { Stack } from '@ag.ds-next/box';
 import { Header } from '@ag.ds-next/header';
 import { MainNav, MainNavLink } from '@ag.ds-next/main-nav';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
+import { ExternalLinkCallout } from '@ag.ds-next/a11y';
 
 const NAV_LINKS = [
 	{ label: 'Home', href: '/' },
@@ -32,7 +33,12 @@ export const SiteHeader = () => {
 				activePath={router.asPath}
 				rightContent={
 					<MainNavLink
-						label="GitHub"
+						label={
+							<>
+								GitHub
+								<ExternalLinkCallout />
+							</>
+						}
 						href="https://github.com/steelthreads/agds-next"
 						target="_blank"
 						rel="noopener noeferrer"

--- a/docs/components/design-system-components.tsx
+++ b/docs/components/design-system-components.tsx
@@ -8,7 +8,7 @@ import { Button, ButtonLink } from '@ag.ds-next/button';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Body, unsetBodyStylesClassname } from '@ag.ds-next/body';
 import { useTernaryState, tokens } from '@ag.ds-next/core';
-import { Text, TextLink } from '@ag.ds-next/text';
+import { Text, TextLink, TextLinkExternal } from '@ag.ds-next/text';
 import { Heading, H1, H2, H3, H4, H5, H6 } from '@ag.ds-next/heading';
 import { LinkList } from '@ag.ds-next/link-list';
 import { Breadcrumbs } from '@ag.ds-next/breadcrumbs';
@@ -82,7 +82,7 @@ import {
 	SearchBoxButton,
 } from '@ag.ds-next/search-box';
 import { Select } from '@ag.ds-next/select';
-import { VisuallyHidden } from '@ag.ds-next/a11y';
+import { ExternalLinkCallout, VisuallyHidden } from '@ag.ds-next/a11y';
 import { ProgressIndicator } from '@ag.ds-next/progress-indicator';
 import { Checkbox, Radio, ControlGroup } from '@ag.ds-next/control-input';
 import { KeywordList } from '@ag.ds-next/keyword-list';
@@ -133,6 +133,7 @@ export const designSystemComponents = {
 	TableHead,
 	Text,
 	TextLink,
+	TextLinkExternal,
 	Heading,
 	H1,
 	H2,
@@ -189,6 +190,7 @@ export const designSystemComponents = {
 	SearchBoxButton,
 	Select,
 	VisuallyHidden,
+	ExternalLinkCallout,
 	ProgressIndicator,
 	Checkbox,
 	Radio,

--- a/docs/components/utils.tsx
+++ b/docs/components/utils.tsx
@@ -8,13 +8,13 @@ export const mdxComponents = {
 	pre: Fragment,
 	code: Code,
 	Fragment,
-	a: (props: AnchorHTMLAttributes<HTMLAnchorElement>) => {
-		if (!props.href) return <a {...props} />;
+	a: ({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+		if (!href) return <a {...props} />;
 
 		// Render an external link icon and open page in new tab
-		if (props.href && /^(https?:\/\/|\/\/)/i.test(props.href)) {
-			return <TextLinkExternal {...props} />;
+		if (/^(https?:\/\/|\/\/)/i.test(href)) {
+			return <TextLinkExternal href={href} {...props} />;
 		}
-		return <Link {...props} />;
+		return <Link href={href} {...props} />;
 	},
 };

--- a/docs/components/utils.tsx
+++ b/docs/components/utils.tsx
@@ -1,5 +1,5 @@
-import { Fragment } from 'react';
-import { LinkProps } from '@ag.ds-next/core';
+import { AnchorHTMLAttributes, Fragment } from 'react';
+import Link from 'next/link';
 import { TextLinkExternal } from '@ag.ds-next/text';
 import { Code } from './Code';
 
@@ -8,10 +8,13 @@ export const mdxComponents = {
 	pre: Fragment,
 	code: Code,
 	Fragment,
-	a: (props: LinkProps) => {
+	a: (props: AnchorHTMLAttributes<HTMLAnchorElement>) => {
+		if (!props.href) return <a {...props} />;
+
+		// Render an external link icon and open page in new tab
 		if (props.href && /^(https?:\/\/|\/\/)/i.test(props.href)) {
 			return <TextLinkExternal {...props} />;
 		}
-		return <a {...props} />;
+		return <Link {...props} />;
 	},
 };

--- a/docs/components/utils.tsx
+++ b/docs/components/utils.tsx
@@ -1,4 +1,6 @@
 import { Fragment } from 'react';
+import { LinkProps } from '@ag.ds-next/core';
+import { TextLinkExternal } from '@ag.ds-next/text';
 import { Code } from './Code';
 
 export const mdxComponents = {
@@ -6,4 +8,10 @@ export const mdxComponents = {
 	pre: Fragment,
 	code: Code,
 	Fragment,
+	a: (props: LinkProps) => {
+		if (props.href && /^(https?:\/\/|\/\/)/i.test(props.href)) {
+			return <TextLinkExternal {...props} />;
+		}
+		return <a {...props} />;
+	},
 };

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -7,6 +7,7 @@ import { HeroBanner } from '@ag.ds-next/hero-banner';
 import { AppLayout } from '../components/AppLayout';
 import { PictogramCard } from '../components/PictogramCard';
 import { DocumentTitle } from '../components/DocumentTitle';
+import { TextLinkExternal } from '@ag.ds-next/text';
 
 export default function Homepage() {
 	return (
@@ -31,23 +32,15 @@ export default function Homepage() {
 						<Body>
 							<p>
 								AgDS is based on the{' '}
-								<a
-									href="https://gold.designsystemau.org/"
-									target="_blank"
-									rel="noreferrer"
-								>
+								<TextLinkExternal href="https://gold.designsystemau.org/">
 									GOLD Design System
-								</a>{' '}
+								</TextLinkExternal>{' '}
 								which incorporates the highest usability and accessibility
 								standards, helping us to deliver a consistent experience for all
 								users, in line with the{' '}
-								<a
-									href="https://www.dta.gov.au/help-and-advice/about-digital-service-standard"
-									target="_blank"
-									rel="noreferrer"
-								>
+								<TextLinkExternal href="https://www.dta.gov.au/help-and-advice/about-digital-service-standard">
 									Digital Service Standard
-								</a>
+								</TextLinkExternal>
 								.
 							</p>
 							<p>

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -19,6 +19,7 @@ import { mdxComponents } from '../../../components/utils';
 import { AppLayout } from '../../../components/AppLayout';
 import { DocumentTitle } from '../../../components/DocumentTitle';
 import { PageLayout } from '../../../components/PageLayout';
+import { ExternalLinkCallout } from '@ag.ds-next/a11y';
 
 export default function Packages({
 	pkg,
@@ -57,7 +58,7 @@ export default function Packages({
 									variant="secondary"
 									iconAfter={ExternalLinkIcon}
 								>
-									View in Storybook
+									View in Storybook <ExternalLinkCallout />
 								</ButtonLink>
 							</div>
 						)}

--- a/docs/playroom/components.js
+++ b/docs/playroom/components.js
@@ -27,7 +27,7 @@ export { FileUpload } from '@ag.ds-next/file-upload';
 export { Header } from '@ag.ds-next/header';
 export { Heading, H1, H2, H3, H4, H5, H6 } from '@ag.ds-next/heading';
 export { Select } from '@ag.ds-next/select';
-export { Text, TextLink } from '@ag.ds-next/text';
+export { Text, TextLink, TextLinkExternal } from '@ag.ds-next/text';
 export { TextInput } from '@ag.ds-next/text-input';
 export { Textarea } from '@ag.ds-next/textarea';
 export { Field } from '@ag.ds-next/field';

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -33,10 +33,11 @@ Use the `ExternalLinkCallout` component to announce to a screenreader user that 
 
 ```jsx live
 <TextLink href="#" target="_blank">
-  Visit the Design System
+	Visit the Design System
 	<ExternalLinkCallout />
 </TextLink>
 ```
+
 > link, "Visit the Design System (Opens in a new Tab)"
 
 For links in Body text, we recommend reaching for the `TextLinkExternal` component in the [Text package](text#TextLinkExternal) instead.

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -5,7 +5,7 @@ group: Foundations
 storybookPath: /story/foundations-a11y-visuallyhidden--basic
 ---
 
-### Visually Hidden
+## Visually Hidden
 
 Use the `VisuallyHidden` component to hide an element visually without hiding it from screen readers.
 
@@ -26,3 +26,17 @@ function Example() {
 	);
 }
 ```
+
+## ExternalLinkCallout
+
+Use the `ExternalLinkCallout` component to announce to a screenreader user that a link will open in a new tab.
+
+```jsx live
+<TextLink href="#" target="_blank">
+  Visit the Design System
+	<ExternalLinkCallout />
+</TextLink>
+```
+> link, "Visit the Design System (Opens in a new Tab)"
+
+For links in Body text, we recommend reaching for the `TextLinkExternal` component in the [Text package](text#TextLinkExternal) instead.

--- a/packages/a11y/src/ExternalLinkCallout.stories.tsx
+++ b/packages/a11y/src/ExternalLinkCallout.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Stack } from '@ag.ds-next/box';
+import { ComponentMeta } from '@storybook/react';
+import { Text, TextLink } from '@ag.ds-next/text';
+import { ExternalLinkCallout } from './ExternalLinkCallout';
+import { H1 } from '@ag.ds-next/heading';
+
+export default {
+	title: 'foundations/A11y/ExternalLinkCallout',
+	component: ExternalLinkCallout,
+} as ComponentMeta<typeof ExternalLinkCallout>;
+
+export const Basic = () => (
+	<Stack gap={1}>
+		<H1>ExternalLinkCallout</H1>
+		<Text>
+			Interact with the link in this example using Apple VoiceOver or your
+			chosen screenreader.
+		</Text>
+
+		<Text>
+			Experiment with all of our Design System components in{' '}
+			<TextLink href="https://steelthreads.github.io/agds-next/playroom/index.html">
+				Playroom
+				<ExternalLinkCallout />
+			</TextLink>
+			.
+		</Text>
+	</Stack>
+);

--- a/packages/a11y/src/ExternalLinkCallout.tsx
+++ b/packages/a11y/src/ExternalLinkCallout.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { VisuallyHidden } from './VisuallyHidden';
+
+export const ExternalLinkCallout = () => {
+	return <VisuallyHidden> (opens in a new tab)</VisuallyHidden>;
+};

--- a/packages/a11y/src/VisuallyHidden.stories.tsx
+++ b/packages/a11y/src/VisuallyHidden.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Stack } from '@ag.ds-next/box';
 import { ComponentMeta } from '@storybook/react';
-import { TextLink } from '@ag.ds-next/text/src/Text';
+import { Text, TextLink } from '@ag.ds-next/text';
+import { H1 } from '@ag.ds-next/heading';
 import { VisuallyHidden, visuallyHiddenStyles } from './VisuallyHidden';
 
 export default {
@@ -9,10 +11,18 @@ export default {
 } as ComponentMeta<typeof VisuallyHidden>;
 
 export const Basic = () => (
-	<TextLink href="#">
-		Read more
-		<VisuallyHidden> about how to visually hide content</VisuallyHidden>
-	</TextLink>
+	<Stack gap={1}>
+		<H1>VisuallyHidden</H1>
+		<Text>
+			Interact with the link in this example using Apple VoiceOver or your
+			chosen screenreader.
+		</Text>
+
+		<TextLink href="#">
+			Read more
+			<VisuallyHidden> about how to visually hide content</VisuallyHidden>
+		</TextLink>
+	</Stack>
 );
 
 export const Styles = () => (

--- a/packages/a11y/src/index.ts
+++ b/packages/a11y/src/index.ts
@@ -1,1 +1,2 @@
+export * from './ExternalLinkCallout';
 export * from './VisuallyHidden';

--- a/packages/text/README.md
+++ b/packages/text/README.md
@@ -66,7 +66,7 @@ The `TextLink` component creates a hyperlink to web pages, files, email addresse
 
 ## TextLinkExternal
 
-The `TextLinkExternal` component creates a hyperlink to a web page, which will open in a new tab. It is adorned by an external link Icon, and includes descriptive text to communicate to a screenreader that communicates the interaction.
+The `TextLinkExternal` component creates a hyperlink to a web page, which will open in a new tab. It is adorned by an external link Icon, and includes descriptive text to communicate to a screenreader the interaction.
 
 ```jsx live
 <Text>

--- a/packages/text/README.md
+++ b/packages/text/README.md
@@ -63,3 +63,14 @@ The `TextLink` component creates a hyperlink to web pages, files, email addresse
 	This is some text with <TextLink href="#">a link</TextLink> inside.
 </Text>
 ```
+
+
+## TextLinkExternal
+
+The `TextLinkExternal` component creates a hyperlink to a web page, which will open in a new tab. It is adorned by an external link Icon, and includes descriptive text to communicate to a screenreader that communicates the interaction.
+
+```jsx live
+<Text>
+	Interact with our components in <TextLinkExternal href="https://steelthreads.github.io/agds-next/playroom/index.html">Playroom</TextLinkExternal>.
+</Text>
+```

--- a/packages/text/README.md
+++ b/packages/text/README.md
@@ -64,13 +64,16 @@ The `TextLink` component creates a hyperlink to web pages, files, email addresse
 </Text>
 ```
 
-
 ## TextLinkExternal
 
 The `TextLinkExternal` component creates a hyperlink to a web page, which will open in a new tab. It is adorned by an external link Icon, and includes descriptive text to communicate to a screenreader that communicates the interaction.
 
 ```jsx live
 <Text>
-	Interact with our components in <TextLinkExternal href="https://steelthreads.github.io/agds-next/playroom/index.html">Playroom</TextLinkExternal>.
+	Interact with our components in{' '}
+	<TextLinkExternal href="https://steelthreads.github.io/agds-next/playroom/index.html">
+		Playroom
+	</TextLinkExternal>
+	.
 </Text>
 ```

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -8,12 +8,14 @@
 		"@ag.ds-next/a11y": "1.0.2",
 		"@ag.ds-next/box": "5.0.0",
 		"@ag.ds-next/core": "2.2.0",
+		"@ag.ds-next/icon": "7.0.0",
 		"@emotion/react": "^11.7.0"
 	},
 	"devDependencies": {
 		"@ag.ds-next/a11y": "*",
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/core": "*",
+		"@ag.ds-next/icon": "*",
 		"@emotion/react": "^11.7.0"
 	}
 }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -5,11 +5,13 @@
 	"module": "dist/ag.ds-next-text.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
+		"@ag.ds-next/a11y": "1.0.2",
 		"@ag.ds-next/box": "5.0.0",
 		"@ag.ds-next/core": "2.2.0",
 		"@emotion/react": "^11.7.0"
 	},
 	"devDependencies": {
+		"@ag.ds-next/a11y": "*",
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/core": "*",
 		"@emotion/react": "^11.7.0"

--- a/packages/text/src/Text.tsx
+++ b/packages/text/src/Text.tsx
@@ -1,9 +1,5 @@
-import {
-	forwardRefWithAs,
-	useLinkComponent,
-	LinkProps,
-} from '@ag.ds-next/core';
-import { Box, BoxProps, focusStyles, linkStyles } from '@ag.ds-next/box';
+import { forwardRefWithAs } from '@ag.ds-next/core';
+import { Box, BoxProps } from '@ag.ds-next/box';
 
 export type TextProps = BoxProps;
 
@@ -36,10 +32,3 @@ export const Text = forwardRefWithAs<'span', BoxProps>(function Text(
 		/>
 	);
 });
-
-export type TextLinkProps = LinkProps;
-
-export const TextLink = (props: TextLinkProps) => {
-	const Link = useLinkComponent();
-	return <Link css={[linkStyles, focusStyles]} {...props} />;
-};

--- a/packages/text/src/TextLink.tsx
+++ b/packages/text/src/TextLink.tsx
@@ -1,0 +1,9 @@
+import { useLinkComponent, LinkProps } from '@ag.ds-next/core';
+import { focusStyles, linkStyles } from '@ag.ds-next/box';
+
+export type TextLinkProps = LinkProps;
+
+export const TextLink = (props: TextLinkProps) => {
+	const Link = useLinkComponent();
+	return <Link css={[linkStyles, focusStyles]} {...props} />;
+};

--- a/packages/text/src/TextLinkExternal.tsx
+++ b/packages/text/src/TextLinkExternal.tsx
@@ -1,9 +1,12 @@
+import { AnchorHTMLAttributes } from 'react';
 import { ExternalLinkCallout } from '@ag.ds-next/a11y';
 import { Flex } from '@ag.ds-next/box';
-import { LinkProps } from '@ag.ds-next/core';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 
-export type TextLinkExternalProps = Omit<LinkProps, 'color'>;
+export type TextLinkExternalProps = Omit<
+	AnchorHTMLAttributes<HTMLAnchorElement>,
+	'color'
+>;
 
 export const TextLinkExternal = ({
 	children,

--- a/packages/text/src/TextLinkExternal.tsx
+++ b/packages/text/src/TextLinkExternal.tsx
@@ -1,0 +1,28 @@
+import { ExternalLinkCallout } from '@ag.ds-next/a11y';
+import { Flex } from '@ag.ds-next/box';
+import { LinkProps } from '@ag.ds-next/core';
+import { ExternalLinkIcon } from '@ag.ds-next/icon';
+
+export type TextLinkExternalProps = Omit<LinkProps, 'color'>;
+
+export const TextLinkExternal = ({
+	children,
+	...props
+}: TextLinkExternalProps) => {
+	return (
+		<Flex
+			as="a"
+			inline
+			link
+			alignItems="center"
+			gap={0.25}
+			target="_blank"
+			rel="noopener noreferrer"
+			{...props}
+		>
+			{children}
+			<ExternalLinkCallout />
+			<ExternalLinkIcon weight="bold" size="sm" />
+		</Flex>
+	);
+};

--- a/packages/text/src/index.tsx
+++ b/packages/text/src/index.tsx
@@ -1,1 +1,3 @@
 export * from './Text';
+export * from './TextLink';
+export * from './TextLinkExternal';


### PR DESCRIPTION
## Describe your changes

- Create ExternalLinkCallout component, to consistently announce to a screenreader that a link that will open in a new tab
- Create TextLinkExternal for body links that open in a new tab.
- Use TextLinkExternal and ExternalLinkCallout within the documentation website
- Move TextLink to own files

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook

For new components...

- [x] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [x] Add to Docs for jsx live (docs/components/utils.tsx)
