### PR TITLE
docs/example: Add `PageTitle` component

### DIFF
--- a/.changeset/mighty-berries-wash.md
+++ b/.changeset/mighty-berries-wash.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/docs': patch
+'@ag.ds-next/example-site': patch
+---
+
+Created `PageTitle` component

--- a/docs/components/PageTitle.tsx
+++ b/docs/components/PageTitle.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+import { Stack } from '@ag.ds-next/box';
+import { H1 } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
+
+export type PageTitleProps = {
+	pretext?: ReactNode;
+	title: ReactNode;
+	introduction?: ReactNode;
+};
+
+export const PageTitle = ({ pretext, title, introduction }: PageTitleProps) => (
+	<Stack gap={1.5}>
+		<Stack gap={0.5}>
+			{pretext ? (
+				<Text
+					fontSize="sm"
+					color="muted"
+					fontWeight="bold"
+					lineHeight="heading"
+				>
+					{pretext}
+				</Text>
+			) : null}
+			<H1>{title}</H1>
+		</Stack>
+		{introduction ? (
+			<Text as="p" fontSize="md" color="muted">
+				{introduction}
+			</Text>
+		) : null}
+	</Stack>
+);

--- a/docs/components/TemplateLayout.tsx
+++ b/docs/components/TemplateLayout.tsx
@@ -17,6 +17,7 @@ import type {
 	getTemplateBreadcrumbs,
 	getTemplateSubNavItems,
 } from '../lib/mdx';
+import { PageTitle } from './PageTitle';
 
 type TemplateLayoutProps = PropsWithChildren<{
 	breadcrumbs: Awaited<ReturnType<typeof getTemplateBreadcrumbs>>;
@@ -51,15 +52,11 @@ export const TemplateLayout = ({
 			>
 				<Stack as="main" gap={2}>
 					<Stack gap={1.5} alignItems="flex-start">
-						<Stack gap={0.25}>
-							<Text fontSize="sm" color="muted" fontWeight="bold">
-								v{template.data.version}
-							</Text>
-							<H1>{template.title}</H1>
-							<Text as="p" fontSize="lg" color="muted">
-								{template.data.description}
-							</Text>
-						</Stack>
+						<PageTitle
+							pretext={`v${template.data.version}`}
+							title={template.title}
+							introduction={template.data.description}
+						/>
 						{template.previewUrl && (
 							<CallToActionLink href={template.previewUrl}>
 								View template preview

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -20,6 +20,7 @@ import { mdxComponents } from '../../../components/utils';
 import { AppLayout } from '../../../components/AppLayout';
 import { DocumentTitle } from '../../../components/DocumentTitle';
 import { PageLayout } from '../../../components/PageLayout';
+import { PageTitle } from '../../../components/PageTitle';
 
 export default function Packages({
 	pkg,
@@ -41,17 +42,11 @@ export default function Packages({
 				>
 					<Stack as="main" gap={2}>
 						<Stack gap={1.5} alignItems="flex-start">
-							<Stack gap={0.25}>
-								<Text fontSize="sm" color="muted" fontWeight="bold">
-									v{pkg.version}
-								</Text>
-								<H1>{pkg.data.title}</H1>
-								{pkg.data.description && (
-									<Text as="p" fontSize="lg" color="muted">
-										{pkg.data.description}
-									</Text>
-								)}
-							</Stack>
+							<PageTitle
+								pretext={`v${pkg.version}`}
+								title={pkg.data.title}
+								introduction={pkg.data.description}
+							/>
 							{pkg.storybookPath && (
 								<div>
 									<ButtonLink

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep0.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep0.tsx
@@ -42,7 +42,7 @@ export const FormExampleMultiStep0 = () => {
 	return (
 		<FormExampleMultiStepContainer
 			title="Conditional fork title (H1)"
-			subTitle="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
+			introduction="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
 		>
 			<form onSubmit={handleSubmit(onSubmit)}>
 				<FormStack>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep1.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep1.tsx
@@ -70,7 +70,7 @@ export const FormExampleMultiStep1 = () => {
 	return (
 		<FormExampleMultiStepContainer
 			title="Submit evidence (H1)"
-			subTitle="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
+			introduction="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
 		>
 			<form onSubmit={handleSubmit(onSubmit, onError)}>
 				<FormStack>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep2.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep2.tsx
@@ -35,7 +35,7 @@ export const FormExampleMultiStep2 = () => {
 	return (
 		<FormExampleMultiStepContainer
 			title="Select date (H1)"
-			subTitle="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
+			introduction="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
 		>
 			<form onSubmit={handleSubmit(onSubmit)}>
 				<FormStack>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep3.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep3.tsx
@@ -88,7 +88,7 @@ export const FormExampleMultiStep3 = () => {
 	return (
 		<FormExampleMultiStepContainer
 			title="Conditional reveal title (H1)"
-			subTitle="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
+			introduction="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
 		>
 			<form onSubmit={handleSubmit(onSubmit, onError)}>
 				<FormStack>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep4.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep4.tsx
@@ -78,7 +78,7 @@ export const FormExampleMultiStep4 = () => {
 	return (
 		<FormExampleMultiStepContainer
 			title="Confirm and submit (H1)"
-			subTitle="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
+			introduction="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
 		>
 			<FormStack>
 				{FORM_STEPS.filter((_, idx) => idx !== FORM_STEPS.length - 1).map(

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStepContainer.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStepContainer.tsx
@@ -1,32 +1,27 @@
 import { ReactNode } from 'react';
 import { Stack } from '@ag.ds-next/box';
-import { H1 } from '@ag.ds-next/heading';
-import { Text } from '@ag.ds-next/text';
 import { PageAlert } from '@ag.ds-next/page-alert';
 import { Body } from '@ag.ds-next/body';
 import { useFormExampleMultiStep } from './FormExampleMultiStep';
+import { PageTitle } from '../PageTitle';
 
 export const FormExampleMultiStepContainer = ({
 	children,
 	title,
-	subTitle,
+	introduction,
 }: {
 	children: ReactNode;
 	title: string;
-	subTitle: string;
+	introduction: string;
 }) => {
 	const { hasCompletedPreviousSteps } = useFormExampleMultiStep();
 	return (
-		<Stack gap={2}>
-			<Stack gap={0.25}>
-				<Text as="span" fontWeight="bold" fontSize="sm" color="muted">
-					Title of multi page form
-				</Text>
-				<H1>{title}</H1>
-				<Text as="p" fontSize="lg" color="muted">
-					{subTitle}
-				</Text>
-			</Stack>
+		<Stack gap={3}>
+			<PageTitle
+				pretext="Title of multi page form"
+				title={title}
+				introduction={introduction}
+			/>
 			{hasCompletedPreviousSteps ? (
 				children
 			) : (

--- a/example-site/components/PageTitle.tsx
+++ b/example-site/components/PageTitle.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+import { Stack } from '@ag.ds-next/box';
+import { H1 } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
+
+export type PageTitleProps = {
+	pretext?: ReactNode;
+	title: ReactNode;
+	introduction?: ReactNode;
+};
+
+export const PageTitle = ({ pretext, title, introduction }: PageTitleProps) => (
+	<Stack gap={1.5}>
+		<Stack gap={0.5}>
+			{pretext ? (
+				<Text
+					fontSize="sm"
+					color="muted"
+					fontWeight="bold"
+					lineHeight="heading"
+				>
+					{pretext}
+				</Text>
+			) : null}
+			<H1>{title}</H1>
+		</Stack>
+		{introduction ? (
+			<Text as="p" fontSize="md" color="muted">
+				{introduction}
+			</Text>
+		) : null}
+	</Stack>
+);

--- a/example-site/pages/form-multi-step/index.tsx
+++ b/example-site/pages/form-multi-step/index.tsx
@@ -7,8 +7,8 @@ import { DocumentTitle } from '../../components/DocumentTitle';
 import { FormExampleMultiStepCallout } from '../../components/FormExampleMultiStep/FormExampleMultiStepCallout';
 import { Body } from '@ag.ds-next/body';
 import { Stack } from '@ag.ds-next/box';
-import { H1 } from '@ag.ds-next/heading';
-import { Text, TextLinkExternal } from '@ag.ds-next/text';
+import { TextLinkExternal } from '@ag.ds-next/text';
+import { PageTitle } from '../../components/PageTitle';
 
 const FormMultiStepPage: NextPage = () => {
 	return (
@@ -21,14 +21,10 @@ const FormMultiStepPage: NextPage = () => {
 					<Columns>
 						<Column columnSpan={{ xs: 12, md: 8 }}>
 							<Stack gap={3}>
-								<Stack gap={0.25}>
-									<H1>Multipage form title (H1)</H1>
-									<Text as="p" fontSize="lg" color="muted">
-										The introductory paragraph provides context about the entire
-										multipage form. Use a short paragraph to reduce cognitive
-										load.
-									</Text>
-								</Stack>
+								<PageTitle
+									title="Multipage form title (H1)"
+									introduction="The introductory paragraph provides context about the entire multipage form. Use a short paragraph to reduce cognitive load."
+								/>
 								<Body>
 									<h2>Multipage form subheading (H2)</h2>
 									<p>Multipage form subheading content</p>

--- a/example-site/pages/form-sign-in.tsx
+++ b/example-site/pages/form-sign-in.tsx
@@ -1,11 +1,11 @@
 import type { NextPage } from 'next';
-import { Body } from '@ag.ds-next/body';
 import { Stack } from '@ag.ds-next/box';
 import { Content } from '@ag.ds-next/content';
 import { Columns, Column } from '@ag.ds-next/columns';
 import { AppLayout } from '../components/AppLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { FormExampleSignIn } from '../components/FormExampleSignIn';
+import { PageTitle } from '../components/PageTitle';
 
 const FormSignInPage: NextPage = () => {
 	return (
@@ -15,14 +15,11 @@ const FormSignInPage: NextPage = () => {
 				<Content>
 					<Columns>
 						<Column columnSpan={{ xs: 12, md: 7 }}>
-							<Stack gap={2}>
-								<Body>
-									<h1>Sign in example</h1>
-									<p>
-										The page heading communicates the main focus of the page.
-										Make your page heading descriptive and keep it succinct.
-									</p>
-								</Body>
+							<Stack gap={3}>
+								<PageTitle
+									title="Sign in example"
+									introduction="The page heading communicates the main focus of the page. Make your page heading descriptive and keep it succinct."
+								/>
 								<FormExampleSignIn />
 							</Stack>
 						</Column>

--- a/example-site/pages/form-single-page.tsx
+++ b/example-site/pages/form-single-page.tsx
@@ -1,5 +1,4 @@
 import type { NextPage } from 'next';
-import { Body } from '@ag.ds-next/body';
 import { Stack } from '@ag.ds-next/box';
 import { Content } from '@ag.ds-next/content';
 import { Columns, Column } from '@ag.ds-next/columns';
@@ -7,6 +6,7 @@ import { AppLayout } from '../components/AppLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { FormExampleSinglePage } from '../components/FormExampleSinglePage';
 import { Divider } from '../components/Divider';
+import { PageTitle } from '../components/PageTitle';
 
 const FormSinglePage: NextPage = () => {
 	return (
@@ -19,13 +19,10 @@ const FormSinglePage: NextPage = () => {
 					<Columns>
 						<Column columnSpan={{ xs: 12, md: 7 }}>
 							<Stack gap={3}>
-								<Body>
-									<h1>Single page form example</h1>
-									<p>
-										Lorem ipsum dolor sit amet, laoreet necessitatibus sed in,
-										ut quem latine eligendi vim, noster utamur sit an.
-									</p>
-								</Body>
+								<PageTitle
+									title="Single page form example"
+									introduction="Lorem ipsum dolor sit amet, laoreet necessitatibus sed in, ut quem latine eligendi vim, noster utamur sit an."
+								/>
 								<Divider />
 								<FormExampleSinglePage />
 							</Stack>


### PR DESCRIPTION
## Describe your changes

Created a `PageTitle` component which is composed of a pretext, title and introduction paragraph. This has been moved into a component as it repeated on almost every page of docs website and example website.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file

