### PR TITLE
example-site: Fix multi step form stack

### DIFF
--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep1.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep1.tsx
@@ -131,8 +131,8 @@ export const FormExampleMultiStep1 = () => {
 							</div>
 						)}
 					/>
+					<FormExampleMultiStepActions />
 				</FormStack>
-				<FormExampleMultiStepActions />
 			</form>
 		</FormExampleMultiStepContainer>
 	);

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStepActions.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStepActions.tsx
@@ -10,15 +10,8 @@ import { Fragment } from 'react';
 export const FormExampleMultiStepActions = () => {
 	const [isModalOpen, openModal, closeModal] = useTernaryState(false);
 
-	const {
-		hasCompletedPreviousSteps,
-		isSubmittingStep,
-		saveAndExit,
-		isSavingBeforeExiting,
-		cancel,
-	} = useFormExampleMultiStep();
-
-	if (!hasCompletedPreviousSteps) return null;
+	const { isSubmittingStep, saveAndExit, isSavingBeforeExiting, cancel } =
+		useFormExampleMultiStep();
 
 	return (
 		<Fragment>


### PR DESCRIPTION
## Describe your changes

On step 3, the divider is not inside of the `FormStack` which causes incorrect spacing of elements

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing