### PR TITLE
Breadcrumbs: Use ordered list

### DIFF
--- a/.changeset/hot-pears-rest.md
+++ b/.changeset/hot-pears-rest.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+---
+
+Use ordered-list HTML element

--- a/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
@@ -10,7 +10,7 @@ export const BreadcrumbsContainer = ({
 	'aria-label': ariaLabel,
 }: BreadcrumbsContainerProps) => (
 	<nav aria-label={ariaLabel}>
-		<Flex as="ul" gap={0.5} alignItems="center">
+		<Flex as="ol" gap={0.5} alignItems="center">
 			{children}
 		</Flex>
 	</nav>


### PR DESCRIPTION
## Describe your changes

In [this example from W3](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html), the Breadcrumbs examples uses an OL html element. I've updated ours to do the same.

## Checklist

- [X] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file