### PR TITLE
Examples: Improve validation in mutli-step form conditional step

### DIFF
--- a/.changeset/wicked-tools-sneeze.md
+++ b/.changeset/wicked-tools-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/example-site': minor
+---
+
+Improve validation in multi-step form conditional example

--- a/example-site/components/FormExampleMultiStep/utils.ts
+++ b/example-site/components/FormExampleMultiStep/utils.ts
@@ -1,8 +1,11 @@
+// Note this function is pretty basic. It doesn't cover a lot of scenarios so it should be used with caution
+
 export function formatFieldValue(value: unknown) {
 	switch (typeof value) {
 		case 'boolean':
 			return value ? 'Yes' : 'No';
 		case 'object':
+			if (Array.isArray(value)) return value.join();
 			if (value instanceof File) return value.name;
 			if (value instanceof Date) return value.toLocaleDateString();
 			return 'Unknown';


### PR DESCRIPTION
In this PR, we have improved the form validation for the 'conditional' step in the multi-step for, by showing validation messages onChange.

We've also changed the state-management logic, so each checkbox is treated as a value for the 'checkbox' field, rather than each being treated as seperate values.

## Checklist

- [X] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
