### PR TITLE
Body: Adjust styles for blockquotes and hr

### DIFF
--- a/.changeset/selfish-socks-hide.md
+++ b/.changeset/selfish-socks-hide.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/body': patch
+---
+
+- Updated color of `hr` elements
+- Removed margin top for first of type blockquotes and figures

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -267,6 +267,7 @@ export const bodyClass = css({
 		marginBottom: 0,
 		marginLeft: 0,
 		marginRight: 0,
+		'&:first-of-type': { marginTop: 0 },
 	},
 
 	[`blockquote${notSelector}`]: {
@@ -279,6 +280,7 @@ export const bodyClass = css({
 		borderLeftStyle: 'solid',
 		borderColor: boxPalette.border,
 		background: boxPalette.backgroundShade,
+		'&:first-of-type': { marginTop: 0 },
 	},
 
 	/**
@@ -316,7 +318,7 @@ export const bodyClass = css({
 		border: 'none',
 		borderTopWidth: tokens.borderWidth.sm,
 		borderTopStyle: 'solid',
-		borderColor: boxPalette.border,
+		borderColor: boxPalette.borderMuted,
 		marginBottom: mapSpacing(1.5),
 	},
 


### PR DESCRIPTION
## Describe your changes

- Updated color of `hr` elements
- Removed margin top for first of type blockquotes and figures

Screenshot of fixed issue

<img width="1438" alt="Screen Shot 2022-05-26 at 9 57 32 am" src="https://user-images.githubusercontent.com/6265154/170388940-e8fb6779-52e0-477b-85bc-95e4179b1e20.png">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
