### PR TITLE
LinkList: Use external link indicator

### DIFF
--- a/.changeset/pretty-parents-complain.md
+++ b/.changeset/pretty-parents-complain.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/link-list': minor
+---
+
+Links that open in a new tab will use show the external link indicator

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -13,6 +13,12 @@ The default link list component removes the normal bullets and spacing associate
 		{ href: '#', label: 'Home' },
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
+		{
+			href: 'https://steelthreads.github.io/agds-next',
+			label: 'External link',
+			target: '_blank',
+			rel: 'external noreferrer',
+		},
 	]}
 />
 ```
@@ -27,6 +33,12 @@ Setting the `horizontal` prop will stack the links horizontally.
 		{ href: '#', label: 'Home' },
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
+		{
+			href: 'https://steelthreads.github.io/agds-next',
+			label: 'External link',
+			target: '_blank',
+			rel: 'external noreferrer',
+		},
 	]}
 	horizontal
 />

--- a/packages/link-list/src/LinkListItem.tsx
+++ b/packages/link-list/src/LinkListItem.tsx
@@ -1,10 +1,14 @@
 import { Box } from '@ag.ds-next/box';
-import { TextLink, TextLinkProps } from '@ag.ds-next/text';
+import { LinkProps } from '@ag.ds-next/core';
+import { TextLink, TextLinkExternal } from '@ag.ds-next/text';
 
-export type LinkListItemProps = TextLinkProps;
+export type LinkListItemProps = LinkProps;
 
-export const LinkListItem = (props: LinkListItemProps) => (
-	<Box as="li">
-		<TextLink {...props} />
-	</Box>
-);
+export const LinkListItem = (props: LinkListItemProps) => {
+	const TextComponent = props.target == '_blank' ? TextLinkExternal : TextLink;
+	return (
+		<Box as="li">
+			<TextComponent {...props} />
+		</Box>
+	);
+};


### PR DESCRIPTION
## Describe your changes

Links that open in a new tab will use show the external link indicator.

<img width="822" alt="Screen Shot 2022-06-01 at 8 59 58 am" src="https://user-images.githubusercontent.com/6265154/171297565-56669c51-52df-4059-ba28-215b24324782.png">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file