### PR TITLE
TextLinkExternal: Use global link component

### DIFF
--- a/.changeset/rare-avocados-develop.md
+++ b/.changeset/rare-avocados-develop.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text': minor
+---
+
+Update `TextLinkExternal` to use the link component from context.

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -78,7 +78,7 @@ const LiveCode = withLive((props: unknown) => {
 	);
 
 	const playroomUrl = createUrl({
-		baseUrl: '/playroom',
+		baseUrl: 'https://steelthreads.github.io/agds-next/playroom',
 		code: live.code,
 	});
 

--- a/docs/components/SiteFooter.tsx
+++ b/docs/components/SiteFooter.tsx
@@ -10,13 +10,13 @@ const footerLinks = [
 	},
 	{
 		label: 'Storybook',
-		href: '/storybook/index.html',
+		href: 'https://steelthreads.github.io/agds-next/storybook/index.html',
 		target: '_blank',
 		rel: 'noopener noreferrer',
 	},
 	{
 		label: 'Playroom',
-		href: '/playroom/index.html',
+		href: 'https://steelthreads.github.io/agds-next/playroom/index.html',
 		target: '_blank',
 		rel: 'noopener noreferrer',
 	},

--- a/packages/text/src/TextLinkExternal.tsx
+++ b/packages/text/src/TextLinkExternal.tsx
@@ -1,7 +1,7 @@
 import { ExternalLinkCallout } from '@ag.ds-next/a11y';
-import { focusStyles, linkStyles } from '@ag.ds-next/box';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
-import { LinkProps, mapSpacing, useLinkComponent } from '@ag.ds-next/core';
+import { LinkProps, mapSpacing } from '@ag.ds-next/core';
+import { TextLink } from './TextLink';
 
 export type TextLinkExternalProps = LinkProps;
 
@@ -9,14 +9,8 @@ export const TextLinkExternal = ({
 	children,
 	...props
 }: TextLinkExternalProps) => {
-	const Link = useLinkComponent();
 	return (
-		<Link
-			css={[linkStyles, focusStyles]}
-			target="_blank"
-			rel="noopener noreferrer"
-			{...props}
-		>
+		<TextLink target="_blank" rel="noopener noreferrer" {...props}>
 			{children}
 			<ExternalLinkCallout />
 			<ExternalLinkIcon
@@ -28,6 +22,6 @@ export const TextLinkExternal = ({
 					marginLeft: mapSpacing(0.25),
 				}}
 			/>
-		</Link>
+		</TextLink>
 	);
 };

--- a/packages/text/src/TextLinkExternal.tsx
+++ b/packages/text/src/TextLinkExternal.tsx
@@ -1,20 +1,22 @@
-import { AnchorHTMLAttributes } from 'react';
 import { ExternalLinkCallout } from '@ag.ds-next/a11y';
-import { Box } from '@ag.ds-next/box';
+import { focusStyles, linkStyles } from '@ag.ds-next/box';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
-import { mapSpacing } from '@ag.ds-next/core';
+import { LinkProps, mapSpacing, useLinkComponent } from '@ag.ds-next/core';
 
-export type TextLinkExternalProps = Omit<
-	AnchorHTMLAttributes<HTMLAnchorElement>,
-	'color'
->;
+export type TextLinkExternalProps = LinkProps;
 
 export const TextLinkExternal = ({
 	children,
 	...props
 }: TextLinkExternalProps) => {
+	const Link = useLinkComponent();
 	return (
-		<Box as="a" link target="_blank" rel="noopener noreferrer" {...props}>
+		<Link
+			css={[linkStyles, focusStyles]}
+			target="_blank"
+			rel="noopener noreferrer"
+			{...props}
+		>
 			{children}
 			<ExternalLinkCallout />
 			<ExternalLinkIcon
@@ -26,6 +28,6 @@ export const TextLinkExternal = ({
 					marginLeft: mapSpacing(0.25),
 				}}
 			/>
-		</Box>
+		</Link>
 	);
 };


### PR DESCRIPTION
## Describe your changes

Update `TextLinkExternal` to use the link component from context.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
