### PR TITLE
Docs: Relabel 'show live code' button

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -121,7 +121,7 @@ const LiveCode = withLive((props: unknown) => {
 					aria-label={isCodeVisible ? 'Hide code snippet' : 'Show code snippet'}
 					aria-controls={codeId}
 				>
-					{isCodeVisible ? 'Hide code' : 'Show code'}
+					{isCodeVisible ? 'Hide live code' : 'Show live code'}
 				</Button>
 				<Button
 					size="sm"


### PR DESCRIPTION
## Describe your changes
Relabel the show code button to highlight the fact a user can edit the 'live' code.

[Product Backlog Item 240754](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/240754?McasTsid=26110): Change label to 'Show live code' 'Hide live code'

<img width="256" alt="image" src="https://user-images.githubusercontent.com/12689383/171340021-bb51d264-8bc7-4506-b818-6295664287da.png">


## Checklist

- [X] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
