### PR TITLE
accordion: Update documentation

### DIFF
--- a/.changeset/cool-buttons-press.md
+++ b/.changeset/cool-buttons-press.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/accordion': patch
+---
+
+Update documentation

--- a/.storybook/stories/kitchenSink.tsx
+++ b/.storybook/stories/kitchenSink.tsx
@@ -174,7 +174,7 @@ const KitchenSink = ({
 						<Accordion>
 							<AccordionItem title="Accordion">
 								<AccordionItemContent>
-									<Text>
+									<Text as="p">
 										Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 										Pellentesque at arcu eleifend, varius enim non, eleifend
 										nibh. Quisque ac lacinia elit. Orci varius natoque penatibus

--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -264,7 +264,7 @@ items={[
 		group: 'Accordion',
 		name: 'Basic',
 		code: `<Accordion><AccordionItem title="Accordion">
-    <AccordionItemContent><Text>This is some text inside an Accordion</Text></AccordionItemContent>
+    <AccordionItemContent><Text as="p">This is some text inside an Accordion</Text></AccordionItemContent>
   </AccordionItem></Accordion>`,
 	},
 	{

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -11,7 +11,7 @@ A singular method of expanding and collapsing a piece of content with a title.
 <Accordion>
 	<AccordionItem title="Accordion">
 		<AccordionItemContent>
-			<Text>This is some text inside an Accordion</Text>
+			<Text as="p">This is some text inside an Accordion</Text>
 		</AccordionItemContent>
 	</AccordionItem>
 </Accordion>
@@ -25,21 +25,23 @@ It is common for multiple AccordionItems to appear together. Grouped AccordionIt
 <Accordion>
 	<AccordionItem title="Accordion 1">
 		<AccordionItemContent>
-			<p>
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce a libero
-				vel dolor sollicitudin pretium quis quis mi. Fusce sapien mi, efficitur
-				sit amet ex et, bibendum efficitur odio. Ut nec gravida metus, nec
-				suscipit nulla. Donec est nulla, dictum sed ultricies congue, suscipit
-				at velit. Integer ut leo lectus. Nullam volutpat ex quis imperdiet
-				scelerisque. Etiam ultrices et nisi eget pulvinar. Cras ultrices lectus
-				ut nisl gravida, eu rutrum sem luctus. Praesent vulputate eu dolor
-				commodo tempor. Sed nec lorem consectetur, maximus justo at, tincidunt
-				quam. Suspendisse pellentesque accumsan accumsan. Cras in odio leo. Nam
-				pharetra, lorem eget aliquam gravida, felis ex tempor sapien, a ornare
-				leo nulla eget magna. Quisque tempus ipsum eu elit bibendum, nec
-				bibendum ligula posuere. Nam porttitor est eros, ac maximus nisl euismod
-				nec.
-			</p>
+			<Body>
+				<p>
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce a
+					libero vel dolor sollicitudin pretium quis quis mi. Fusce sapien mi,
+					efficitur sit amet ex et, bibendum efficitur odio. Ut nec gravida
+					metus, nec suscipit nulla. Donec est nulla, dictum sed ultricies
+					congue, suscipit at velit. Integer ut leo lectus. Nullam volutpat ex
+					quis imperdiet scelerisque. Etiam ultrices et nisi eget pulvinar. Cras
+					ultrices lectus ut nisl gravida, eu rutrum sem luctus. Praesent
+					vulputate eu dolor commodo tempor. Sed nec lorem consectetur, maximus
+					justo at, tincidunt quam. Suspendisse pellentesque accumsan accumsan.
+					Cras in odio leo. Nam pharetra, lorem eget aliquam gravida, felis ex
+					tempor sapien, a ornare leo nulla eget magna. Quisque tempus ipsum eu
+					elit bibendum, nec bibendum ligula posuere. Nam porttitor est eros, ac
+					maximus nisl euismod nec.
+				</p>
+			</Body>
 		</AccordionItemContent>
 	</AccordionItem>
 	<AccordionItem title="Accordion 2">
@@ -92,7 +94,7 @@ It is common for multiple AccordionItems to appear together. Grouped AccordionIt
 			width="100%"
 		/>
 		<AccordionItemContent>
-			<Text>
+			<Text as="p">
 				In this example, we remove the default padding from the AccordionItem,
 				in order to achieve the edge-to-edge image above. This Text is wrapped
 				in the AccordionItemContent component.

--- a/packages/accordion/src/Accordion.stories.tsx
+++ b/packages/accordion/src/Accordion.stories.tsx
@@ -36,7 +36,7 @@ const AccordionBasicExample: Story<AccordionExampleProps> = ({
 		<Accordion>
 			<AccordionItem title="Accordion test">
 				<AccordionItemContent>
-					<Text>This is some text inside an Accordion</Text>
+					<Text as="p">This is some text inside an Accordion</Text>
 				</AccordionItemContent>
 			</AccordionItem>
 		</Accordion>
@@ -62,10 +62,9 @@ const AccordionGroupExample: Story<AccordionExampleProps> = ({
 		<Accordion>
 			<AccordionItem title="Accordion 1">
 				<AccordionItemContent>
-					<Text>This is some text inside an Accordion</Text>
+					<Text as="p">This is some text inside an Accordion</Text>
 				</AccordionItemContent>
 			</AccordionItem>
-
 			<AccordionItem title="Accordion 2">
 				<AccordionItemContent>
 					<Body>
@@ -100,10 +99,9 @@ const AccordionGroupExample: Story<AccordionExampleProps> = ({
 					</Body>
 				</AccordionItemContent>
 			</AccordionItem>
-
 			<AccordionItem title="Accordion 3">
 				<AccordionItemContent>
-					<Text>This is some text inside an Accordion</Text>
+					<Text as="p">This is some text inside an Accordion</Text>
 				</AccordionItemContent>
 			</AccordionItem>
 		</Accordion>
@@ -178,7 +176,7 @@ const AccordionControlledGroupExample = ({
 				onToggle={() => toggle(1)}
 			>
 				<AccordionItemContent>
-					<Text>This is some text inside an Accordion</Text>
+					<Text as="p">This is some text inside an Accordion</Text>
 				</AccordionItemContent>
 			</AccordionItem>
 			<AccordionItem
@@ -219,14 +217,13 @@ const AccordionControlledGroupExample = ({
 					</Body>
 				</AccordionItemContent>
 			</AccordionItem>
-
 			<AccordionItem
 				title="Accordion 3"
 				isOpen={openAccordions.includes(3)}
 				onToggle={() => toggle(3)}
 			>
 				<AccordionItemContent>
-					<Text>This is some text inside an Accordion</Text>
+					<Text as="p">This is some text inside an Accordion</Text>
 				</AccordionItemContent>
 			</AccordionItem>
 		</Accordion>
@@ -274,7 +271,7 @@ export const InitiallyOpened = () => (
 	<Accordion>
 		<AccordionItem title="Initially opened" isInitiallyOpen>
 			<AccordionItemContent>
-				<Text>
+				<Text as="p">
 					This is some text inside an Accordion, which is opened at time of page
 					render.
 				</Text>
@@ -292,7 +289,7 @@ export const EdgeToEdgeImage = () => (
 				width="100%"
 			/>
 			<AccordionItemContent>
-				<Text>
+				<Text as="p">
 					In this example, we remove the default padding from the AccordionItem,
 					in order to achieve the edge-to-edge image above. This Text is wrapped
 					in the AccordionItemContent component.


### PR DESCRIPTION
## Describe your changes

This PR fixes a typography bug in the accordion package documentation.

- One of the examples has a `p` tag not wrapped in a `Body` tag which causes incorrect styling. 
- Lots of the examples use `span` tags instead of `p` tags

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook