### PR TITLE
breadcrumbs: Fix items shrinking smaller devices

### DIFF
--- a/.changeset/popular-ligers-pay.md
+++ b/.changeset/popular-ligers-pay.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': patch
+---
+
+Fix breadcrumb items shrinking smaller devices

--- a/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
@@ -10,7 +10,7 @@ export const BreadcrumbsContainer = ({
 	'aria-label': ariaLabel,
 }: BreadcrumbsContainerProps) => (
 	<nav aria-label={ariaLabel}>
-		<Flex as="ol" gap={0.5} alignItems="center">
+		<Flex as="ol" gap={0.5} alignItems="center" flexWrap="wrap">
 			{children}
 		</Flex>
 	</nav>


### PR DESCRIPTION
## Describe your changes

Fix breadcrumb items shrinking smaller devices.

| Before      | After |
| ----------- | ----------- |
| <img width="375" alt="Screen Shot 2022-06-03 at 2 19 30 pm" src="https://user-images.githubusercontent.com/6265154/171785537-1be91273-e694-47f1-be6a-f6743031df79.png">      | <img width="376" alt="Screen Shot 2022-06-03 at 2 19 43 pm" src="https://user-images.githubusercontent.com/6265154/171785530-c0b890ea-b279-40e1-8cea-821fa8820931.png">       |



## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file
