### PR TITLE
FileUpload: Fix Select button in Safari. Styling improvements

### DIFF
--- a/.changeset/orange-mice-cheer.md
+++ b/.changeset/orange-mice-cheer.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/file-upload': patch
 ---
 
-Fix non-working Select button in Safari
+Fixed `Select files` button not working in Safari

--- a/.changeset/orange-mice-cheer.md
+++ b/.changeset/orange-mice-cheer.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/file-upload': patch
+---
+
+Fix non-working Select button in Safari

--- a/.changeset/shy-buckets-sleep.md
+++ b/.changeset/shy-buckets-sleep.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/file-upload': patch
+---
+
+Improve styling for invalid states

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -121,6 +121,8 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 				id={id}
 			>
 				{(allyProps) => {
+					// Avoid passing `color` to the Stack component, which causes
+					// TypeScript errors.
 					// eslint-disable-next-line @typescript-eslint/no-unused-vars
 					const { color, ...rootProps } = getRootProps();
 

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -64,7 +64,6 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 		ref
 	) {
 		const [files, setFiles] = useState<FileWithPath[]>([]);
-		const styles = fileInputStyles({ disabled, invalid, valid });
 		const filesPlural = multiple ? 'files' : 'file';
 		const maxSizeBytes = (maxSize || 0) * 1000;
 		const formattedMaxFileSize = formatFileSize(maxSizeBytes);
@@ -105,20 +104,28 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			maxFiles
 		);
 		const acceptedFilesSummary = getAcceptedFilesSummary(accept);
+		const styles = fileInputStyles({
+			disabled,
+			invalid: invalid || !!errorSummary,
+			valid,
+		});
 
 		return (
-			<Stack gap={0.5}>
-				<Field
-					label={label}
-					required={Boolean(required)}
-					hint={hint}
-					message={message || errorSummary}
-					invalid={invalid || !!errorSummary}
-					valid={valid}
-					id={id}
-				>
-					{(allyProps) => (
-						<div {...getRootProps()}>
+			<Field
+				label={label}
+				required={Boolean(required)}
+				hint={hint}
+				message={message || errorSummary}
+				invalid={invalid || !!errorSummary}
+				valid={valid}
+				id={id}
+			>
+				{(allyProps) => {
+					// eslint-disable-next-line @typescript-eslint/no-unused-vars
+					const { color, ...rootProps } = getRootProps();
+
+					return (
+						<Stack gap={0.5} {...rootProps}>
 							<Flex
 								gap={1}
 								padding={1.5}
@@ -126,7 +133,6 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 								flexDirection="column"
 								border
 								rounded
-								background="shade"
 								css={styles}
 							>
 								<UploadIcon size="lg" color="muted" />
@@ -166,38 +172,37 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 									{`Select ${filesPlural}`}
 								</Button>
 							</Flex>
-						</div>
-					)}
-				</Field>
-				{files.length ? (
-					<Fragment>
-						<Text color="muted">{getFilesTotal(files)}</Text>
-						<Stack as="ul" gap={0.5}>
-							{files.map((file, index) => (
-								<FileUploadFile
-									file={file}
-									key={index}
-									onRemove={() => handleRemoveFile(file)}
-								/>
-							))}
+							{files.length ? (
+								<Fragment>
+									<Text color="muted">{getFilesTotal(files)}</Text>
+									<Stack as="ul" gap={0.5}>
+										{files.map((file, index) => (
+											<FileUploadFile
+												file={file}
+												key={index}
+												onRemove={() => handleRemoveFile(file)}
+											/>
+										))}
+									</Stack>
+								</Fragment>
+							) : null}
+							{fileRejections.length ? (
+								<Stack as="ul" gap={0.5}>
+									{fileRejections.map((err, index) => (
+										<FileRejection key={index}>
+											{getFileRejectionErrorMessage(
+												err,
+												formattedMaxFileSize,
+												acceptedFilesSummary
+											)}
+										</FileRejection>
+									))}
+								</Stack>
+							) : null}{' '}
 						</Stack>
-					</Fragment>
-				) : null}
-
-				{fileRejections.length ? (
-					<Stack as="ul" gap={0.5}>
-						{fileRejections.map((err, index) => (
-							<FileRejection key={index}>
-								{getFileRejectionErrorMessage(
-									err,
-									formattedMaxFileSize,
-									acceptedFilesSummary
-								)}
-							</FileRejection>
-						))}
-					</Stack>
-				) : null}
-			</Stack>
+					);
+				}}
+			</Field>
 		);
 	}
 );
@@ -216,6 +221,7 @@ export const fileInputStyles = ({
 		borderWidth: tokens.borderWidth.lg,
 		borderStyle: 'dashed',
 		borderColor: boxPalette.borderInput,
+		backgroundColor: boxPalette.backgroundShade,
 		...(invalid
 			? {
 					backgroundColor: globalPalette.errorMuted,

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -95,6 +95,8 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 				multiple,
 				onDropAccepted: handleDropAccepted,
 				disabled,
+				noClick: true,
+				noKeyboard: true,
 			});
 
 		const errorSummary = getErrorSummary(


### PR DESCRIPTION
## Describe your changes
- Fix Select button in Safari, which did not add the file to the 'value' of the input.
- Fix bug that caused the red tint to not be applied in 'internal validation'.
- Indent file validation messages to sit within the red border.

<img width="898" alt="image" src="https://user-images.githubusercontent.com/12689383/172280198-daf285d6-9981-462e-a692-5a4a411d5f85.png">

## Checklist

- [X] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn changeset` to create a changeset file
