### PR TITLE
example-site: Fix broken links on content page

### DIFF
--- a/example-site/pages/category/subcategory/content.tsx
+++ b/example-site/pages/category/subcategory/content.tsx
@@ -146,11 +146,11 @@ const ContentPage: NextPage = () => {
 
 const sideNavItems = [
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/content',
+		href: '#',
 		label: 'Content page',
 		items: [
 			{
@@ -164,31 +164,31 @@ const sideNavItems = [
 		],
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 	{
-		href: '/',
+		href: '#',
 		label: 'Content page',
 	},
 ];


### PR DESCRIPTION
## Describe your changes

The links on the `content` example site page are currently broken. They should just be "fake" links as they don't go anywhere.