### PR TITLE
button: use `forwardRefWithAs`

### DIFF
--- a/.changeset/dirty-guests-deny.md
+++ b/.changeset/dirty-guests-deny.md
@@ -1,0 +1,15 @@
+---
+'@ag.ds-next/button': major
+---
+
+- Added the ability the forward refs and use the as prop
+- Removed `ButtonLink` component. Usage of this component can be replaced with:
+
+```jsx
+const Link = useLinkComponent();
+return (
+	<Button as={LinkComponent} href="/sign-in">
+		Sign in
+	</Button>
+);
+```

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -17,11 +17,12 @@ import {
 	mapSpacing,
 	packs,
 	tokens,
+	useLinkComponent,
 	useToggleState,
 } from '@ag.ds-next/core';
 import { Box, Flex } from '@ag.ds-next/box';
 import { unsetBodyStylesClassname } from '@ag.ds-next/body';
-import { Button, ButtonLink } from '@ag.ds-next/button';
+import { Button } from '@ag.ds-next/button';
 import {
 	CopyIcon,
 	ChevronDownIcon,
@@ -40,6 +41,7 @@ const PlaceholderImage = () => (
 );
 
 const LiveCode = withLive((props: unknown) => {
+	const Link = useLinkComponent();
 	const { query } = useRouter();
 
 	// The types on `withLive` are kind of useless.
@@ -124,7 +126,8 @@ const LiveCode = withLive((props: unknown) => {
 				>
 					Copy code
 				</Button>
-				<ButtonLink
+				<Button
+					as={Link}
 					href={playroomUrl}
 					target="_blank"
 					rel="noopener noreferrer"
@@ -135,7 +138,7 @@ const LiveCode = withLive((props: unknown) => {
 				>
 					Open in Playroom
 					<ExternalLinkCallout />
-				</ButtonLink>
+				</Button>
 			</Flex>
 			<Box
 				id={codeId}

--- a/docs/components/design-system-components.tsx
+++ b/docs/components/design-system-components.tsx
@@ -4,12 +4,7 @@ import {
 	AccordionItemContent,
 } from '@ag.ds-next/accordion';
 import { Logo } from '@ag.ds-next/ag-branding';
-import {
-	BaseButton,
-	Button,
-	ButtonLink,
-	ButtonGroup,
-} from '@ag.ds-next/button';
+import { BaseButton, Button, ButtonGroup } from '@ag.ds-next/button';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Body, unsetBodyStylesClassname } from '@ag.ds-next/body';
 import { useTernaryState, tokens } from '@ag.ds-next/core';
@@ -125,7 +120,6 @@ export const designSystemComponents = {
 	AgLogo,
 	BaseButton,
 	Button,
-	ButtonLink,
 	ButtonGroup,
 	Box,
 	Flex,

--- a/docs/pages/packages/[group]/[slug].tsx
+++ b/docs/pages/packages/[group]/[slug].tsx
@@ -1,7 +1,8 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
+import { useLinkComponent } from '@ag.ds-next/core';
 import { Body } from '@ag.ds-next/body';
-import { ButtonGroup, ButtonLink } from '@ag.ds-next/button';
+import { Button, ButtonGroup } from '@ag.ds-next/button';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 import { ExternalLinkCallout } from '@ag.ds-next/a11y';
 import {
@@ -22,6 +23,7 @@ export default function Packages({
 	navLinks,
 	breadcrumbs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
+	const Link = useLinkComponent();
 	return (
 		<>
 			<DocumentTitle title={pkg.title} />
@@ -42,7 +44,8 @@ export default function Packages({
 						callToAction={
 							pkg.storybookPath && (
 								<ButtonGroup>
-									<ButtonLink
+									<Button
+										as={Link}
 										target="_blank"
 										href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${pkg.storybookPath}`}
 										rel="noopener noreferrer"
@@ -51,7 +54,7 @@ export default function Packages({
 									>
 										View in Storybook
 										<ExternalLinkCallout />
-									</ButtonLink>
+									</Button>
 								</ButtonGroup>
 							)
 						}

--- a/docs/playroom/components.js
+++ b/docs/playroom/components.js
@@ -7,7 +7,7 @@ export {
 } from '@ag.ds-next/accordion';
 export { Body } from '@ag.ds-next/body';
 export { Box, Flex, Stack } from '@ag.ds-next/box';
-export { BaseButton, ButtonLink, ButtonGroup } from '@ag.ds-next/button';
+export { BaseButton, Button, ButtonGroup } from '@ag.ds-next/button';
 export {
 	Content,
 	ContentBleed,

--- a/example-site/pages/category/subcategory/multi-page-form/index.tsx
+++ b/example-site/pages/category/subcategory/multi-page-form/index.tsx
@@ -1,6 +1,7 @@
 import { PageContent } from '@ag.ds-next/content';
+import { useLinkComponent } from '@ag.ds-next/core';
 import { Columns, Column } from '@ag.ds-next/columns';
-import { ButtonLink } from '@ag.ds-next/button';
+import { Button } from '@ag.ds-next/button';
 import { Body } from '@ag.ds-next/body';
 import { Breadcrumbs } from '@ag.ds-next/breadcrumbs';
 import { Stack } from '@ag.ds-next/box';
@@ -14,6 +15,7 @@ import { PageTitle } from '../../../../components/PageTitle';
 import { FormDivider } from '../../../../components/FormDivider';
 
 export default function FormMultiPageHomePage() {
+	const Link = useLinkComponent();
 	return (
 		<>
 			<DocumentTitle title="Multi-page form example" />
@@ -44,9 +46,12 @@ export default function FormMultiPageHomePage() {
 									<Text as="p">Multi-page form subheading content</Text>
 								</Stack>
 								<div>
-									<ButtonLink href="/category/subcategory/multi-page-form/form">
+									<Button
+										as={Link}
+										href="/category/subcategory/multi-page-form/form"
+									>
 										Start form
-									</ButtonLink>
+									</Button>
 								</div>
 								<FormDivider />
 								<Body>

--- a/example-site/pages/index.tsx
+++ b/example-site/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@ag.ds-next/box';
-import { ButtonGroup, ButtonLink } from '@ag.ds-next/button';
+import { useLinkComponent } from '@ag.ds-next/core';
+import { ButtonGroup, Button } from '@ag.ds-next/button';
 import { SectionContent } from '@ag.ds-next/content';
 import { Columns, Column } from '@ag.ds-next/columns';
 import { H2, H3 } from '@ag.ds-next/heading';
@@ -16,6 +17,7 @@ import { DocumentTitle } from '../components/DocumentTitle';
 import { ArticleCard } from '../components/ArticleCard';
 
 export default function HomePage() {
+	const Link = useLinkComponent();
 	return (
 		<>
 			<DocumentTitle title="Home" />
@@ -39,10 +41,12 @@ export default function HomePage() {
 						</HeroBannerSubtitle>
 					</HeroBannerTitleContainer>
 					<ButtonGroup>
-						<ButtonLink href="/sign-in-form">Create account</ButtonLink>
-						<ButtonLink href="/sign-in-form" variant="secondary">
+						<Button as={Link} href="/sign-in-form">
+							Create account
+						</Button>
+						<Button as={Link} href="/sign-in-form" variant="secondary">
 							Sign in
-						</ButtonLink>
+						</Button>
 					</ButtonGroup>
 				</HeroBanner>
 

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -97,7 +97,7 @@ The `loading` prop can be used to inform users that their action is being proces
 <Button loading>Submit</Button>
 ```
 
-## Buttons links
+## As link element
 
 For situations where you need the appearance of a `Button` but the functionality of a link, you can use `as` prop.
 

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -86,14 +86,7 @@ A block-level button uses 100% of the available width of the container or parent
 The `iconAfter` and `iconBefore` props can be used to add system icons to buttons.
 
 ```jsx live
-<ButtonLink
-	iconAfter={ExternalLinkIcon}
-	href="https://steelthreads.github.io/agds-next"
-	target="_blank"
-	rel="noopener noreferrer"
->
-	Open external link
-</ButtonLink>
+<Button iconAfter={AvatarIcon}>Sign in</Button>
 ```
 
 ### Loading
@@ -106,12 +99,15 @@ The `loading` prop can be used to inform users that their action is being proces
 
 ## Buttons links
 
-For situations where you need something that has the visual weight of a Button, but the functionality of a link, you can use `ButtonLink`!
+For situations where you need the appearance of a `Button` but the functionality of a link, you can use `as` prop.
 
-`ButtonLink` adopts the `Link` component from your chosen router framework, which you can set in the `Core` component.
-
-```jsx live
-<ButtonLink href="/sign-in">Sign in</ButtonLink>
+```jsx
+const Link = useLinkComponent();
+return (
+	<Button as={LinkComponent} href="/sign-in">
+		Sign in
+	</Button>
+);
 ```
 
 ## ButtonGroup

--- a/packages/button/src/BaseButton.tsx
+++ b/packages/button/src/BaseButton.tsx
@@ -28,6 +28,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
 		return (
 			<button
 				ref={mergeRefs([ref, forwardedRef])}
+				type="button"
 				onClick={onClick}
 				css={{
 					appearance: 'none',

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -95,11 +95,11 @@ export const Size: ComponentStory<typeof Button> = (args) => (
 	</ButtonGroup>
 );
 
-export const ButtonLink: ComponentStory<typeof Button> = (args) => {
+export const AsLink: ComponentStory<typeof Button> = (args) => {
 	const Link = useLinkComponent();
 	return <Button as={Link} {...args} />;
 };
-ButtonLink.args = {
+AsLink.args = {
 	children: 'Button Link',
 	block: false,
 	href: '#',

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -1,14 +1,14 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { useLinkComponent } from '@ag.ds-next/core';
 import { Flex } from '@ag.ds-next/box';
-import { allIcons, ExternalLinkIcon } from '@ag.ds-next/icon';
+import { allIcons, AvatarIcon } from '@ag.ds-next/icon';
 import { Text } from '@ag.ds-next/text';
-import { Button, ButtonLink } from './Button';
+import { Button } from './Button';
 import { ButtonGroup } from './ButtonGroup';
 
 export default {
 	title: 'forms/Button',
 	component: Button,
-	subcomponents: { ButtonLink },
 	argTypes: {
 		iconAfter: {
 			options: Object.keys(allIcons), // An array of serializable values
@@ -95,11 +95,11 @@ export const Size: ComponentStory<typeof Button> = (args) => (
 	</ButtonGroup>
 );
 
-export const ButtonLinkStory: ComponentStory<typeof ButtonLink> = (args) => (
-	<ButtonLink {...args} />
-);
-ButtonLinkStory.storyName = 'ButtonLink';
-ButtonLinkStory.args = {
+export const ButtonLink: ComponentStory<typeof Button> = (args) => {
+	const Link = useLinkComponent();
+	return <Button as={Link} {...args} />;
+};
+ButtonLink.args = {
 	children: 'Button Link',
 	block: false,
 	href: '#',
@@ -111,17 +111,5 @@ export const ButtonWithIcon: ComponentStory<typeof Button> = (args) => (
 );
 ButtonWithIcon.args = {
 	children: 'Primary',
-	iconAfter: ExternalLinkIcon,
-};
-
-export const ButtonLinkWithIcon: ComponentStory<typeof ButtonLink> = (args) => (
-	<ButtonLink {...args} />
-);
-ButtonLinkWithIcon.storyName = 'ButtonLink With Icon';
-ButtonLinkWithIcon.args = {
-	children: 'Open external link',
-	href: 'https://steelthreads.github.io/agds-next',
-	target: '_blank',
-	rel: 'noopener noreferrer',
-	iconAfter: ExternalLinkIcon,
+	iconAfter: AvatarIcon,
 };

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -1,14 +1,8 @@
-import {
-	forwardRef,
-	ButtonHTMLAttributes,
-	AnchorHTMLAttributes,
-	ComponentType,
-	Fragment,
-	ReactNode,
-} from 'react';
-import { useLinkComponent } from '@ag.ds-next/core';
+import { ComponentType, Fragment, ReactNode, PropsWithChildren } from 'react';
+import { forwardRefWithAs } from '@ag.ds-next/core';
 import { IconProps } from '@ag.ds-next/icon';
 import { LoadingDots } from '@ag.ds-next/loading';
+import { BaseButton } from './BaseButton';
 import {
 	buttonStyles,
 	ButtonSize,
@@ -16,9 +10,8 @@ import {
 	iconSize,
 	loadingSize,
 } from './styles';
-import { BaseButton } from './BaseButton';
 
-type CommonButtonProps = {
+type ButtonProps = PropsWithChildren<{
 	block?: boolean;
 	iconBefore?: ComponentType<IconProps>;
 	iconAfter?: ComponentType<IconProps>;
@@ -26,67 +19,26 @@ type CommonButtonProps = {
 	loadingLabel?: string;
 	size?: ButtonSize;
 	variant?: ButtonVariant;
-};
+}>;
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
-	CommonButtonProps;
-
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-	function Button(
-		{
-			type = 'button',
-			block = false,
-			iconBefore: IconBefore,
-			iconAfter: IconAfter,
-			children,
-			size = 'md',
-			loading = false,
-			loadingLabel = 'Busy',
-			variant = 'primary',
-			...props
-		},
-		ref
-	) {
-		const styles = buttonStyles({ block, size, variant });
-		return (
-			<BaseButton ref={ref} css={styles} type={type} {...props}>
-				{IconBefore ? (
-					<IconBefore size={iconSize[size]} weight="regular" />
-				) : null}
-				{loading ? (
-					<Fragment>
-						<HiddenText>{children}</HiddenText>
-						<CenteredLoading aria-label={loadingLabel} size={size} />
-					</Fragment>
-				) : (
-					children
-				)}
-				{IconAfter ? (
-					<IconAfter size={iconSize[size]} weight="regular" />
-				) : null}
-			</BaseButton>
-		);
-	}
-);
-
-export type ButtonLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> &
-	CommonButtonProps;
-
-export const ButtonLink = ({
-	children,
-	block = false,
-	iconBefore: IconBefore,
-	iconAfter: IconAfter,
-	size = 'md',
-	loading,
-	loadingLabel = 'Busy',
-	variant = 'primary',
-	...props
-}: ButtonLinkProps) => {
+export const Button = forwardRefWithAs<'button', ButtonProps>(function Button(
+	{
+		as: Tag = BaseButton,
+		block = false,
+		iconBefore: IconBefore,
+		iconAfter: IconAfter,
+		children,
+		size = 'md',
+		loading = false,
+		loadingLabel = 'Busy',
+		variant = 'primary',
+		...props
+	},
+	ref
+) {
 	const styles = buttonStyles({ block, size, variant });
-	const Link = useLinkComponent();
 	return (
-		<Link css={styles} {...props}>
+		<Tag ref={ref} css={styles} {...props}>
 			{IconBefore ? (
 				<IconBefore size={iconSize[size]} weight="regular" />
 			) : null}
@@ -99,9 +51,9 @@ export const ButtonLink = ({
 				children
 			)}
 			{IconAfter ? <IconAfter size={iconSize[size]} weight="regular" /> : null}
-		</Link>
+		</Tag>
 	);
-};
+});
 
 const HiddenText = ({ children }: { children: ReactNode }) => (
 	<span css={{ visibility: 'hidden' }}>{children}</span>

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -24,10 +24,10 @@ type ButtonProps = PropsWithChildren<{
 export const Button = forwardRefWithAs<'button', ButtonProps>(function Button(
 	{
 		as: Tag = BaseButton,
+		children,
 		block = false,
 		iconBefore: IconBefore,
 		iconAfter: IconAfter,
-		children,
 		size = 'md',
 		loading = false,
 		loadingLabel = 'Busy',


### PR DESCRIPTION
## Describe your changes

- Added the ability the forward refs and use the as prop
- Removed `ButtonLink` component. Usage of this component can be replaced with:

```jsx
const Link = useLinkComponent();
return (
	<Button as={LinkComponent} href="/sign-in">
		Sign in
	</Button>
);
```

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [x] Add components to Playroom (docs/playroom/components.js)
- [x] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
