### PR TITLE
direction-link: Use `forwardRefWithAs`

### DIFF
--- a/.changeset/plenty-elephants-cover.md
+++ b/.changeset/plenty-elephants-cover.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/direction-link': major
+---
+
+- Added the ability the forward refs and use the as prop
+- Removed `DirectionButton` component. Usage of this component can be replaced with `<DirectionLink as={BaseButton} {...} />`

--- a/docs/components/design-system-components.tsx
+++ b/docs/components/design-system-components.tsx
@@ -89,7 +89,7 @@ import {
 	SkipLinkContainer,
 	SkipLinkItem,
 } from '@ag.ds-next/skip-link';
-import { DirectionLink, DirectionButton } from '@ag.ds-next/direction-link';
+import { DirectionLink } from '@ag.ds-next/direction-link';
 import { Tags } from '@ag.ds-next/tags';
 import {
 	Content,
@@ -212,7 +212,6 @@ export const designSystemComponents = {
 	SkipLinkContainer,
 	SkipLinkItem,
 	DirectionLink,
-	DirectionButton,
 	Tags,
 	Content,
 	PageContent,

--- a/docs/playroom/components.js
+++ b/docs/playroom/components.js
@@ -99,7 +99,7 @@ export {
 	InpageNavItemContainer,
 	InpageNavTitle,
 } from '@ag.ds-next/inpage-nav';
-export { DirectionLink, DirectionButton } from '@ag.ds-next/direction-link';
+export { DirectionLink } from '@ag.ds-next/direction-link';
 export { Tags } from '@ag.ds-next/tags';
 export { FormStack } from '@ag.ds-next/form-stack';
 export { TaskList } from '@ag.ds-next/task-list';

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep.tsx
@@ -10,8 +10,9 @@ import { Column, Columns } from '@ag.ds-next/columns';
 import { PageContent, ContentBleed } from '@ag.ds-next/content';
 import { ProgressIndicator } from '@ag.ds-next/progress-indicator';
 import { Stack } from '@ag.ds-next/box';
+import { BaseButton } from '@ag.ds-next/button';
 import { Text } from '@ag.ds-next/text';
-import { DirectionButton } from '@ag.ds-next/direction-link';
+import { DirectionLink } from '@ag.ds-next/direction-link';
 import { AppLayout } from '../AppLayout';
 import {
 	FormExampleMultiStep0,
@@ -224,9 +225,9 @@ export const FormExampleMultiStep = () => {
 						</Column>
 						<Column columnSpan={{ xs: 12, md: 8 }} columnStart={{ md: 5 }}>
 							<Stack gap={3} alignItems="flex-start">
-								<DirectionButton direction="left" onClick={back}>
+								<DirectionLink as={BaseButton} direction="left" onClick={back}>
 									Back
-								</DirectionButton>
+								</DirectionLink>
 								{FormStepComponent ? <FormStepComponent /> : null}
 							</Stack>
 						</Column>

--- a/packages/direction-link/README.md
+++ b/packages/direction-link/README.md
@@ -2,7 +2,7 @@
 title: Direction link
 description: Direction links are accompanied by arrows to help users move quickly to other parts of the page or through a process.
 group: Navigation
-storybookPath: /story/navigation-directionlink--on-light
+storybookPath: /story/navigation-directionlink--basic
 ---
 
 Use direction links to indicate a physical direction, such as:

--- a/packages/direction-link/README.md
+++ b/packages/direction-link/README.md
@@ -12,7 +12,7 @@ Use direction links to indicate a physical direction, such as:
 - Showing the `next` or `previous` pages.
 
 ```jsx live
-<Flex flexDirection="column" alignItems="flex-start" gap={2}>
+<Stack gap={2}>
 	<DirectionLink href="#" direction="left">
 		Back
 	</DirectionLink>
@@ -25,15 +25,15 @@ Use direction links to indicate a physical direction, such as:
 	<DirectionLink href="#" direction="down">
 		Skip to footer
 	</DirectionLink>
-</Flex>
+</Stack>
 ```
 
-### Buttons
+### As button element
 
-Sometimes direction is needed inside a form. Buttons offer a way to direct users to the next or previous section inside a form.
+For situations where you need the appearance of a `DirectionLink` but the functionality of a HTML `button` element, you can use `as` prop.
 
 ```jsx live
-<Flex flexDirection="column" alignItems="flex-start" gap={2}>
+<Stack gap={2}>
 	<DirectionLink as={BaseButton} onClick={console.log} direction="left">
 		Back
 	</DirectionLink>
@@ -46,5 +46,5 @@ Sometimes direction is needed inside a form. Buttons offer a way to direct users
 	<DirectionLink as={BaseButton} onClick={console.log} direction="down">
 		Skip to footer
 	</DirectionLink>
-</Flex>
+</Stack>
 ```

--- a/packages/direction-link/README.md
+++ b/packages/direction-link/README.md
@@ -34,17 +34,17 @@ Sometimes direction is needed inside a form. Buttons offer a way to direct users
 
 ```jsx live
 <Flex flexDirection="column" alignItems="flex-start" gap={2}>
-	<DirectionButton onClick={console.log} direction="left">
+	<DirectionLink as={BaseButton} onClick={console.log} direction="left">
 		Back
-	</DirectionButton>
-	<DirectionButton onClick={console.log} direction="right">
+	</DirectionLink>
+	<DirectionLink as={BaseButton} onClick={console.log} direction="right">
 		Next
-	</DirectionButton>
-	<DirectionButton onClick={console.log} direction="up">
+	</DirectionLink>
+	<DirectionLink as={BaseButton} onClick={console.log} direction="up">
 		Top
-	</DirectionButton>
-	<DirectionButton onClick={console.log} direction="down">
+	</DirectionLink>
+	<DirectionLink as={BaseButton} onClick={console.log} direction="down">
 		Skip to footer
-	</DirectionButton>
+	</DirectionLink>
 </Flex>
 ```

--- a/packages/direction-link/src/DirectionLink.stories.tsx
+++ b/packages/direction-link/src/DirectionLink.stories.tsx
@@ -1,46 +1,34 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Flex } from '@ag.ds-next/box';
-import { DirectionLink, DirectionButton } from './index';
+import { Stack } from '@ag.ds-next/box';
+import { BaseButton } from '@ag.ds-next/button';
+import { DirectionLink } from './DirectionLink';
 
 export default {
 	title: 'navigation/DirectionLink',
 	component: DirectionLink,
-	subcomponents: {
-		DirectionButton,
-	},
 } as ComponentMeta<typeof DirectionLink>;
 
-export const OnLight: ComponentStory<typeof DirectionLink> = (args) => (
-	<DirectionLink {...args} />
-);
-OnLight.args = {
+const Template: ComponentStory<typeof DirectionLink> = (args) => {
+	return <DirectionLink {...args} />;
+};
+
+export const Basic = Template.bind({});
+Basic.args = {
 	children: 'Continue',
 	direction: 'right',
 	href: '#',
 };
 
-export const OnDark: ComponentStory<typeof DirectionLink> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<DirectionLink {...args} />
-	</Box>
-);
-OnDark.args = {
-	children: 'Continue',
-	direction: 'right',
-	href: '#',
-};
-
-export const Button: ComponentStory<typeof DirectionButton> = (args) => (
-	<DirectionButton {...args} />
-);
-Button.args = {
-	children: 'Continue',
+export const AsButton = Template.bind({});
+AsButton.args = {
+	as: BaseButton,
+	children: 'Button element',
 	direction: 'right',
 	onClick: console.log,
 };
 
 export const AllDirections = () => (
-	<Flex flexDirection="column" alignItems="flex-start" gap={2}>
+	<Stack gap={1}>
 		<DirectionLink href="#" direction="left">
 			Back
 		</DirectionLink>
@@ -53,5 +41,5 @@ export const AllDirections = () => (
 		<DirectionLink href="#" direction="down">
 			Skip to footer
 		</DirectionLink>
-	</Flex>
+	</Stack>
 );

--- a/packages/direction-link/src/DirectionLink.stories.tsx
+++ b/packages/direction-link/src/DirectionLink.stories.tsx
@@ -28,7 +28,7 @@ AsButton.args = {
 };
 
 export const AllDirections = () => (
-	<Stack gap={1}>
+	<Stack gap={2}>
 		<DirectionLink href="#" direction="left">
 			Back
 		</DirectionLink>

--- a/packages/direction-link/src/DirectionLink.tsx
+++ b/packages/direction-link/src/DirectionLink.tsx
@@ -1,76 +1,47 @@
-import { ButtonHTMLAttributes, ElementType, PropsWithChildren } from 'react';
-import { LinkProps } from '@ag.ds-next/core';
+import { PropsWithChildren } from 'react';
+import { forwardRefWithAs, useLinkComponent } from '@ag.ds-next/core';
 import { Flex } from '@ag.ds-next/box';
-import { BaseButton } from '@ag.ds-next/button';
 import {
 	ArrowDownIcon,
 	ArrowRightIcon,
 	ArrowLeftIcon,
 	ArrowUpIcon,
 } from '@ag.ds-next/icon';
-import { TextLink } from '@ag.ds-next/text-link';
 
 export type Direction = 'up' | 'right' | 'down' | 'left';
 
-export type DirectionLinkProps = LinkProps & {
+export type DirectionLinkProps = PropsWithChildren<{
 	direction: Direction;
-};
-
-export const DirectionLink = ({ children, ...props }: DirectionLinkProps) => (
-	<DirectionLinkBase as={TextLink} {...props}>
-		{children}
-	</DirectionLinkBase>
-);
-
-export type DirectionButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-	direction: Direction;
-};
-
-export const DirectionButton = ({
-	children,
-	...props
-}: DirectionButtonProps) => (
-	<DirectionLinkBase as={BaseButton} {...props}>
-		{children}
-	</DirectionLinkBase>
-);
-
-type DirectionLinkBaseProps = PropsWithChildren<{
-	as: ElementType;
-	direction: Direction;
-	className?: string;
 }>;
 
-const DirectionLinkBase = ({
-	as,
-	children,
-	direction,
-	className,
-	...props
-}: DirectionLinkBaseProps) => {
-	const Icon = iconMap[direction];
-	const iconLeft = direction === 'left';
-	return (
-		<Flex
-			as={as}
-			className={className}
-			inline
-			gap={0.5}
-			alignItems="center"
-			fontFamily="body"
-			fontWeight="normal"
-			link
-			focus
-			{...props}
-		>
-			{iconLeft ? <Icon size="sm" /> : null}
-			{children}
-			{!iconLeft ? <Icon size="sm" /> : null}
-		</Flex>
-	);
-};
+export const DirectionLink = forwardRefWithAs<'a', DirectionLinkProps>(
+	function DirectionLink({ as, children, direction, ...props }, ref) {
+		const Link = useLinkComponent();
+		const Icon = ICON_MAP[direction];
+		const iconLeft = direction === 'left';
+		return (
+			<Flex
+				as={as ?? Link}
+				ref={ref}
+				inline
+				gap={0.5}
+				alignItems="center"
+				fontFamily="body"
+				fontWeight="normal"
+				link
+				focus
+				css={{ alignSelf: 'flex-start' }}
+				{...props}
+			>
+				{iconLeft ? <Icon size="sm" /> : null}
+				{children}
+				{!iconLeft ? <Icon size="sm" /> : null}
+			</Flex>
+		);
+	}
+);
 
-const iconMap = {
+const ICON_MAP = {
 	up: ArrowUpIcon,
 	right: ArrowRightIcon,
 	down: ArrowDownIcon,


### PR DESCRIPTION
## Describe your changes

- Added the ability the forward refs and use the as prop
- Removed `DirectionButton` component. Usage of this component can be replaced with `<DirectionLink as={BaseButton} {...} />`

## Checklist

- [x] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
