### PR TITLE
progress-indicator: Use `forwardRefWithAs`

### DIFF
--- a/.changeset/gold-pants-provide.md
+++ b/.changeset/gold-pants-provide.md
@@ -1,0 +1,11 @@
+---
+'@ag.ds-next/progress-indicator': major
+---
+
+- Added the ability the forward refs and use the as prop
+- Removed `ProgressIndicatorItemLink` and `ProgressIndicatorItemButton`. Usage of these components can be replaced with:
+
+```jsx
+const Link = useLinkComponent();
+return <ProgressIndicatorItem as={LinkComponent} {...} />
+```

--- a/packages/call-to-action/src/CallToAction.tsx
+++ b/packages/call-to-action/src/CallToAction.tsx
@@ -35,7 +35,6 @@ export const CallToAction = forwardRefWithAs<'a', PropsWithChildren<{}>>(
 				onMouseLeave={setMouseOverFalse}
 				gap={0.5}
 				alignItems="center"
-				fontFamily="body"
 				fontWeight="bold"
 				fontSize="md"
 				link

--- a/packages/direction-link/src/DirectionLink.tsx
+++ b/packages/direction-link/src/DirectionLink.tsx
@@ -26,7 +26,7 @@ export const DirectionLink = forwardRefWithAs<'a', DirectionLinkProps>(
 				inline
 				gap={0.5}
 				alignItems="center"
-				fontFamily="body"
+				fontSize="sm"
 				fontWeight="normal"
 				link
 				focus

--- a/packages/progress-indicator/src/ProgressIndicator.stories.tsx
+++ b/packages/progress-indicator/src/ProgressIndicator.stories.tsx
@@ -1,12 +1,12 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useLinkComponent } from '@ag.ds-next/core';
 import { Box } from '@ag.ds-next/box';
 import {
 	ProgressIndicator,
 	ProgressIndicatorCollapseButton,
 	ProgressIndicatorContainer,
-	ProgressIndicatorItemButton,
-	ProgressIndicatorItemLink,
 	ProgressIndicatorList,
+	ProgressIndicatorItem,
 } from './index';
 
 export default {
@@ -15,8 +15,6 @@ export default {
 	subcomponents: {
 		ProgressIndicatorCollapseButton,
 		ProgressIndicatorContainer,
-		ProgressIndicatorItemButton,
-		ProgressIndicatorItemLink,
 		ProgressIndicatorList,
 	},
 } as ComponentMeta<typeof ProgressIndicator>;
@@ -60,22 +58,30 @@ Button.args = {
 	items: exampleButtonItems,
 };
 
-export const ModularLinks = () => (
-	<ProgressIndicatorList>
-		{exampleLinkItems.map(({ label, ...props }, index) => (
-			<ProgressIndicatorItemLink key={index} {...props}>
-				{label}
-			</ProgressIndicatorItemLink>
-		))}
-	</ProgressIndicatorList>
-);
+export const ModularLinks = () => {
+	const Link = useLinkComponent();
+	return (
+		<ProgressIndicatorList>
+			{exampleLinkItems.map(({ label, status, href }, index) => (
+				<ProgressIndicatorItem
+					key={index}
+					as={Link}
+					href={href}
+					status={status}
+				>
+					{label}
+				</ProgressIndicatorItem>
+			))}
+		</ProgressIndicatorList>
+	);
+};
 
 export const ModularButtons = () => (
 	<ProgressIndicatorList>
-		{exampleButtonItems.map(({ label, ...props }, index) => (
-			<ProgressIndicatorItemButton key={index} {...props}>
+		{exampleButtonItems.map(({ label, status, onClick }, index) => (
+			<ProgressIndicatorItem key={index} onClick={onClick} status={status}>
 				{label}
-			</ProgressIndicatorItemButton>
+			</ProgressIndicatorItem>
 		))}
 	</ProgressIndicatorList>
 );

--- a/packages/progress-indicator/src/ProgressIndicator.tsx
+++ b/packages/progress-indicator/src/ProgressIndicator.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 import { useId } from '@reach/auto-id';
 import { useSpring, animated } from '@react-spring/web';
+import { useLinkComponent } from '@ag.ds-next/core';
+import { BaseButton } from '@ag.ds-next/button';
 import {
 	packs,
 	tokens,
@@ -11,17 +13,16 @@ import { ProgressIndicatorCollapseButton } from './ProgressIndicatorCollapseButt
 import { ProgressIndicatorContainer } from './ProgressIndicatorContainer';
 import {
 	ProgressIndicatorItem,
-	ProgressIndicatorItemButton,
-	ProgressIndicatorItemLink,
-	ProgressIndicatorItemLinkProps,
+	ProgressIndicatorItemProps,
 } from './ProgressIndicatorItem';
 import { ProgressIndicatorList } from './ProgressIndicatorList';
 
 export type ProgressIndicatorProps = {
-	items: ProgressIndicatorItem[];
+	items: (Omit<ProgressIndicatorItemProps, 'children'> & { label: string })[];
 };
 
 export const ProgressIndicator = ({ items }: ProgressIndicatorProps) => {
+	const Link = useLinkComponent();
 	const { buttonId, bodyId } = useProgressIndicatorIds();
 	const ref = useRef<HTMLUListElement>(null);
 	const [isOpen, onToggle] = useToggleState(false, true);
@@ -64,20 +65,15 @@ export const ProgressIndicator = ({ items }: ProgressIndicatorProps) => {
 				}}
 			>
 				<ProgressIndicatorList ref={ref}>
-					{items.map(({ label, ...props }, index) => {
-						if (isItemLink(props)) {
-							return (
-								<ProgressIndicatorItemLink key={index} {...props}>
-									{label}
-								</ProgressIndicatorItemLink>
-							);
-						}
-						return (
-							<ProgressIndicatorItemButton key={index} {...props}>
-								{label}
-							</ProgressIndicatorItemButton>
-						);
-					})}
+					{items.map(({ label, ...props }, index) => (
+						<ProgressIndicatorItem
+							key={index}
+							as={'href' in props ? Link : BaseButton}
+							{...props}
+						>
+							{label}
+						</ProgressIndicatorItem>
+					))}
 				</ProgressIndicatorList>
 			</animated.div>
 		</ProgressIndicatorContainer>
@@ -91,7 +87,3 @@ export const useProgressIndicatorIds = () => {
 		bodyId: `progress-indicator-${autoId}-body`,
 	};
 };
-
-export const isItemLink = (
-	item: Omit<ProgressIndicatorItem, 'label'>
-): item is ProgressIndicatorItemLinkProps => 'href' in item;

--- a/packages/progress-indicator/src/ProgressIndicatorCollapseButton.tsx
+++ b/packages/progress-indicator/src/ProgressIndicatorCollapseButton.tsx
@@ -4,13 +4,13 @@ import { Flex } from '@ag.ds-next/box';
 import { ChevronDownIcon } from '@ag.ds-next/icon';
 import { boxPalette, tokens, usePrefersReducedMotion } from '@ag.ds-next/core';
 import { BaseButton } from '@ag.ds-next/button';
-import type { ProgressIndicatorItem } from './ProgressIndicatorItem';
+import type { ProgressIndicatorItemProps } from './ProgressIndicatorItem';
 
 type ProgressIndicatorCollapseButtonProps = {
 	ariaControls: string;
 	id: string;
 	isOpen: boolean;
-	items: ProgressIndicatorItem[];
+	items: (Omit<ProgressIndicatorItemProps, 'children'> & { label: string })[];
 	onClick: () => void;
 };
 

--- a/packages/progress-indicator/src/ProgressIndicatorItem.tsx
+++ b/packages/progress-indicator/src/ProgressIndicatorItem.tsx
@@ -1,76 +1,39 @@
-import { ButtonHTMLAttributes, ElementType, PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 import { Box, Flex } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
-import { TextLink } from '@ag.ds-next/text-link';
 import {
 	ProgressDoingIcon,
 	ProgressDoneIcon,
 	ProgressTodoIcon,
 } from '@ag.ds-next/icon';
-import { boxPalette, LinkProps, packs } from '@ag.ds-next/core';
+import { boxPalette, forwardRefWithAs, packs } from '@ag.ds-next/core';
 import { BaseButton } from '@ag.ds-next/button';
 
-export type ProgressIndicatorItem = (
-	| ProgressIndicatorItemButtonProps
-	| ProgressIndicatorItemLinkProps
-) & {
-	label: string;
-};
-
-export type ProgressIndicatorItemStatus = 'doing' | 'todo' | 'done';
-
-export type ProgressIndicatorItemLinkProps = LinkProps & {
-	status: ProgressIndicatorItemStatus;
-};
-
-export const ProgressIndicatorItemLink = ({
-	children,
-	...props
-}: ProgressIndicatorItemLinkProps) => (
-	<ProgressIndicatorItem as={TextLink} {...props}>
-		{children}
-	</ProgressIndicatorItem>
-);
-
-export type ProgressIndicatorItemButtonProps =
-	ButtonHTMLAttributes<HTMLButtonElement> & {
-		status: ProgressIndicatorItemStatus;
-	};
-
-export const ProgressIndicatorItemButton = ({
-	children,
-	...props
-}: ProgressIndicatorItemButtonProps) => (
-	<ProgressIndicatorItem as={BaseButton} {...props}>
-		{children}
-	</ProgressIndicatorItem>
-);
-
-type ProgressIndicatorItemProps = PropsWithChildren<{
-	as: ElementType;
-	className?: string;
+export type ProgressIndicatorItemProps = PropsWithChildren<{
 	status: ProgressIndicatorItemStatus;
 }>;
 
-const ProgressIndicatorItem = ({
-	as,
-	children,
-	status,
-	className,
-	...props
-}: ProgressIndicatorItemProps) => {
+export type ProgressIndicatorItemStatus = 'doing' | 'todo' | 'done';
+
+export const ProgressIndicatorItem = forwardRefWithAs<
+	'button',
+	ProgressIndicatorItemProps
+>(function ProgressIndicatorItem(
+	{ as = BaseButton, children, status, ...props },
+	ref
+) {
 	const active = status === 'doing';
 	const Icon = statusIconMap[status];
 	return (
 		<Box as="li" borderBottom>
 			<Flex
+				ref={ref}
 				as={as}
-				className={className}
 				alignItems="center"
 				gap={0.75}
 				padding={0.75}
 				color="text"
-				fontFamily="body"
+				fontSize="sm"
 				fontWeight={active ? 'bold' : 'normal'}
 				borderLeft
 				borderLeftWidth="xl"
@@ -96,7 +59,7 @@ const ProgressIndicatorItem = ({
 			</Flex>
 		</Box>
 	);
-};
+});
 
 const statusIconMap = {
 	doing: ProgressDoingIcon,


### PR DESCRIPTION
## Describe your changes

- Added the ability the forward refs and use the as prop
- Removed `ProgressIndicatorItemLink` and `ProgressIndicatorItemButton`. Usage of these components can be replaced with:

```jsx
const Link = useLinkComponent();
return <ProgressIndicatorItem as={LinkComponent} {...} />
```

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook

For new components...

- [x] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
