### PR TITLE
TextLink: Inherit font size

### DIFF
--- a/.changeset/cool-adults-relax.md
+++ b/.changeset/cool-adults-relax.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text-link': patch
+---
+
+Updated `TextLink` to internally render a `Box` instead of `Text`. This is so font size is inherited from the parent.

--- a/.changeset/sweet-actors-hammer.md
+++ b/.changeset/sweet-actors-hammer.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/core': patch
+'@ag.ds-next/side-nav': patch
+'@ag.ds-next/tags': patch
+---
+
+Removed color from `LinkProps`

--- a/packages/core/src/CoreProvider.tsx
+++ b/packages/core/src/CoreProvider.tsx
@@ -15,7 +15,7 @@ const DefaultLinkComponent = forwardRef<
 	return <a ref={ref} {...props} />;
 });
 
-export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>;
+export type LinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'color'>;
 
 export const coreContext = createContext({
 	linkComponent: DefaultLinkComponent,

--- a/packages/side-nav/src/SideNavTitle.tsx
+++ b/packages/side-nav/src/SideNavTitle.tsx
@@ -2,7 +2,7 @@ import { Box } from '@ag.ds-next/box';
 import { LinkProps, packs, useLinkComponent } from '@ag.ds-next/core';
 import { localPalette } from './utils';
 
-export type SideNavTitleProps = Omit<LinkProps, 'color'> & {
+export type SideNavTitleProps = LinkProps & {
 	isCurrentPage?: boolean;
 };
 

--- a/packages/tags/src/Tag.tsx
+++ b/packages/tags/src/Tag.tsx
@@ -2,7 +2,7 @@ import { Box } from '@ag.ds-next/box';
 import { TextLink } from '@ag.ds-next/text-link';
 import { boxPalette, LinkProps } from '@ag.ds-next/core';
 
-export type TagProps = Omit<LinkProps, 'color'>;
+export type TagProps = LinkProps;
 
 export const Tag = (props: TagProps) => {
 	const { children, href } = props;

--- a/packages/text-link/src/TextLink.tsx
+++ b/packages/text-link/src/TextLink.tsx
@@ -1,12 +1,11 @@
+import { Box } from '@ag.ds-next/box';
 import { useLinkComponent, forwardRefWithAs } from '@ag.ds-next/core';
-import { Text } from '@ag.ds-next/text';
+import { TextProps } from '@ag.ds-next/text';
 
-export const TextLink = forwardRefWithAs<'a', {}>(function TextLink(
-	{ as, ...props },
+export const TextLink = forwardRefWithAs<'a', TextProps>(function TextLink(
+	{ as, color = 'action', ...props },
 	ref
 ) {
 	const Link = useLinkComponent();
-	return (
-		<Text as={as ?? Link} ref={ref} color="action" link focus {...props} />
-	);
+	return <Box as={as ?? Link} ref={ref} color={color} link focus {...props} />;
 });


### PR DESCRIPTION
## Describe your changes

Updated `TextLink` to internally render a `Box` instead of `Text`. This is so font size is inherited from the parent.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
