### PR TITLE
docs: Update component names to title case

### DIFF
--- a/.changeset/flat-teachers-smile.md
+++ b/.changeset/flat-teachers-smile.md
@@ -1,0 +1,18 @@
+---
+'@ag.ds-next/call-to-action': patch
+'@ag.ds-next/control-input': patch
+'@ag.ds-next/direction-link': patch
+'@ag.ds-next/file-upload': patch
+'@ag.ds-next/inpage-nav': patch
+'@ag.ds-next/link-list': patch
+'@ag.ds-next/main-nav': patch
+'@ag.ds-next/page-alert': patch
+'@ag.ds-next/progress-indicator': patch
+'@ag.ds-next/secondary-nav': patch
+'@ag.ds-next/side-nav': patch
+'@ag.ds-next/skip-link': patch
+'@ag.ds-next/task-list': patch
+'@ag.ds-next/text-link': patch
+---
+
+Updated documentation

--- a/packages/call-to-action/README.md
+++ b/packages/call-to-action/README.md
@@ -1,5 +1,5 @@
 ---
-title: Call to action
+title: Call To Action
 description: Call to action links are visually distinct instructions to users designed to provoke an immediate response using verbs such as 'call now' or 'find out more'.
 group: Navigation
 storybookPath: /story/navigation-calltoaction--on-light

--- a/packages/control-input/README.md
+++ b/packages/control-input/README.md
@@ -1,5 +1,5 @@
 ---
-title: Control input
+title: Control Input
 description: Control inputs help users input one or more selections from multiple options. Our control inputs consist of checkboxes and radio buttons.
 group: Forms
 storybookPath: /story/forms-checkbox--on-light

--- a/packages/direction-link/README.md
+++ b/packages/direction-link/README.md
@@ -1,5 +1,5 @@
 ---
-title: Direction link
+title: Direction Link
 description: Direction links are accompanied by arrows to help users move quickly to other parts of the page or through a process.
 group: Navigation
 storybookPath: /story/navigation-directionlink--on-light

--- a/packages/file-upload/README.md
+++ b/packages/file-upload/README.md
@@ -1,9 +1,11 @@
 ---
-title: File upload
+title: File Upload
 description: Allows a user to insert a file into a form, via drag-and-drop or using the system file browser.
 group: Forms
 storybookPath: /story/forms-fileupload--on-light
 ---
+
+`FileUpload` is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components).
 
 ```jsx live
 <FileUpload

--- a/packages/inpage-nav/README.md
+++ b/packages/inpage-nav/README.md
@@ -1,5 +1,5 @@
 ---
-title: Inpage nav
+title: Inpage Nav
 description: Inpage nav links helps users scan the contents of a page and navigate to different sections of the page.
 group: Navigation
 storybookPath: /story/navigation-inpagenav--on-light

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -1,5 +1,5 @@
 ---
-title: LinkList
+title: Link List
 description: The link list style is a simple list of vertical or horizontal links used for site navigation. It is used to order information for users.
 group: Navigation
 storybookPath: /story/navigation-linklist--on-light

--- a/packages/main-nav/README.md
+++ b/packages/main-nav/README.md
@@ -1,5 +1,5 @@
 ---
-title: Main nav
+title: Main Nav
 description: A horizontal list of links to key areas on the website. Typically placed in the header.
 group: Navigation
 storybookPath: /story/navigation-mainnav--agriculture-variant

--- a/packages/page-alert/README.md
+++ b/packages/page-alert/README.md
@@ -1,11 +1,11 @@
 ---
-title: Page alert
+title: Page Alert
 description: Page alerts are used to notify users of important information or changes on a page, in a way that attracts the user's attention without interrupting the current task.
 group: Content
 storybookPath: /story/content-page-alert--on-light
 ---
 
-Typically Page Alerts appear at the top of a page following a submit action.
+Typically page alerts appear at the top of a page following a submit action.
 
 ## Tones
 

--- a/packages/progress-indicator/README.md
+++ b/packages/progress-indicator/README.md
@@ -1,5 +1,5 @@
 ---
-title: Progress indicator
+title: Progress Indicator
 description: Progress indicators provide visual feedback to users to let them know and understand their current context at any given time and be assured that they are progressing through the system.
 group: Forms
 storybookPath: /story/forms-progressindicator--on-light

--- a/packages/secondary-nav/README.md
+++ b/packages/secondary-nav/README.md
@@ -1,5 +1,5 @@
 ---
-title: Secondary nav
+title: Secondary Nav
 description: A horizontal list of links typically placed between the main navigation and page content.
 group: Navigation
 storybookPath: /story/navigation-secondarynav--light-variant

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -1,5 +1,5 @@
 ---
-title: Side nav
+title: Side Nav
 description: A vertical list of links for site navigation typically placed next to the body content.
 group: Navigation
 storybookPath: /story/navigation-sidenav--light-variant

--- a/packages/skip-link/README.md
+++ b/packages/skip-link/README.md
@@ -1,5 +1,5 @@
 ---
-title: Skip link
+title: Skip Link
 description: Skip links are internal page links that aid navigation around a page. They are detected by screen readers and help users quickly jump to and over content on the page.
 group: Navigation
 storybookPath: /story/navigation-skiplinks--basic

--- a/packages/task-list/README.md
+++ b/packages/task-list/README.md
@@ -1,5 +1,5 @@
 ---
-title: Task list
+title: Task List
 description:
 group: Forms
 storybookPath: /story/forms-tasklist--on-light

--- a/packages/text-link/README.md
+++ b/packages/text-link/README.md
@@ -1,11 +1,11 @@
 ---
-title: Text link
+title: Text Link
 description: A typographic component for creating a hyperlinks.
 group: Navigation
 storybookPath: /story/navigation-textlink--basic
 ---
 
-This package includes the components `<TextLink />` and `<TextLinkExternal />`.
+This package includes the components `<TextLink />`, `<TextButton />` and `<TextLinkExternal />`.
 
 The `TextLink` component creates a hyperlink to web pages, files, email addresses, locations in the same page, or anything else a URL can address.
 
@@ -15,7 +15,7 @@ The `TextLink` component creates a hyperlink to web pages, files, email addresse
 </Text>
 ```
 
-### As button element
+## TextButton
 
 For situations where you need the appearance of a `TextLink` but the functionality of a HTML `button` element, you can use the `TextButton` component.
 


### PR DESCRIPTION
## Describe your changes

This PR makes sure every component uses title case. Right now, this is a bit inconsistent.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
