### PR TITLE
Add typescript types to playroom

### DIFF
--- a/docs/playroom.config.js
+++ b/docs/playroom.config.js
@@ -1,9 +1,14 @@
 module.exports = {
+	title: 'Playroom | Agriculture Design System',
 	components: './playroom/components',
 	snippets: './playroom/snippets.js',
 	outputPath: './public/playroom',
-	title: 'AgDS Playroom',
 	frameComponent: './playroom/frame.js',
+	typeScriptFiles: [
+		'../packages/**/*.{ts,tsx}',
+		'./components/**/*.{ts,tsx}',
+		'!**/node_modules',
+	],
 	openBrowser: false,
 	webpackConfig: () => ({
 		module: {


### PR DESCRIPTION
## Describe your changes

We need to include ur typescript types in our playroom config, otherwise we don't get the nice autocomplete!

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
