### PR TITLE
playroom: Add button component

### DIFF
--- a/docs/playroom/components.js
+++ b/docs/playroom/components.js
@@ -7,7 +7,12 @@ export {
 } from '@ag.ds-next/accordion';
 export { Body } from '@ag.ds-next/body';
 export { Box, Flex, Stack } from '@ag.ds-next/box';
-export { BaseButton, ButtonLink, ButtonGroup } from '@ag.ds-next/button';
+export {
+	BaseButton,
+	Button,
+	ButtonLink,
+	ButtonGroup,
+} from '@ag.ds-next/button';
 export {
 	Content,
 	ContentBleed,


### PR DESCRIPTION
## Describe your changes

The `Button` component doesn't work in playroom, I believe this was just the result of a bad merge.