### PR TITLE
docs/example: Remove links that open up new tabs

### DIFF
--- a/.changeset/six-sheep-itch.md
+++ b/.changeset/six-sheep-itch.md
@@ -1,0 +1,9 @@
+---
+'@ag.ds-next/docs': minor
+'@ag.ds-next/example-site': minor
+'@ag.ds-next/breadcrumbs': minor
+'@ag.ds-next/button': minor
+'@ag.ds-next/main-nav': minor
+---
+
+Removed `target="_blank"` from all links as per accessibility recommendations.

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -126,11 +126,9 @@ const LiveCode = withLive((props: unknown) => {
 				</Button>
 				<ButtonLink
 					href={playroomUrl}
-					target="_blank"
 					rel="noopener noreferrer"
 					size="sm"
 					variant="tertiary"
-					iconAfter={ExternalLinkIcon}
 					aria-label="Open code snippet in Playroom"
 				>
 					Open in Playroom

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -126,7 +126,6 @@ const LiveCode = withLive((props: unknown) => {
 				</Button>
 				<ButtonLink
 					href={playroomUrl}
-					rel="noopener noreferrer"
 					size="sm"
 					variant="tertiary"
 					aria-label="Open code snippet in Playroom"

--- a/docs/components/EditPage.tsx
+++ b/docs/components/EditPage.tsx
@@ -1,4 +1,4 @@
-import { TextLinkExternal } from '@ag.ds-next/text-link';
+import { TextLink } from '@ag.ds-next/text-link';
 
 const ORG = 'steelthreads';
 const REPO = 'agds-next';
@@ -6,10 +6,8 @@ const BRANCH = 'main';
 
 export function EditPage({ path = '' }) {
 	return (
-		<TextLinkExternal
-			href={`https://github.com/${ORG}/${REPO}/edit/${BRANCH}${path}`}
-		>
+		<TextLink href={`https://github.com/${ORG}/${REPO}/edit/${BRANCH}${path}`}>
 			Edit this page
-		</TextLinkExternal>
+		</TextLink>
 	);
 }

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -1,7 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { useRouter } from 'next/router';
-import { ButtonGroup, ButtonLink } from '@ag.ds-next/button';
-import { ExternalLinkIcon } from '@ag.ds-next/icon';
+import { CallToActionLink } from '@ag.ds-next/call-to-action';
 import { Body } from '@ag.ds-next/body';
 import { SkipLinksProps } from '@ag.ds-next/skip-link';
 import { SubNav } from '@ag.ds-next/sub-nav';
@@ -41,17 +40,11 @@ export function PkgLayout({
 				introduction={pkg.data.description}
 				callToAction={
 					pkg.storybookPath && (
-						<ButtonGroup>
-							<ButtonLink
-								target="_blank"
-								href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${pkg.storybookPath}`}
-								rel="noopener noreferrer"
-								variant="secondary"
-								iconAfter={ExternalLinkIcon}
-							>
-								View in Storybook
-							</ButtonLink>
-						</ButtonGroup>
+						<CallToActionLink
+							href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${pkg.storybookPath}`}
+						>
+							View in Storybook
+						</CallToActionLink>
 					)
 				}
 			/>

--- a/docs/components/SiteFooter.tsx
+++ b/docs/components/SiteFooter.tsx
@@ -4,27 +4,18 @@ import { LinkList } from '@ag.ds-next/link-list';
 import { tokens } from '@ag.ds-next/core';
 
 const footerLinks = [
-	{
-		label: 'Home',
-		href: '/',
-	},
+	{ label: 'Home', href: '/' },
 	{
 		label: 'Storybook',
 		href: 'https://steelthreads.github.io/agds-next/storybook/index.html',
-		target: '_blank',
-		rel: 'noopener noreferrer',
 	},
 	{
 		label: 'Playroom',
 		href: 'https://steelthreads.github.io/agds-next/playroom/index.html',
-		target: '_blank',
-		rel: 'noopener noreferrer',
 	},
 	{
 		label: 'Starter kit',
 		href: 'https://github.com/steelthreads/agds-next-starter-kit',
-		target: '_blank',
-		rel: 'noopener noreferrer',
 	},
 ];
 

--- a/docs/components/SiteHeader.tsx
+++ b/docs/components/SiteHeader.tsx
@@ -3,8 +3,6 @@ import { Logo } from '@ag.ds-next/ag-branding';
 import { Stack } from '@ag.ds-next/box';
 import { Header } from '@ag.ds-next/header';
 import { MainNav, MainNavLink } from '@ag.ds-next/main-nav';
-import { ExternalLinkIcon } from '@ag.ds-next/icon';
-import { ExternalLinkCallout } from '@ag.ds-next/a11y';
 
 const NAV_LINKS = [
 	{ label: 'Home', href: '/' },
@@ -33,16 +31,8 @@ export const SiteHeader = () => {
 				activePath={router.asPath}
 				rightContent={
 					<MainNavLink
-						label={
-							<>
-								GitHub
-								<ExternalLinkCallout />
-							</>
-						}
+						label="GitHub"
 						href="https://github.com/steelthreads/agds-next"
-						target="_blank"
-						rel="noopener noeferrer"
-						icon={ExternalLinkIcon}
 					/>
 				}
 			/>

--- a/docs/components/utils.tsx
+++ b/docs/components/utils.tsx
@@ -1,7 +1,6 @@
 // TODO Rename this file `mdxComponents`
 import { AnchorHTMLAttributes, HTMLAttributes, Fragment } from 'react';
 import Link from 'next/link';
-import { TextLinkExternal } from '@ag.ds-next/text-link';
 import { slugify } from '../lib/slugify';
 import { Code } from './Code';
 
@@ -16,10 +15,6 @@ export const mdxComponents: Record<string, any> = {
 	Fragment,
 	a: ({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
 		if (!href) return <a {...props} />;
-		// Render an external link icon and open page in new tab
-		if (/^(https?:\/\/|\/\/)/i.test(href)) {
-			return <TextLinkExternal href={href} {...props} />;
-		}
 		return <Link href={href} {...props} />;
 	},
 	// Automatically assign an ID to h2 and h3 elements so they can be linked to

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -3,7 +3,7 @@ import { SectionContent } from '@ag.ds-next/content';
 import { Stack } from '@ag.ds-next/box';
 import { CallToActionLink } from '@ag.ds-next/call-to-action';
 import { Body } from '@ag.ds-next/body';
-import { TextLinkExternal } from '@ag.ds-next/text-link';
+import { TextLink } from '@ag.ds-next/text-link';
 import {
 	HeroBanner,
 	HeroBannerTitleContainer,
@@ -39,15 +39,15 @@ export default function Homepage() {
 						<Body>
 							<p>
 								AgDS is based on the{' '}
-								<TextLinkExternal href="https://gold.designsystemau.org/">
+								<TextLink href="https://gold.designsystemau.org/">
 									GOLD Design System
-								</TextLinkExternal>{' '}
+								</TextLink>{' '}
 								which incorporates the highest usability and accessibility
 								standards, helping us to deliver a consistent experience for all
 								users, in line with the{' '}
-								<TextLinkExternal href="https://www.dta.gov.au/help-and-advice/about-digital-service-standard">
+								<TextLink href="https://www.dta.gov.au/help-and-advice/about-digital-service-standard">
 									Digital Service Standard
-								</TextLinkExternal>
+								</TextLink>
 								.
 							</p>
 							<p>
@@ -86,8 +86,6 @@ export default function Homepage() {
 									title="Starter kit"
 									pictogram="starter"
 									href="https://github.com/steelthreads/agds-next-starter-kit"
-									target="_blank"
-									rel="noopener noreferrer"
 								/>
 							</Column>
 						</Columns>

--- a/example-site/components/SiteFooter.tsx
+++ b/example-site/components/SiteFooter.tsx
@@ -4,27 +4,18 @@ import { LinkList } from '@ag.ds-next/link-list';
 import { tokens } from '@ag.ds-next/core';
 
 const footerLinks = [
-	{
-		label: 'Home',
-		href: '/',
-	},
+	{ label: 'Home', href: '/' },
 	{
 		label: 'Storybook',
 		href: 'https://steelthreads.github.io/agds-next/storybook/index.html',
-		target: '_blank',
-		rel: 'noopener noreferrer',
 	},
 	{
 		label: 'Playroom',
 		href: 'https://steelthreads.github.io/agds-next/playroom/index.html',
-		target: '_blank',
-		rel: 'noopener noreferrer',
 	},
 	{
 		label: 'Starter kit',
 		href: 'https://github.com/steelthreads/agds-next-starter-kit',
-		target: '_blank',
-		rel: 'noopener noreferrer',
 	},
 ];
 

--- a/example-site/pages/category/subcategory/multi-page-form/index.tsx
+++ b/example-site/pages/category/subcategory/multi-page-form/index.tsx
@@ -6,7 +6,6 @@ import { Breadcrumbs } from '@ag.ds-next/breadcrumbs';
 import { Stack } from '@ag.ds-next/box';
 import { H2 } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
-import { TextLinkExternal } from '@ag.ds-next/text-link';
 import { AppLayout } from '../../../../components/AppLayout';
 import { DocumentTitle } from '../../../../components/DocumentTitle';
 import { FormHelpCallout } from '../../../../components/FormHelpCallout';
@@ -54,19 +53,19 @@ export default function FormMultiPageHomePage() {
 									<h3>More information link list heading (H3)</h3>
 									<ul>
 										<li>
-											<TextLinkExternal href="#">
+											<a href="#">
 												Meaningful link label that shows link purpose
-											</TextLinkExternal>
+											</a>
 										</li>
 										<li>
-											<TextLinkExternal href="#">
+											<a href="#">
 												Meaningful link label that shows link purpose
-											</TextLinkExternal>
+											</a>
 										</li>
 										<li>
-											<TextLinkExternal href="#">
+											<a href="#">
 												Meaningful link label that shows link purpose
-											</TextLinkExternal>
+											</a>
 										</li>
 									</ul>
 								</Body>

--- a/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
@@ -37,14 +37,6 @@ OnDark.args = {
 
 export const Modular = () => (
 	<BreadcrumbsContainer aria-label="breadcrumb">
-		<BreadcrumbsItem
-			href="https://github.com/steelthreads/agds-next"
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			External
-		</BreadcrumbsItem>
-		<BreadcrumbsDivider />
 		<BreadcrumbsItem href="#one">One</BreadcrumbsItem>
 		<BreadcrumbsDivider />
 		<BreadcrumbsItem href="#two">Two</BreadcrumbsItem>

--- a/packages/button/docs/overview.mdx
+++ b/packages/button/docs/overview.mdx
@@ -109,14 +109,7 @@ A button should have a [meaningful text label](/packages/forms/button/rationale#
 For example, using a magnifying glass icon to indicate to a user they can search for something on mobile.
 
 ```jsx live
-<ButtonLink
-	iconAfter={ExternalLinkIcon}
-	href="https://steelthreads.github.io/agds-next"
-	target="_blank"
-	rel="noopener noreferrer"
->
-	Open external link
-</ButtonLink>
+<ButtonLink iconAfter={AvatarIcon}>Sign out</ButtonLink>
 ```
 
 ### Links

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Flex } from '@ag.ds-next/box';
-import { allIcons, ExternalLinkIcon } from '@ag.ds-next/icon';
+import { allIcons, AvatarIcon } from '@ag.ds-next/icon';
 import { Text } from '@ag.ds-next/text';
 import { Button, ButtonLink } from './Button';
 import { ButtonGroup } from './ButtonGroup';
@@ -110,18 +110,6 @@ export const ButtonWithIcon: ComponentStory<typeof Button> = (args) => (
 	<Button {...args} />
 );
 ButtonWithIcon.args = {
-	children: 'Primary',
-	iconAfter: ExternalLinkIcon,
-};
-
-export const ButtonLinkWithIcon: ComponentStory<typeof ButtonLink> = (args) => (
-	<ButtonLink {...args} />
-);
-ButtonLinkWithIcon.storyName = 'ButtonLink With Icon';
-ButtonLinkWithIcon.args = {
-	children: 'Open external link',
-	href: 'https://steelthreads.github.io/agds-next',
-	target: '_blank',
-	rel: 'noopener noreferrer',
-	iconAfter: ExternalLinkIcon,
+	children: 'Sign out',
+	iconAfter: AvatarIcon,
 };

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -13,12 +13,6 @@ The default link list component removes the normal bullets and spacing associate
 		{ href: '#', label: 'Home' },
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
-		{
-			href: 'https://steelthreads.github.io/agds-next',
-			label: 'External link',
-			target: '_blank',
-			rel: 'external noreferrer',
-		},
 	]}
 />
 ```
@@ -33,12 +27,6 @@ Setting the `horizontal` prop will stack the links horizontally.
 		{ href: '#', label: 'Home' },
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
-		{
-			href: 'https://steelthreads.github.io/agds-next',
-			label: 'External link',
-			target: '_blank',
-			rel: 'external noreferrer',
-		},
 	]}
 	horizontal
 />

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -13,6 +13,12 @@ The default link list component removes the normal bullets and spacing associate
 		{ href: '#', label: 'Home' },
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
+		{
+			href: 'https://steelthreads.github.io/agds-next',
+			label: 'External link',
+			target: '_blank',
+			rel: 'external noreferrer',
+		},
 	]}
 />
 ```
@@ -27,6 +33,12 @@ Setting the `horizontal` prop will stack the links horizontally.
 		{ href: '#', label: 'Home' },
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
+		{
+			href: 'https://steelthreads.github.io/agds-next',
+			label: 'External link',
+			target: '_blank',
+			rel: 'external noreferrer',
+		},
 	]}
 	horizontal
 />

--- a/packages/main-nav/src/MainNav.stories.tsx
+++ b/packages/main-nav/src/MainNav.stories.tsx
@@ -16,12 +16,6 @@ const NAV_ITEMS = [
 	{ href: '#form', label: 'Form page' },
 	{ href: '#', label: 'Simple terms' },
 	{ href: '#', label: 'Distinct from each other' },
-	{
-		href: 'https://steelthreads.github.io/agds-next',
-		label: 'External link',
-		target: '_blank',
-		rel: 'external noreferrer',
-	},
 ];
 
 const defaultArgs = {


### PR DESCRIPTION
## Describe your changes

Removed `target="_blank"` from all links as per accessibility recommendations.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
