### PR TITLE
switch: Prevent hover styles from being applied when element is focused

### DIFF
--- a/.changeset/chilly-dolphins-flash.md
+++ b/.changeset/chilly-dolphins-flash.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/switch': minor
+---
+
+Prevent hover styles from being applied when element is focused

--- a/packages/switch/src/Switch.tsx
+++ b/packages/switch/src/Switch.tsx
@@ -31,14 +31,14 @@ export const Switch = ({
 				cursor: 'pointer',
 				'&:hover': {
 					// Hover state for SwitchTrack
-					'& > div > div:first-of-type': {
+					'& input:not(:focus) ~ div:first-of-type': {
 						borderColor: boxPalette.foregroundText,
 						backgroundColor: checked
 							? boxPalette.foregroundText
 							: boxPalette.backgroundShadeAlt,
 					},
 					// Hover state for SwitchThumb
-					'& > div > div:last-of-type': {
+					'& input:not(:focus) ~ div:last-of-type': {
 						borderColor: boxPalette.foregroundText,
 						'& svg': {
 							stroke: checked ? boxPalette.foregroundText : undefined,


### PR DESCRIPTION
## Describe your changes

Prevent hover styles from being applied when element is focused. 

https://user-images.githubusercontent.com/6265154/175463490-a75593b7-aaa7-4fa6-ae32-329dfa8d4c3b.mov

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
