### PR TITLE
docs: Disable scrolling to the top of the page when using `SubNav`

### DIFF
--- a/.changeset/honest-sloths-shave.md
+++ b/.changeset/honest-sloths-shave.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+Disable scrolling to the top of the page when using `SubNav`

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -61,6 +61,7 @@ export function PkgLayout({
 					links={pkg.subNavItems.map((item) => ({
 						label: item.title,
 						href: item.slug,
+						scroll: false,
 					}))}
 				/>
 			) : null}

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -59,8 +59,7 @@ export function PkgLayout({
 				<SubNav
 					activePath={asPath}
 					links={pkg.subNavItems.map((item) => ({
-						label: item.title,
-						href: item.slug,
+						...item,
 						scroll: false,
 					}))}
 				/>

--- a/docs/components/TemplateLayout.tsx
+++ b/docs/components/TemplateLayout.tsx
@@ -58,7 +58,13 @@ export const TemplateLayout = ({
 						)
 					}
 				/>
-				<SubNav activePath={router.asPath} links={subNavItems} />
+				<SubNav
+					activePath={router.asPath}
+					links={subNavItems.map((item) => ({
+						...item,
+						scroll: false,
+					}))}
+				/>
 				{children}
 				<Callout title="Questions or feedback?">
 					<Text as="p">Contact details go here...</Text>

--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -48,28 +48,28 @@ export async function getPkgSubNavItems(slug: string) {
 		const meta = pkgNavMetaData(slug, data);
 		return [
 			{
-				title: 'Overview',
-				slug: `/packages/${meta.group}/${meta.slug}`,
+				label: 'Overview',
+				href: `/packages/${meta.group}/${meta.slug}`,
 				path: pkgReadmePath(slug),
 			},
 			{
-				title: 'Rationale',
-				slug: `/packages/${meta.group}/${meta.slug}/rationale`,
+				label: 'Rationale',
+				href: `/packages/${meta.group}/${meta.slug}/rationale`,
 				path: pkgReadmePath(slug),
 			},
 			{
-				title: 'Content',
-				slug: `/packages/${meta.group}/${meta.slug}/content`,
+				label: 'Content',
+				href: `/packages/${meta.group}/${meta.slug}/content`,
 				path: `${pkgDocsPath(slug)}/content.mdx`,
 			},
 			{
-				title: 'Code',
-				slug: `/packages/${meta.group}/${meta.slug}/code`,
+				label: 'Code',
+				href: `/packages/${meta.group}/${meta.slug}/code`,
 				path: `${pkgDocsPath(slug)}/code.mdx`,
 			},
 			{
-				title: 'Accessibility',
-				slug: `/packages/${meta.group}/${meta.slug}/accessibility`,
+				label: 'Accessibility',
+				href: `/packages/${meta.group}/${meta.slug}/accessibility`,
 				path: `${pkgDocsPath(slug)}/accessibility.mdx`,
 			},
 		].filter(({ path }) => existsSync(path));


### PR DESCRIPTION
## Describe your changes

Next allows us to prevent scrolling to the top of the page when using their `Link` component. More information  about this can be found here: https://nextjs.org/docs/api-reference/next/link#disable-scrolling-to-the-top-of-the-page

This PR disabled automatic scrolling to top of page for the `SubNav` component on our templates and packages page.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
