### PR TITLE
docs: Fix rationale page showing incorrectly

### DIFF
--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -55,7 +55,7 @@ export async function getPkgSubNavItems(slug: string) {
 			{
 				label: 'Rationale',
 				href: `/packages/${meta.group}/${meta.slug}/rationale`,
-				path: pkgReadmePath(slug),
+				path: `${pkgDocsPath(slug)}/rationale.mdx`,
 			},
 			{
 				label: 'Content',


### PR DESCRIPTION
## Describe your changes

Prevents the `rationale` page appearing on documentation pages where we don't have content.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
