### PR TITLE
ag-branding: New error token

### DIFF
--- a/.changeset/new-err-token.md
+++ b/.changeset/new-err-token.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/ag-branding': patch
+---
+
+New error colour token

--- a/packages/ag-branding/src/theme.ts
+++ b/packages/ag-branding/src/theme.ts
@@ -8,6 +8,7 @@ export const theme: Theme = {
 	darkBackgroundShadeAlt: '#1B3154',
 	darkForegroundAction: '#9EE8FF',
 	accent: '#F36C52',
+	error: '#E60000',
 	success: '#0B996C',
 	successMuted: '#E8FFF4',
 	warning: '#E67300',


### PR DESCRIPTION
## Describe your changes

Add an "ag overwrite" for the system error token colour.
The result is a much more vibrant red which improves contrast on dark mode:

<img width="974" alt="image" src="https://user-images.githubusercontent.com/12689383/176815011-8ddb5e3b-d28b-494c-85f9-408793010b45.png">
<img width="932" alt="image" src="https://user-images.githubusercontent.com/12689383/176815042-1de3da6e-5311-4323-ab40-d78f94b1a314.png">


## Checklist

- [x] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
