### PR TITLE
field: add flex shrink to message error icon

### DIFF
--- a/.changeset/long-chairs-know.md
+++ b/.changeset/long-chairs-know.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/field': patch
 ---
 
-Prevent flex shrink of field message alert icon
+Prevent flex shrinking of field message alert icon

--- a/.changeset/long-chairs-know.md
+++ b/.changeset/long-chairs-know.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/field': patch
+---
+
+Prevent flex shrink of field message alert icon

--- a/packages/field/src/FieldMessage.tsx
+++ b/packages/field/src/FieldMessage.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@ag.ds-next/box';
+import { Box, Flex } from '@ag.ds-next/box';
 import { AlertFilledIcon } from '@ag.ds-next/icon';
 import { Text } from '@ag.ds-next/text';
 
@@ -14,7 +14,11 @@ export const FieldMessage = ({
 	valid?: boolean;
 }) => (
 	<Flex gap={0.5} alignItems="center">
-		{invalid ? <AlertFilledIcon color="error" size="md" /> : null}
+		{invalid ? (
+			<Box flexShrink={0}>
+				<AlertFilledIcon color="error" size="md" />
+			</Box>
+		) : null}
 		<Text
 			display="block"
 			fontWeight="bold"


### PR DESCRIPTION
## Describe your changes

Prevent flex shrinking of field message alert icon

| Before      | After |
| ----------- | ----------- |
| <img width="330" alt="Screen Shot 2022-07-05 at 11 29 47 am" src="https://user-images.githubusercontent.com/6265154/177234101-76a4216e-e0e7-4bf1-b832-ef372970e8f0.png">      | <img width="330" alt="Screen Shot 2022-07-05 at 11 29 26 am" src="https://user-images.githubusercontent.com/6265154/177234095-0e591cd3-e948-48ae-acc7-ca96a14ae7f8.png">       |

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in package.json is set to 0.0.1
- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
