### PR TITLE
docs: Adjust widths in props table

### DIFF
--- a/.changeset/small-toys-visit.md
+++ b/.changeset/small-toys-visit.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/table': patch
+---
+
+Added more options to the `width` prop in `TableOption`

--- a/docs/components/ComponentPropsTable.tsx
+++ b/docs/components/ComponentPropsTable.tsx
@@ -35,7 +35,7 @@ export const ComponentPropsTable = ({ data }: ComponentPropsTableProps) => (
 				<TableHeader scope="col" width="35%">
 					Type
 				</TableHeader>
-				<TableHeader scope="col" width="45%">
+				<TableHeader scope="col" width="40%">
 					Description
 				</TableHeader>
 			</tr>

--- a/docs/components/ComponentPropsTable.tsx
+++ b/docs/components/ComponentPropsTable.tsx
@@ -29,13 +29,13 @@ export const ComponentPropsTable = ({ data }: ComponentPropsTableProps) => (
 		<TableCaption>{data.displayName} Props</TableCaption>
 		<TableHead>
 			<tr>
-				<TableHeader scope="col" width="33%">
+				<TableHeader scope="col" width="25%">
 					Prop
 				</TableHeader>
-				<TableHeader scope="col" width="33%">
+				<TableHeader scope="col" width="35%">
 					Type
 				</TableHeader>
-				<TableHeader scope="col" width="33%">
+				<TableHeader scope="col" width="45%">
 					Description
 				</TableHeader>
 			</tr>

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -3,6 +3,7 @@ import { Box } from '@ag.ds-next/box';
 import { boxPalette } from '@ag.ds-next/core';
 
 export type TableProps = PropsWithChildren<{
+	/** If true, alternating rows will have a different background colour. */
 	striped?: boolean;
 }>;
 

--- a/packages/table/src/TableCell.tsx
+++ b/packages/table/src/TableCell.tsx
@@ -3,8 +3,11 @@ import { Box } from '@ag.ds-next/box';
 import { ResponsiveProp } from '@ag.ds-next/core';
 
 export type TableCellProps = PropsWithChildren<{
+	/** Can be used to conditionally hide or show table cells at different breakpoints. */
 	display?: ResponsiveProp<'none' | 'table-cell'>;
+	/** Sets the horizontal alignment of the content. */
 	textAlign?: 'center' | 'left' | 'right';
+	/** Sets the vertical alignment of the content. */
 	verticalAlign?: 'top' | 'middle' | 'bottom';
 }>;
 

--- a/packages/table/src/TableHeader.tsx
+++ b/packages/table/src/TableHeader.tsx
@@ -4,11 +4,24 @@ import { ResponsiveProp } from '@ag.ds-next/core';
 
 export type TableHeaderWidthType =
 	| '10%'
+	| '15%'
 	| '20%'
 	| '25%'
+	| '30%'
 	| '33%'
+	| '35%'
+	| '40%'
+	| '45%'
 	| '50%'
-	| '75%';
+	| '55%'
+	| '60%'
+	| '65%'
+	| '66%'
+	| '70%'
+	| '75%'
+	| '80%'
+	| '85%'
+	| '90%';
 
 export type TableHeaderProps = PropsWithChildren<{
 	scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';

--- a/packages/table/src/TableHeader.tsx
+++ b/packages/table/src/TableHeader.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react';
-import { Box, BoxProps } from '@ag.ds-next/box';
+import { Box } from '@ag.ds-next/box';
 import { ResponsiveProp } from '@ag.ds-next/core';
 
 export type TableHeaderWidthType =
@@ -24,11 +24,15 @@ export type TableHeaderWidthType =
 	| '90%';
 
 export type TableHeaderProps = PropsWithChildren<{
+	/** Can be used to conditionally hide or show table cells at different breakpoints. */
+	display?: ResponsiveProp<'none' | 'table-cell'>;
+	/** Defines the cells that the header (defined in the <th>) element relates to. */
 	scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+	/** Sets the horizontal alignment of the content. */
 	textAlign?: 'left' | 'center' | 'right';
+	/** Sets the width of the column. */
 	width?: ResponsiveProp<TableHeaderWidthType>;
-}> &
-	Pick<BoxProps, 'display'>;
+}>;
 
 export const TableHeader = ({
 	children,


### PR DESCRIPTION
## Describe your changes

Adjust widths to improve content in the component props table

<img width="818" alt="Screen Shot 2022-07-06 at 9 26 59 am" src="https://user-images.githubusercontent.com/6265154/177433146-04974393-d6e6-4d21-97f9-4ff6a3bd7571.png">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in package.json is set to 0.0.1
- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
