### PR TITLE
button: Add default `type` to `BaseButton`

### DIFF
--- a/.changeset/grumpy-stingrays-repeat.md
+++ b/.changeset/grumpy-stingrays-repeat.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/button': patch
+---
+
+Added default `type="button"` to `BaseButton`

--- a/packages/button/src/BaseButton.tsx
+++ b/packages/button/src/BaseButton.tsx
@@ -32,7 +32,10 @@ export type BaseButtonProps = PropsWithChildren<{
 }>;
 
 export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
-	function BaseButton({ onClick: onClickProp, ...props }, forwardedRef) {
+	function BaseButton(
+		{ onClick: onClickProp, type = 'button', ...props },
+		forwardedRef
+	) {
 		const ref = useRef<HTMLButtonElement>(null);
 
 		/**
@@ -50,6 +53,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
 		return (
 			<button
 				ref={mergeRefs([ref, forwardedRef])}
+				type={type}
 				onClick={onClick}
 				css={{
 					appearance: 'none',


### PR DESCRIPTION
## Describe your changes

All buttons in the design system are routed through our `BaseButton` component which provides us with a blank slate for styling, as well as a centralised place to fixing any global a11y issues. This PR adds the `type="button` to button components by default, which will prevent various components from accidentally submitting forms.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in package.json is set to 0.0.1
- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/utils.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
