### PR TITLE
Story: Visualisation of background tokens

### DIFF
--- a/packages/core/src/tokens.stories.tsx
+++ b/packages/core/src/tokens.stories.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { CardList, Card, CardInner } from '@ag.ds-next/card';
 import { H2 } from '@ag.ds-next/heading';
+import { Body } from '@ag.ds-next/body';
 import { boxPalette } from './boxPalette';
 import { mapSpacing, Spacing } from './tokens';
 import { globalPalette } from './globalPalette';
@@ -73,6 +74,52 @@ export const Color = () => {
 				</CardList>
 			</Stack>
 		</Stack>
+	);
+};
+
+const BackgroundRow = ({ palette }: { palette: 'light' | 'dark' }) => (
+	<Flex palette={palette} width="100%">
+		<Flex padding={2} background="body" flexGrow={1}>
+			<Box flexGrow={1} color="text" paddingY={2} paddingX={1}>
+				backgroundBody
+			</Box>
+			<Box
+				flexGrow={1}
+				color="text"
+				paddingY={2}
+				paddingX={1}
+				background="shade"
+			>
+				backgroundShade
+			</Box>
+		</Flex>
+		<Flex padding={2} background="bodyAlt" flexGrow={1}>
+			<Box flexGrow={1} color="text" paddingY={2} paddingX={1}>
+				backgroundBodyAlt
+			</Box>
+			<Box
+				flexGrow={1}
+				color="text"
+				paddingY={2}
+				paddingX={1}
+				background="shadeAlt"
+			>
+				backgroundShadeAlt
+			</Box>
+		</Flex>
+	</Flex>
+);
+
+export const Backgrounds = () => {
+	return (
+		<>
+			<Body>
+				<h2>Backgrounds</h2>
+				<p>A visualisation of how body and shade backgrounds work together.</p>
+			</Body>
+			<BackgroundRow palette="light" />
+			<BackgroundRow palette="dark" />
+		</>
 	);
 };
 


### PR DESCRIPTION
## Describe your changes
Add a backgrounds story to the Core/Tokens group. This is a visualisation of how backgrounds work together.
Please note that colours in screenshot do not match live tokens.
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/12689383/178638109-8212f427-b826-4da0-aebc-9a9d765a202c.png">

<img width="258" alt="image" src="https://user-images.githubusercontent.com/12689383/178638177-a1139b6b-4da1-4499-a2c5-964a96a8c76a.png">