### PR TITLE
Storybook: Add 'palette' selection for preview area

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -48,14 +48,6 @@ export const globalTypes = {
 			showName: true,
 		},
 	},
-	bg: {
-		name: 'Background',
-		defaultValue: 'body',
-		toolbar: {
-			items: ['body', 'bodyAlt', 'shade', 'shadeAlt'],
-			showName: true,
-		},
-	},
 };
 
 export const parameters = {
@@ -82,7 +74,6 @@ const getTheme = (brand) => {
 const withBrandTheme = (Story, context) => {
 	const brand = getTheme(context.globals.brand);
 	const palette = context.globals.palette;
-	const background = context.globals.bg;
 	return (
 		<Core theme={brand}>
 			<Box
@@ -90,7 +81,7 @@ const withBrandTheme = (Story, context) => {
 				minHeight="100vh"
 				padding={1}
 				palette={palette}
-				background={background}
+				background="body"
 			>
 				<Story />
 			</Box>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { Box } from '@ag.ds-next/box';
 import { Core, tokens } from '@ag.ds-next/core';
 import { theme } from '@ag.ds-next/ag-branding';
 
@@ -38,9 +40,26 @@ export const globalTypes = {
 			showName: true,
 		},
 	},
+	palette: {
+		name: 'Palette',
+		defaultValue: 'light',
+		toolbar: {
+			items: ['light', 'dark'],
+			showName: true,
+		},
+	},
+	bg: {
+		name: 'Background',
+		defaultValue: 'body',
+		toolbar: {
+			items: ['body', 'bodyAlt', 'shade', 'shadeAlt'],
+			showName: true,
+		},
+	},
 };
 
 export const parameters = {
+	layout: 'fullscreen',
 	actions: { argTypesRegex: '^on[A-Z].*' },
 	controls: {
 		matchers: {
@@ -61,10 +80,20 @@ const getTheme = (brand) => {
 };
 
 const withBrandTheme = (Story, context) => {
-	const palette = getTheme(context.globals.brand);
+	const brand = getTheme(context.globals.brand);
+	const palette = context.globals.palette;
+	const background = context.globals.bg;
 	return (
-		<Core theme={palette}>
-			<Story />
+		<Core theme={brand}>
+			<Box
+				width="100%"
+				minHeight="100vh"
+				padding={1}
+				palette={palette}
+				background={background}
+			>
+				<Story />
+			</Box>
 		</Core>
 	);
 };

--- a/packages/ag-branding/docs/overview.mdx
+++ b/packages/ag-branding/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: AG Branding
 description: A colour palette and logo set for Agriculture
 group: Brand
-storybookPath: /story/brand-ag-branding-logo--on-light
+storybookPath: /story/brand-ag-branding-logo--logo
 ---
 
 ## Agriculture theme

--- a/packages/ag-branding/docs/overview.mdx
+++ b/packages/ag-branding/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: AG Branding
 description: A colour palette and logo set for Agriculture
 group: Brand
-storybookPath: /story/brand-ag-branding-logo--logo
+storybookPath: /story/brand-ag-branding--logo
 ---
 
 ## Agriculture theme
@@ -25,7 +25,7 @@ export default function App({ Component }) {
 ## Agriculture logo
 
 ```jsx live
-<Box maxWidth={600}>
+<Box maxWidth={600} color="text">
 	<Logo />
 </Box>
 ```

--- a/packages/ag-branding/src/Logo.stories.tsx
+++ b/packages/ag-branding/src/Logo.stories.tsx
@@ -3,12 +3,12 @@ import { Box } from '@ag.ds-next/box';
 import { Logo as AgLogo } from './Logo';
 
 export default {
-	title: 'Brand/AG Branding/Logo',
+	title: 'Brand/AG Branding',
 	component: AgLogo,
 } as ComponentMeta<typeof AgLogo>;
 
 export const Logo: ComponentStory<typeof AgLogo> = () => (
-	<Box maxWidth={600} background="body" color="text" padding={1.5}>
+	<Box maxWidth={600} color="text">
 		<AgLogo />
 	</Box>
 );

--- a/packages/ag-branding/src/Logo.stories.tsx
+++ b/packages/ag-branding/src/Logo.stories.tsx
@@ -1,22 +1,14 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Box } from '@ag.ds-next/box';
-import { Logo } from './Logo';
+import { Logo as AgLogo } from './Logo';
 
 export default {
 	title: 'Brand/AG Branding/Logo',
-	component: Logo,
-} as ComponentMeta<typeof Logo>;
+	component: AgLogo,
+} as ComponentMeta<typeof AgLogo>;
 
-export const OnLight: ComponentStory<typeof Logo> = () => (
+export const Logo: ComponentStory<typeof AgLogo> = () => (
 	<Box maxWidth={600}>
-		<Logo />
-	</Box>
-);
-
-export const OnDark: ComponentStory<typeof Logo> = () => (
-	<Box palette="dark" background="body" color="text" padding={1.5}>
-		<Box maxWidth={600}>
-			<Logo />
-		</Box>
+		<AgLogo />
 	</Box>
 );

--- a/packages/ag-branding/src/Logo.stories.tsx
+++ b/packages/ag-branding/src/Logo.stories.tsx
@@ -8,7 +8,7 @@ export default {
 } as ComponentMeta<typeof AgLogo>;
 
 export const Logo: ComponentStory<typeof AgLogo> = () => (
-	<Box maxWidth={600}>
+	<Box maxWidth={600} background="body" color="text" padding={1.5}>
 		<AgLogo />
 	</Box>
 );

--- a/packages/badge/docs/overview.mdx
+++ b/packages/badge/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Badge
 description: Badges are decorative indicators used to either call attention to an item or for communicating non-actionable, supplemental information.
 group: Content
-storybookPath: /story/content-badge--on-light
+storybookPath: /story/content-badge-statusbadge--basic
 ---
 
 ## StatusBadge

--- a/packages/badge/src/IndicatorDot.stories.tsx
+++ b/packages/badge/src/IndicatorDot.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { IndicatorDot } from './IndicatorDot';
 
 export default {
@@ -7,20 +6,9 @@ export default {
 	component: IndicatorDot,
 } as ComponentMeta<typeof IndicatorDot>;
 
-const Template: ComponentStory<typeof IndicatorDot> = (args) => (
+export const Basic: ComponentStory<typeof IndicatorDot> = (args) => (
 	<IndicatorDot {...args} />
 );
-
-export const OnLight = Template.bind({});
-OnLight.args = {
-	tone: 'neutral',
-};
-
-export const OnDark: ComponentStory<typeof IndicatorDot> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	tone: 'neutral',
 };

--- a/packages/badge/src/NotificationBadge.stories.tsx
+++ b/packages/badge/src/NotificationBadge.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { NotificationBadge } from './NotificationBadge';
 
 export default {
@@ -11,20 +10,9 @@ const Template: ComponentStory<typeof NotificationBadge> = (args) => (
 	<NotificationBadge {...args} />
 );
 
-export const OnLight = Template.bind({});
-OnLight.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	value: 48,
-	tone: 'neutral',
-};
-
-export const OnDark: ComponentStory<typeof NotificationBadge> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
-	value: 64,
-	max: 99,
 	tone: 'neutral',
 };
 

--- a/packages/badge/src/StatusBadge.stories.tsx
+++ b/packages/badge/src/StatusBadge.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Flex, Stack } from '@ag.ds-next/box';
+import { Flex, Stack } from '@ag.ds-next/box';
 import { StatusBadge } from './StatusBadge';
 
 export default {
@@ -11,18 +11,8 @@ const Template: ComponentStory<typeof StatusBadge> = (args) => (
 	<StatusBadge {...args} />
 );
 
-export const OnLight = Template.bind({});
-OnLight.args = {
-	tone: 'info',
-	label: 'In progress',
-};
-
-export const OnDark: ComponentStory<typeof StatusBadge> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	tone: 'info',
 	label: 'In progress',
 };

--- a/packages/body/docs/overview.mdx
+++ b/packages/body/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Body
 description: Provides correct styling for Markdown or CMS content.
 group: Content
-storybookPath: /story/content-body--on-light
+storybookPath: /story/content-body--body
 ---
 
 Many sites will have content being generated in a WYSIWIG or HTML field within a content management system. This content is inherently difficult to style as developers often times have limited control over the markup being generated in these editors. `Body` is designed to apply styling to make CMS content look ok.

--- a/packages/body/src/Body.stories.tsx
+++ b/packages/body/src/Body.stories.tsx
@@ -1,13 +1,13 @@
 import { Fragment } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Body } from './index';
+import { Body as BodyComponent } from './index';
 
 export default {
 	title: 'content/Body',
-	component: Body,
-} as ComponentMeta<typeof Body>;
+	component: BodyComponent,
+} as ComponentMeta<typeof BodyComponent>;
 
-const Template = () => (
+const UnstyledContent = () => (
 	<Fragment>
 		<h1>Heading level 1. Page heading</h1>
 		<h2>Heading level 2, proceeding H1</h2>
@@ -225,14 +225,8 @@ const Template = () => (
 	</Fragment>
 );
 
-export const OnLight: ComponentStory<typeof Body> = (args) => (
-	<Body {...args}>
-		<Template />
-	</Body>
-);
-
-export const OnDark: ComponentStory<typeof Body> = (args) => (
-	<Body palette="dark" background="body" padding={1.5} {...args}>
-		<Template />
-	</Body>
+export const Body: ComponentStory<typeof BodyComponent> = (args) => (
+	<BodyComponent {...args}>
+		<UnstyledContent />
+	</BodyComponent>
 );

--- a/packages/box/docs/overview.mdx
+++ b/packages/box/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Box
 description: A set of primitive layout components
 group: Foundations
-storybookPath: /story/foundations-box--light-box
+storybookPath: /story/foundations-box--basic
 ---
 
 This package includes the components `<Box />`, `<Flex />` and `<Stack />`.

--- a/packages/box/src/Box.stories.tsx
+++ b/packages/box/src/Box.stories.tsx
@@ -11,31 +11,15 @@ const Template: ComponentStory<typeof Box> = (args) => <Box {...args} />;
 /**
  * The Box with a Light palette applied
  */
-export const LightBox = Template.bind({});
-LightBox.args = {
-	children: 'A light box',
+export const Basic = Template.bind({});
+Basic.args = {
+	children: 'Box with a border',
 	background: 'body',
 	color: 'text',
 	padding: 2,
 	border: true,
 	rounded: true,
-	// palette: 'light',
 	light: true,
-};
-
-/**
- * The Box with a Dark palette applied
- */
-export const DarkBox = Template.bind({});
-DarkBox.args = {
-	children: 'Dark box',
-	background: 'body',
-	color: 'text',
-	padding: 2,
-	border: true,
-	rounded: true,
-	// palette: 'dark',
-	dark: true,
 };
 
 /** Responsive props */

--- a/packages/breadcrumbs/docs/overview.mdx
+++ b/packages/breadcrumbs/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Breadcrumbs
 description: Breadcrumbs are a navigational aid that display a user's location on a website as a row of links, usually located at the top of the page.
 group: Navigation
-storybookPath: /story/navigation-breadcrumbs--on-light
+storybookPath: /story/navigation-breadcrumbs--basic
 ---
 
 Breadcrumbs show users where they are in the website hierarchy and how to navigate back/up to previous levels or content.

--- a/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
@@ -19,19 +19,10 @@ const exampleLinks = [
 	{ label: 'Applications' },
 ];
 
-export const OnLight: ComponentStory<typeof Breadcrumbs> = (args) => (
+export const Basic: ComponentStory<typeof Breadcrumbs> = (args) => (
 	<Breadcrumbs {...args} />
 );
-OnLight.args = {
-	links: exampleLinks,
-};
-
-export const OnDark: ComponentStory<typeof Breadcrumbs> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Breadcrumbs {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	links: exampleLinks,
 };
 

--- a/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import {
 	Breadcrumbs,
 	BreadcrumbsDivider,

--- a/packages/button/docs/overview.mdx
+++ b/packages/button/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Button
 description: Buttons trigger actions and can communicate the hierarchy of interactions a user can choose.
 group: Forms
-storybookPath: /story/forms-button--on-light
+storybookPath: /story/forms-button--basic
 ---
 
 ```jsx live

--- a/packages/button/src/Button.stories.tsx
+++ b/packages/button/src/Button.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
-import { Flex } from '@ag.ds-next/box';
 import { allIcons, AvatarIcon } from '@ag.ds-next/icon';
 import { Text } from '@ag.ds-next/text';
 import { Button, ButtonLink } from './Button';
@@ -21,7 +20,7 @@ export default {
 	},
 } as ComponentMeta<typeof Button>;
 
-export const OnLight: ComponentStory<typeof Button> = (args) => (
+export const Basic: ComponentStory<typeof Button> = (args) => (
 	<ButtonGroup>
 		<Button {...args}>Primary</Button>
 		<Button {...args} variant="secondary">
@@ -32,26 +31,7 @@ export const OnLight: ComponentStory<typeof Button> = (args) => (
 		</Button>
 	</ButtonGroup>
 );
-OnLight.args = {
-	block: false,
-	disabled: false,
-	loading: false,
-};
-
-export const OnDark: ComponentStory<typeof Button> = (args) => (
-	<Flex padding={1.5} background="body" palette="dark">
-		<ButtonGroup>
-			<Button {...args}>Primary</Button>
-			<Button {...args} variant="secondary">
-				Secondary
-			</Button>
-			<Button {...args} variant="tertiary">
-				Tertiary
-			</Button>
-		</ButtonGroup>
-	</Flex>
-);
-OnDark.args = {
+Basic.args = {
 	block: false,
 	disabled: false,
 	loading: false,

--- a/packages/call-to-action/docs/overview.mdx
+++ b/packages/call-to-action/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Call To Action
 description: Call to action links are visually distinct instructions to users designed to provoke an immediate response using verbs such as 'call now' or 'find out more'.
 group: Navigation
-storybookPath: /story/navigation-calltoaction--on-light
+storybookPath: /story/navigation-calltoaction--basic
 ---
 
 A simple and clear link to direct users to a preferred action.

--- a/packages/call-to-action/src/CallToAction.stories.tsx
+++ b/packages/call-to-action/src/CallToAction.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { CallToActionLink, CallToActionButton } from './index';
 
 export default {
@@ -8,25 +7,15 @@ export default {
 	subcomponents: { CallToActionButton },
 } as ComponentMeta<typeof CallToActionLink>;
 
-export const OnLight: ComponentStory<typeof CallToActionLink> = (args) => (
+export const Basic: ComponentStory<typeof CallToActionLink> = (args) => (
 	<CallToActionLink {...args} />
 );
-OnLight.args = {
+Basic.args = {
 	children: 'Sign up',
 	href: '#',
 };
 
-export const OnDark: ComponentStory<typeof CallToActionLink> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<CallToActionLink {...args} />
-	</Box>
-);
-OnDark.args = {
-	children: 'Sign up',
-	href: '#',
-};
-
-export const Button: ComponentStory<typeof CallToActionButton> = (args) => (
+const Button: ComponentStory<typeof CallToActionButton> = (args) => (
 	<CallToActionButton {...args} />
 );
 Button.args = {

--- a/packages/card/docs/overview.mdx
+++ b/packages/card/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Card
 description: The card component is used to provide a brief summary of content or a task, often with a link to more detail. Cards are frequently displayed alongside other cards to group related content or tasks.
 group: Layout
-storybookPath: /story/layout-card--on-light
+storybookPath: /story/layout-card--basic
 ---
 
 ## Basic card

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -21,7 +21,7 @@ export default {
 	subcomponents: { CardInner, CardLink, CardList, CardHeader, CardFooter },
 } as ComponentMeta<typeof Card>;
 
-export const OnLight: ComponentStory<typeof Card> = (args) => (
+export const Basic: ComponentStory<typeof Card> = (args) => (
 	<Box maxWidth={300}>
 		<Card {...args}>
 			<CardInner>
@@ -40,30 +40,6 @@ export const OnLight: ComponentStory<typeof Card> = (args) => (
 				</Stack>
 			</CardInner>
 		</Card>
-	</Box>
-);
-
-export const OnDark: ComponentStory<typeof Card> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Box maxWidth={300}>
-			<Card {...args}>
-				<CardInner>
-					<Stack gap={1}>
-						<Heading as="h2" type="h3">
-							Card heading
-						</Heading>
-						<Text as="p">
-							Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
-							voluptatibus.
-						</Text>
-						<CardLink href="#">
-							Linking out
-							<ChevronRightIcon weight="bold" size="sm" />
-						</CardLink>
-					</Stack>
-				</CardInner>
-			</Card>
-		</Box>
 	</Box>
 );
 

--- a/packages/control-input/docs/overview.mdx
+++ b/packages/control-input/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Control Input
 description: Control inputs help users input one or more selections from multiple options. Our control inputs consist of checkboxes and radio buttons.
 group: Forms
-storybookPath: /story/forms-checkbox--on-light
+storybookPath: /story/forms-checkbox--basic
 ---
 
 ### Checkbox

--- a/packages/control-input/src/Checkbox.stories.tsx
+++ b/packages/control-input/src/Checkbox.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { Checkbox } from './Checkbox';
 
 export default {
@@ -11,18 +10,8 @@ const Template: ComponentStory<typeof Checkbox> = (args) => (
 	<Checkbox {...args} />
 );
 
-export const OnLight = Template.bind({});
-OnLight.args = {
-	children: 'Example',
-	disabled: false,
-};
-
-export const OnDark: ComponentStory<typeof Checkbox> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	children: 'Example',
 	disabled: false,
 };

--- a/packages/control-input/src/ControlGroup.stories.tsx
+++ b/packages/control-input/src/ControlGroup.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { FormStack } from '@ag.ds-next/form-stack';
 import { Checkbox } from './Checkbox';
 import { Radio } from './Radio';
@@ -43,19 +42,10 @@ const Template: ComponentStory<typeof ControlGroup> = (args) => (
 	</FormStack>
 );
 
-export const OnLight: ComponentStory<typeof ControlGroup> = (args) => (
+export const Basic: ComponentStory<typeof ControlGroup> = (args) => (
 	<Template {...args} />
 );
-OnLight.args = {
-	label: 'Choose your interests',
-};
-
-export const OnDark: ComponentStory<typeof ControlGroup> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	label: 'Choose your interests',
 };
 

--- a/packages/control-input/src/Radio.stories.tsx
+++ b/packages/control-input/src/Radio.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { Radio } from './Radio';
 
 export default {
@@ -9,18 +8,8 @@ export default {
 
 const Template: ComponentStory<typeof Radio> = (args) => <Radio {...args} />;
 
-export const OnLight = Template.bind({});
-OnLight.args = {
-	children: 'Example',
-	checked: true,
-};
-
-export const OnDark: ComponentStory<typeof Radio> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	children: 'Example',
 	checked: true,
 };

--- a/packages/date-picker/docs/overview.mdx
+++ b/packages/date-picker/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Date Picker
 description: Allow users to select a single date or a range of dates.
 group: forms
-storybookPath: /story/forms-datepicker-datepicker--on-light
+storybookPath: /story/forms-datepicker-datepicker--basic
 ---
 
 ## Date Picker

--- a/packages/date-picker/src/Calendar.stories.tsx
+++ b/packages/date-picker/src/Calendar.stories.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { DateUtils } from 'react-day-picker';
-import { Box } from '@ag.ds-next/box';
 import { Calendar, CalendarProps } from './Calendar';
 
 export default {
@@ -14,17 +13,10 @@ const Template = (props: CalendarProps) => {
 	return <Calendar selectedDays={value} onDayClick={setValue} {...props} />;
 };
 
-export const OnLight: ComponentStory<typeof Calendar> = (args) => (
+export const Basic: ComponentStory<typeof Calendar> = (args) => (
 	<Template {...args} />
 );
-OnLight.args = {};
-
-export const OnDark: ComponentStory<typeof Calendar> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {};
+Basic.args = {};
 
 export const MultipleMonths: ComponentStory<typeof Calendar> = (args) => (
 	<Template {...args} />

--- a/packages/date-picker/src/DatePicker.stories.tsx
+++ b/packages/date-picker/src/DatePicker.stories.tsx
@@ -14,17 +14,8 @@ const Template: ComponentStory<typeof DatePicker> = (args) => {
 	return <DatePicker {...args} value={value} onChange={setValue} />;
 };
 
-export const OnLight = Template.bind({});
-OnLight.args = {
-	label: 'Example',
-};
-
-export const OnDark: ComponentStory<typeof DatePicker> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	label: 'Example',
 };
 

--- a/packages/date-picker/src/DateRangePicker.stories.tsx
+++ b/packages/date-picker/src/DateRangePicker.stories.tsx
@@ -19,15 +19,8 @@ const Template: ComponentStory<typeof DateRangePicker> = (args) => {
 	return <DateRangePicker {...args} value={range} onChange={setRange} />;
 };
 
-export const OnLight = Template.bind({});
-OnLight.args = {};
-
-export const OnDark: ComponentStory<typeof DateRangePicker> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {};
+export const Basic = Template.bind({});
+Basic.args = {};
 
 export const Disabled = Template.bind({});
 Disabled.args = {

--- a/packages/direction-link/docs/overview.mdx
+++ b/packages/direction-link/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Direction Link
 description: Direction links are accompanied by arrows to help users move quickly to other parts of the page or through a process.
 group: Navigation
-storybookPath: /story/navigation-directionlink--on-light
+storybookPath: /story/navigation-directionlink--basic
 ---
 
 Use direction links to indicate a physical direction, such as:

--- a/packages/direction-link/src/DirectionLink.stories.tsx
+++ b/packages/direction-link/src/DirectionLink.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Stack } from '@ag.ds-next/box';
+import { Stack } from '@ag.ds-next/box';
 import { DirectionLink, DirectionButton } from './index';
 
 export default {
@@ -10,21 +10,10 @@ export default {
 	},
 } as ComponentMeta<typeof DirectionLink>;
 
-export const OnLight: ComponentStory<typeof DirectionLink> = (args) => (
+export const Basic: ComponentStory<typeof DirectionLink> = (args) => (
 	<DirectionLink {...args} />
 );
-OnLight.args = {
-	children: 'Continue',
-	direction: 'right',
-	href: '#',
-};
-
-export const OnDark: ComponentStory<typeof DirectionLink> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<DirectionLink {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	children: 'Continue',
 	direction: 'right',
 	href: '#',

--- a/packages/field/docs/overview.mdx
+++ b/packages/field/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Field
 description: The field package exposes the elements around form inputs, and an API to compose them.
 group: Forms
-storybookPath: /story/forms-field--on-light
+storybookPath: /story/forms-field--basic
 ---
 
 ### Field

--- a/packages/field/src/Field.stories.tsx
+++ b/packages/field/src/Field.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { Field } from './Field';
 import { FieldContainer } from './FieldContainer';
 import { FieldLabel } from './FieldLabel';
@@ -12,22 +11,12 @@ export default {
 	component: Field,
 } as ComponentMeta<typeof Field>;
 
-export const OnLight: ComponentStory<typeof Field> = (args) => (
+export const Basic: ComponentStory<typeof Field> = (args) => (
 	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
 );
-OnLight.args = {
+Basic.args = {
 	label: 'Basic',
 };
-
-export const OnDark: ComponentStory<typeof Field> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
-	</Box>
-);
-OnDark.args = {
-	label: 'Basic',
-};
-
 export const Required: ComponentStory<typeof Field> = (args) => (
 	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
 );

--- a/packages/fieldset/docs/overview.mdx
+++ b/packages/fieldset/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Fieldset
 description: Use the fieldset component to group related form inputs.
 group: Forms
-storybookPath: /story/forms-fieldset--on-light
+storybookPath: /story/forms-fieldset--basic
 ---
 
 Fieldset is used to associate a number of related form fields as well as labels within a form. The legend provides an association and caption for the form fields in the fieldset.

--- a/packages/fieldset/src/Fieldset.stories.tsx
+++ b/packages/fieldset/src/Fieldset.stories.tsx
@@ -24,18 +24,8 @@ const Template: ComponentStory<typeof Fieldset> = (args) => (
 	</Fieldset>
 );
 
-export const OnLight = Template.bind({});
-OnLight.args = {
-	legend: 'What is your address?',
-	hint: 'We will only use this to respond to your requests',
-};
-
-export const OnDark: ComponentStory<typeof Fieldset> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	legend: 'What is your address?',
 	hint: 'We will only use this to respond to your requests',
 };

--- a/packages/fieldset/src/Fieldset.stories.tsx
+++ b/packages/fieldset/src/Fieldset.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Stack } from '@ag.ds-next/box';
+import { Stack } from '@ag.ds-next/box';
 import { TextInput } from '@ag.ds-next/text-input';
 import { FormStack } from '@ag.ds-next/form-stack';
 import { H1 } from '@ag.ds-next/heading';

--- a/packages/file-upload/docs/overview.mdx
+++ b/packages/file-upload/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: File Upload
 description: Allows a user to select files for upload, via drag-and-drop or using the system file browser.
 group: Forms
-storybookPath: /story/forms-fileupload--on-light
+storybookPath: /story/forms-fileupload--basic
 ---
 
 `FileUpload` is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components).

--- a/packages/file-upload/src/FileUpload.stories.tsx
+++ b/packages/file-upload/src/FileUpload.stories.tsx
@@ -8,7 +8,6 @@ import {
 } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
-import { Box } from '@ag.ds-next/box';
 import { FormStack } from '@ag.ds-next/form-stack';
 import { Button } from '@ag.ds-next/button';
 import { LoadingBlanket } from '@ag.ds-next/loading';
@@ -34,17 +33,8 @@ const TemplateWithValue: ComponentStory<typeof FileUpload> = (args) => {
 	return <FileUpload {...args} value={value} onChange={setValue} />;
 };
 
-export const OnLight = TemplateWithValue.bind({});
-OnLight.args = {
-	label: 'Drivers licence',
-};
-
-export const OnDark: ComponentStory<typeof FileUpload> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<TemplateWithValue {...args} />
-	</Box>
-);
-OnDark.args = {
+export const Basic = TemplateWithValue.bind({});
+Basic.args = {
 	label: 'Drivers licence',
 };
 

--- a/packages/icon/src/Icon.stories.tsx
+++ b/packages/icon/src/Icon.stories.tsx
@@ -43,6 +43,7 @@ export const AllIcons: ComponentStory<typeof AlertIcon> = (args) => (
 	</Flex>
 );
 AllIcons.args = {
+	color: 'text',
 	size: 'md',
 	weight: 'regular',
 };

--- a/packages/inpage-nav/docs/overview.mdx
+++ b/packages/inpage-nav/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Inpage Nav
 description: Inpage nav links helps users scan the contents of a page and navigate to different sections of the page.
 group: Navigation
-storybookPath: /story/navigation-inpagenav--on-light
+storybookPath: /story/navigation-inpagenav--basic
 ---
 
 The inpage nav (or page contents) is placed above sections of a page and provides navigation to individual anchor links located in those sections.

--- a/packages/inpage-nav/src/InpageNav.stories.tsx
+++ b/packages/inpage-nav/src/InpageNav.stories.tsx
@@ -54,24 +54,13 @@ const ExampleContent = () => (
 	</Body>
 );
 
-export const OnLight: ComponentStory<typeof InpageNav> = (args) => (
+export const Basic: ComponentStory<typeof InpageNav> = (args) => (
 	<Stack gap={3}>
 		<InpageNav {...args} />
 		<ExampleContent />
 	</Stack>
 );
-OnLight.args = {
-	title: 'Content',
-	links: exampleLinks,
-};
-
-export const OnDark: ComponentStory<typeof InpageNav> = (args) => (
-	<Stack palette="dark" background="body" gap={3} padding={1.5}>
-		<InpageNav {...args} />
-		<ExampleContent />
-	</Stack>
-);
-OnDark.args = {
+Basic.args = {
 	title: 'Content',
 	links: exampleLinks,
 };

--- a/packages/keyword-list/docs/overview.mdx
+++ b/packages/keyword-list/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Keyword List
 description: The keyword list style helps to emphasise and draw the user's eye to phrases that are repeated in a list.
 group: Content
-storybookPath: /story/content-keywordlist--on-light
+storybookPath: /story/content-keywordlist--basic
 ---
 
 A key and value pair used to display a small subtitle above a larger title.

--- a/packages/keyword-list/src/KeywordList.stories.tsx
+++ b/packages/keyword-list/src/KeywordList.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { KeywordList, KeywordListItem, KeywordListContainer } from './index';
 
 export default {
@@ -16,19 +15,10 @@ const exampleItems = [
 	{ subTitle: 'Department of', title: 'Communications and the Arts' },
 ];
 
-export const OnLight: ComponentStory<typeof KeywordList> = (args) => (
+export const Basic: ComponentStory<typeof KeywordList> = (args) => (
 	<KeywordList {...args} />
 );
-OnLight.args = {
-	items: exampleItems,
-};
-
-export const OnDark: ComponentStory<typeof KeywordList> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<KeywordList {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	items: exampleItems,
 };
 

--- a/packages/link-list/docs/overview.mdx
+++ b/packages/link-list/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Link List
 description: The link list style is a simple list of vertical or horizontal links used for site navigation. It is used to order information for users.
 group: Navigation
-storybookPath: /story/navigation-linklist--on-light
+storybookPath: /story/navigation-linklist--basic
 ---
 
 The default link list component removes the normal bullets and spacing associated with a list.

--- a/packages/link-list/src/LinkList.stories.tsx
+++ b/packages/link-list/src/LinkList.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { LinkList, LinkListItem, LinkListContainer } from './index';
 
 export default {
@@ -20,28 +19,15 @@ const exampleLinks = [
 	},
 ];
 
-export const OnLight: ComponentStory<typeof LinkList> = (args) => (
-	<Box palette="light" background="body" padding={1.5}>
-		<LinkList {...args} />
-	</Box>
+export const Basic: ComponentStory<typeof LinkList> = (args) => (
+	<LinkList {...args} />
 );
-OnLight.args = {
-	links: exampleLinks,
-};
-
-export const OnDark: ComponentStory<typeof LinkList> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<LinkList {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	links: exampleLinks,
 };
 
 export const Horizontal: ComponentStory<typeof LinkList> = (args) => (
-	<Box palette="light" background="body">
-		<LinkList {...args} />
-	</Box>
+	<LinkList {...args} />
 );
 Horizontal.args = {
 	links: exampleLinks,

--- a/packages/loading/docs/overview.mdx
+++ b/packages/loading/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Loading
 description: Loading indicators inform users that their action is being processed.
 group: Content
-storybookPath: /story/content-loading-loadingblanket--on-light
+storybookPath: /story/content-loading-loadingblanket--basic
 ---
 
 ## Loading Blanket

--- a/packages/loading/src/LoadingBlanket.stories.tsx
+++ b/packages/loading/src/LoadingBlanket.stories.tsx
@@ -33,19 +33,10 @@ const Template = (props: LoadingBlanketProps) => (
 	</Box>
 );
 
-export const OnLight: ComponentStory<typeof LoadingBlanket> = (args) => (
+export const Basic: ComponentStory<typeof LoadingBlanket> = (args) => (
 	<Template {...args} />
 );
-OnLight.args = {
-	label: 'Component loading state message',
-};
-
-export const OnDark: ComponentStory<typeof LoadingBlanket> = (args) => (
-	<Box dark>
-		<Template {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	label: 'Component loading state message',
 };
 
@@ -107,28 +98,13 @@ const FullScreenContent = () => (
 	</Fragment>
 );
 
-export const FullScreenOnLight: ComponentStory<typeof LoadingBlanket> = (
-	args
-) => (
+export const FullScreen: ComponentStory<typeof LoadingBlanket> = (args) => (
 	<Box background="body">
 		<FullScreenContent />
 		<LoadingBlanket {...args} />
 	</Box>
 );
-FullScreenOnLight.args = {
-	fullScreen: true,
-	label: 'Loading state message',
-};
-
-export const FullScreenOnDark: ComponentStory<typeof LoadingBlanket> = (
-	args
-) => (
-	<Box background="body" dark>
-		<FullScreenContent />
-		<LoadingBlanket {...args} />
-	</Box>
-);
-FullScreenOnDark.args = {
+FullScreen.args = {
 	fullScreen: true,
 	label: 'Loading state message',
 };

--- a/packages/loading/src/LoadingDots.stories.tsx
+++ b/packages/loading/src/LoadingDots.stories.tsx
@@ -1,27 +1,15 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
-import { LoadingDots } from './index';
+import { LoadingDots as LoadingDotsComp } from './index';
 
 export default {
 	title: 'content/Loading/LoadingDots',
-	component: LoadingDots,
-} as ComponentMeta<typeof LoadingDots>;
+	component: LoadingDotsComp,
+} as ComponentMeta<typeof LoadingDotsComp>;
 
-export const OnLight: ComponentStory<typeof LoadingDots> = (args) => (
-	<LoadingDots {...args} />
+export const LoadingDots: ComponentStory<typeof LoadingDotsComp> = (args) => (
+	<LoadingDotsComp {...args} />
 );
-OnLight.args = {
-	size: 'md',
-	'aria-label': 'Loading',
-	role: 'status',
-};
-
-export const OnDark: ComponentStory<typeof LoadingDots> = (args) => (
-	<Box palette="dark" background="body" color="text" padding={1.5}>
-		<LoadingDots {...args} />
-	</Box>
-);
-OnDark.args = {
+LoadingDots.args = {
 	size: 'md',
 	'aria-label': 'Loading',
 	role: 'status',

--- a/packages/search-box/docs/overview.mdx
+++ b/packages/search-box/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Search Box
 description: An input that allows users to enter a keyword to filter content on the website.
 group: Forms
-storybookPath: /story/forms-searchbox--on-light
+storybookPath: /story/forms-searchbox--basic
 ---
 
 ### Default

--- a/packages/search-box/src/SearchBox.stories.tsx
+++ b/packages/search-box/src/SearchBox.stories.tsx
@@ -1,6 +1,5 @@
 import { useState, ChangeEvent, FormEvent } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { SearchBox } from './SearchBox';
 import { SearchBoxButton } from './SearchBoxButton';
 import { SearchBoxInput } from './SearchBoxInput';
@@ -11,22 +10,12 @@ export default {
 	subcomponents: { SearchBoxButton, SearchBoxInput },
 } as ComponentMeta<typeof SearchBox>;
 
-const Template: ComponentStory<typeof SearchBox> = () => (
+export const Basic: ComponentStory<typeof SearchBox> = () => (
 	<SearchBox>
 		<SearchBoxInput />
 		<SearchBoxButton>Search</SearchBoxButton>
 	</SearchBox>
 );
-
-export const OnLight = Template.bind({});
-OnLight.args = {};
-
-export const OnDark = () => (
-	<Box palette="dark" background="body" color="text" padding={1.5}>
-		<Template />
-	</Box>
-);
-OnDark.args = {};
 
 export const LabelVisible: ComponentStory<typeof SearchBoxInput> = (args) => (
 	<SearchBox>

--- a/packages/select/docs/overview.mdx
+++ b/packages/select/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Select
 description: Select provides a means to select a single item from a collapsible list. Use of select helps to reduce input errors and screen space. It's commonly used to help users enter a value into a form field.
 group: Forms
-storybookPath: /story/forms-select--on-light
+storybookPath: /story/forms-select--basic
 ---
 
 ### Default

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -1,6 +1,6 @@
 import { useState, ChangeEvent } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Stack } from '@ag.ds-next/box';
+import { Stack } from '@ag.ds-next/box';
 import { Select } from './Select';
 
 export default {
@@ -14,21 +14,10 @@ const EXAMPLE_OPTIONS = [
 	{ value: 'c', label: 'Option C' },
 ];
 
-export const OnLight: ComponentStory<typeof Select> = (args) => (
+export const Basic: ComponentStory<typeof Select> = (args) => (
 	<Select {...args} />
 );
-OnLight.args = {
-	label: 'Example',
-	placeholder: 'Please select',
-	options: EXAMPLE_OPTIONS,
-};
-
-export const OnDark: ComponentStory<typeof Select> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<Select {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	label: 'Example',
 	placeholder: 'Please select',
 	options: EXAMPLE_OPTIONS,

--- a/packages/switch/docs/overview.mdx
+++ b/packages/switch/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Switch
 description: Allows a user to immediately update interface settings.
 group: Forms
-storybookPath: /story/forms-switch--on-light
+storybookPath: /story/forms-switch--switch
 ---
 
 A Switch allows a user to toggle a setting on or off, immediately affecting the user interface. Common use-cases include filtering interfaces and settings menus.

--- a/packages/switch/src/Switch.stories.tsx
+++ b/packages/switch/src/Switch.stories.tsx
@@ -1,6 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { useState } from 'react';
-import { Box } from '@ag.ds-next/box';
 import { Switch } from './Switch';
 
 export default {
@@ -8,25 +7,11 @@ export default {
 	component: Switch,
 } as ComponentMeta<typeof Switch>;
 
-const Template: ComponentStory<typeof Switch> = (args) => {
+export const Basic: ComponentStory<typeof Switch> = (args) => {
 	const [isChecked, setChecked] = useState(false);
 	return <Switch {...args} checked={isChecked} onChange={setChecked} />;
 };
-
-export const OnLight = Template.bind({});
-OnLight.args = {
-	size: 'md',
-	label: 'Show establishments',
-};
-
-export const OnDark: ComponentStory<typeof Switch> = (args) => {
-	return (
-		<Box palette="dark" background="body" padding={1}>
-			<Template {...args} />
-		</Box>
-	);
-};
-OnDark.args = {
+Basic.args = {
 	size: 'md',
 	label: 'Show establishments',
 };

--- a/packages/table/docs/overview.mdx
+++ b/packages/table/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Table
 description: Used to display tabular data.
 group: Content
-storybookPath: /story/content-table--on-light
+storybookPath: /story/content-table--basic
 ---
 
 For data tables with a small amount of rows use the default table. Align text columns and corresponding data cells to the left. When comparing numbers in a column, align data cells and column headers to the right.

--- a/packages/table/src/Table.stories.tsx
+++ b/packages/table/src/Table.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { TextLink } from '@ag.ds-next/text-link';
 import { Table } from './Table';
 import { TableBody } from './TableBody';
@@ -105,14 +104,8 @@ const Example: ComponentStory<typeof Table> = (args) => {
 	);
 };
 
-export const OnLight: ComponentStory<typeof Table> = (args) => (
+export const Basic: ComponentStory<typeof Table> = (args) => (
 	<Example {...args} />
-);
-
-export const OnDark: ComponentStory<typeof Table> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Example {...args} />
-	</Box>
 );
 
 export const Modular: ComponentStory<typeof Table> = (args) => (

--- a/packages/tags/docs/overview.mdx
+++ b/packages/tags/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Tags
 description: Tags are a means of classifying content, typically using keywords or labels. They are added to a web page, an asset or other content to help users search for and find related content quickly and easily.
 group: Content
-storybookPath: /story/content-tags--on-light
+storybookPath: /story/content-tags--basic
 ---
 
 ## Tags with links

--- a/packages/tags/src/Tags.stories.tsx
+++ b/packages/tags/src/Tags.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { Tags, TagsContainer, TagsList, Tag } from './index';
 
@@ -17,10 +16,8 @@ const exampleLinks = [
 	{ href: '#', label: 'Baz' },
 ];
 
-export const OnLight: ComponentStory<typeof Tags> = (args) => (
-	<Tags {...args} />
-);
-OnLight.args = {
+export const Basic: ComponentStory<typeof Tags> = (args) => <Tags {...args} />;
+Basic.args = {
 	heading: (
 		<Text as="h2" fontWeight="bold">
 			Tags:
@@ -29,38 +26,8 @@ OnLight.args = {
 	items: exampleItems,
 };
 
-export const OnDark: ComponentStory<typeof Tags> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Tags {...args} />
-	</Box>
-);
-OnDark.args = {
-	heading: (
-		<Text as="h2" fontWeight="bold">
-			Tags:
-		</Text>
-	),
-	items: exampleItems,
-};
-
-export const LinksOnLight: ComponentStory<typeof Tags> = (args) => (
-	<Tags {...args} />
-);
-LinksOnLight.args = {
-	heading: (
-		<Text as="h2" fontWeight="bold">
-			Tags:
-		</Text>
-	),
-	items: exampleLinks,
-};
-
-export const LinksOnDark: ComponentStory<typeof Tags> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<Tags {...args} />
-	</Box>
-);
-LinksOnDark.args = {
+export const Links: ComponentStory<typeof Tags> = (args) => <Tags {...args} />;
+Links.args = {
 	heading: (
 		<Text as="h2" fontWeight="bold">
 			Tags:

--- a/packages/task-list/src/TaskList.stories.tsx
+++ b/packages/task-list/src/TaskList.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box } from '@ag.ds-next/box';
 import {
 	TaskListContainer,
 	TaskList,
@@ -60,19 +59,10 @@ const exampleOrderedButtonItems = [
 	},
 ];
 
-export const OnLight: ComponentStory<typeof TaskList> = (args) => (
+export const Basic: ComponentStory<typeof TaskList> = (args) => (
 	<TaskList {...args} />
 );
-OnLight.args = {
-	items: exampleOrderedLinkItems,
-};
-
-export const OnDark: ComponentStory<typeof TaskList> = (args) => (
-	<Box palette="dark" background="body" padding={1.5}>
-		<TaskList {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	items: exampleOrderedLinkItems,
 };
 

--- a/packages/text-input/docs/overview.mdx
+++ b/packages/text-input/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Text Input
 description: Text inputs are input fields typically used in forms that allow the user to enter text data in a structured format.
 group: Forms
-storybookPath: /story/forms-textinput--on-light
+storybookPath: /story/forms-textinput--basic
 ---
 
 ### Default

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Stack } from '@ag.ds-next/box';
+import { Stack } from '@ag.ds-next/box';
 import { TextInput } from './TextInput';
 
 export default {
@@ -7,19 +7,10 @@ export default {
 	component: TextInput,
 } as ComponentMeta<typeof TextInput>;
 
-export const OnLight: ComponentStory<typeof TextInput> = (args) => (
+export const Basic: ComponentStory<typeof TextInput> = (args) => (
 	<TextInput {...args} />
 );
-OnLight.args = {
-	label: 'Example',
-};
-
-export const OnDark: ComponentStory<typeof TextInput> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<TextInput {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	label: 'Example',
 };
 

--- a/packages/textarea/docs/overview.mdx
+++ b/packages/textarea/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Textarea
 description: Textarea is a long form text input and can be scaled up or down in size by the user.
 group: Forms
-storybookPath: /story/forms-textarea--on-light
+storybookPath: /story/forms-textarea--basic
 ---
 
 ### Default

--- a/packages/textarea/src/Textarea.stories.tsx
+++ b/packages/textarea/src/Textarea.stories.tsx
@@ -1,5 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { Box, Stack } from '@ag.ds-next/box';
+import { Stack } from '@ag.ds-next/box';
 import { Textarea } from './Textarea';
 
 export default {
@@ -7,19 +7,10 @@ export default {
 	component: Textarea,
 } as ComponentMeta<typeof Textarea>;
 
-export const OnLight: ComponentStory<typeof Textarea> = (args) => (
+export const Basic: ComponentStory<typeof Textarea> = (args) => (
 	<Textarea {...args} />
 );
-OnLight.args = {
-	label: 'Example',
-};
-
-export const OnDark: ComponentStory<typeof Textarea> = (args) => (
-	<Box background="body" palette="dark" padding={1.5}>
-		<Textarea {...args} />
-	</Box>
-);
-OnDark.args = {
+Basic.args = {
 	label: 'Example',
 };
 


### PR DESCRIPTION
## Describe your changes
- Add 'palette' selection for preview area.
- Remove most of the 'OnDark' stories. Rename 'OnLight' to 'Basic'

The goal here is to decouple 'palette' selection from story code.

<img width="314" alt="image" src="https://user-images.githubusercontent.com/12689383/178649030-24b66577-475a-4156-9357-9bff8bbbbc60.png">
- brand: 'gold' | 'agriculture'
- palette: 'light' | 'dark'

Unfortunately, we can't use Storybook's excellent background plugin as it doesn't respect palette (light|dark) selection (it always uses light palette backgrounds), so I've had to build custom fields for 'palette' and 'background'.

Also, we can't use the fullscreen parameter as we set padding on the box component.



## Checklist

- [ ] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook
