### PR TITLE
SideNav: Add background prop

### DIFF
--- a/.changeset/nine-experts-help.md
+++ b/.changeset/nine-experts-help.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/side-nav': major
+---
+
+Replace 'variant' prop with 'background'

--- a/docs/components/PageLayout.tsx
+++ b/docs/components/PageLayout.tsx
@@ -32,7 +32,6 @@ export function PageLayout({
 					<Column columnSpan={{ xs: 12, md: 3 }}>
 						<ContentBleed visible={{ md: false }}>
 							<SideNav
-								variant="light"
 								collapseTitle="In this section"
 								activePath={router.asPath}
 								title={sideNav.title}

--- a/example-site/pages/category/subcategory/content.tsx
+++ b/example-site/pages/category/subcategory/content.tsx
@@ -29,7 +29,6 @@ export default function ContentPage() {
 								<SideNav
 									collapseTitle="In this section"
 									title="Category 1"
-									variant="light"
 									titleLink="/"
 									activePath="/category/subcategory/content"
 									items={sideNavItems}

--- a/packages/side-nav/docs/overview.mdx
+++ b/packages/side-nav/docs/overview.mdx
@@ -61,4 +61,4 @@ On mobile and smaller viewports, the side navigation uses functionality from the
 />
 ```
 
-The background of the SideNav must match the background it is being placed on. If SideNav is placed on 'bodyAlt' background, please set `background="bodyAlt"`.
+The background of the `SideNav` must match the background it is being placed on. For example, if `SideNav` is placed on a 'bodyAlt' background, please set the `background` prop to `bodyAlt`.

--- a/packages/side-nav/docs/overview.mdx
+++ b/packages/side-nav/docs/overview.mdx
@@ -11,7 +11,6 @@ On mobile and smaller viewports, the side navigation uses functionality from the
 
 ```jsx live
 <SideNav
-	variant="light"
 	activePath="#welcome"
 	title="SideNav"
 	titleLink="#"
@@ -61,3 +60,5 @@ On mobile and smaller viewports, the side navigation uses functionality from the
 	]}
 />
 ```
+
+If SideNav is placed on 'bodyAlt' background, please set `variant="alt"`.

--- a/packages/side-nav/docs/overview.mdx
+++ b/packages/side-nav/docs/overview.mdx
@@ -61,4 +61,4 @@ On mobile and smaller viewports, the side navigation uses functionality from the
 />
 ```
 
-If SideNav is placed on 'bodyAlt' background, please set `variant="alt"`.
+The background of the SideNav must match the background it is being placed on. If SideNav is placed on 'bodyAlt' background, please set `background="bodyAlt"`.

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -89,7 +89,7 @@ OnBodyAlt.args = {
 	...defaultArgs,
 	background: 'bodyAlt',
 };
-OnBodyAlt.storyName = 'bodyAlt background';
+OnBodyAlt.storyName = 'on bodyAlt background';
 
 export const Modular = () => (
 	<SideNavContainer background="body" aria-label="side navigation">

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentProps } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Box } from '@ag.ds-next/box';
 import {
 	SideNav,
 	SideNavContainer,
@@ -71,24 +72,27 @@ const defaultArgs = {
 	activePath: '#in-detail/record-keeping/incorrect-amounts',
 } as ComponentProps<typeof SideNav>;
 
-const Template: ComponentStory<typeof SideNav> = (args) => (
+export const Basic: ComponentStory<typeof SideNav> = (args) => (
 	<SideNav {...args} />
 );
-
-export const DefaultVariant = Template.bind({});
-DefaultVariant.args = {
+Basic.args = {
 	...defaultArgs,
-	variant: 'default',
+	background: 'body',
 };
 
-export const AltVariant = Template.bind({});
-AltVariant.args = {
+export const OnBodyAlt: ComponentStory<typeof SideNav> = (args) => (
+	<Box padding={2} background="bodyAlt">
+		<SideNav {...args} />
+	</Box>
+);
+OnBodyAlt.args = {
 	...defaultArgs,
-	variant: 'alt',
+	background: 'bodyAlt',
 };
+OnBodyAlt.storyName = 'bodyAlt background';
 
 export const Modular = () => (
-	<SideNavContainer variant="default" aria-label="side navigation">
+	<SideNavContainer background="body" aria-label="side navigation">
 		<SideNavTitle href="#">SideNav Title</SideNavTitle>
 		<SideNavGroup>
 			<SideNavLink href="#one" label="One" />

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -89,7 +89,7 @@ OnBodyAlt.args = {
 	...defaultArgs,
 	background: 'bodyAlt',
 };
-OnBodyAlt.storyName = 'on bodyAlt background';
+OnBodyAlt.storyName = 'On bodyAlt background';
 
 export const Modular = () => (
 	<SideNavContainer background="body" aria-label="side navigation">

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -75,32 +75,20 @@ const Template: ComponentStory<typeof SideNav> = (args) => (
 	<SideNav {...args} />
 );
 
-export const LightVariant = Template.bind({});
-LightVariant.args = {
+export const DefaultVariant = Template.bind({});
+DefaultVariant.args = {
 	...defaultArgs,
-	variant: 'light',
+	variant: 'default',
 };
 
-export const LightAltVariant = Template.bind({});
-LightAltVariant.args = {
+export const AltVariant = Template.bind({});
+AltVariant.args = {
 	...defaultArgs,
-	variant: 'lightAlt',
-};
-
-export const DarkVariant = Template.bind({});
-DarkVariant.args = {
-	...defaultArgs,
-	variant: 'dark',
-};
-
-export const DarkAltVariant = Template.bind({});
-DarkAltVariant.args = {
-	...defaultArgs,
-	variant: 'darkAlt',
+	variant: 'alt',
 };
 
 export const Modular = () => (
-	<SideNavContainer variant="light" aria-label="side navigation">
+	<SideNavContainer variant="default" aria-label="side navigation">
 		<SideNavTitle href="#">SideNav Title</SideNavTitle>
 		<SideNavGroup>
 			<SideNavLink href="#one" label="One" />

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -12,13 +12,13 @@ import { SideNavTitle } from './SideNavTitle';
 import { SideNavGroup } from './SideNavGroup';
 import { SideNavLink } from './SideNavLink';
 import { SideNavCollapseButton } from './SideNavCollapseButton';
-import { SideNavVariant, findBestMatch, useSideNavIds } from './utils';
+import { SideNavBackground, findBestMatch, useSideNavIds } from './utils';
 
 export type SideNavProps = LinkListProps & {
 	'aria-label'?: string;
 	collapseTitle: string;
-	/** If SideNav is placed on 'bodyAlt' background, please set this to "alt". */
-	variant?: SideNavVariant;
+	/** If SideNav is placed on 'bodyAlt' background, please set this to "bodyAlt". */
+	background?: SideNavBackground;
 	title: ReactNode;
 	titleLink: string; // TODO: should this be optional
 };
@@ -28,7 +28,7 @@ export function SideNav({
 	activePath,
 	collapseTitle,
 	items,
-	variant = 'default',
+	background = 'body',
 	titleLink,
 	title,
 }: SideNavProps) {
@@ -58,7 +58,7 @@ export function SideNav({
 	});
 
 	return (
-		<SideNavContainer aria-label={ariaLabel} variant={variant}>
+		<SideNavContainer aria-label={ariaLabel} background={background}>
 			<SideNavCollapseButton
 				isOpen={isOpen}
 				onClick={onToggle}

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -27,7 +27,7 @@ export function SideNav({
 	activePath,
 	collapseTitle,
 	items,
-	variant = 'light',
+	variant = 'default',
 	titleLink,
 	title,
 }: SideNavProps) {

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -17,6 +17,7 @@ import { SideNavVariant, findBestMatch, useSideNavIds } from './utils';
 export type SideNavProps = LinkListProps & {
 	'aria-label'?: string;
 	collapseTitle: string;
+	/** If SideNav is placed on 'bodyAlt' background, please set this to "alt". */
 	variant?: SideNavVariant;
 	title: ReactNode;
 	titleLink: string; // TODO: should this be optional

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -1,23 +1,24 @@
 import type { PropsWithChildren } from 'react';
 import { backgroundColorMap, Box } from '@ag.ds-next/box';
 import { mapResponsiveProp, mq, packs } from '@ag.ds-next/core';
-import { variantMap, SideNavVariant, localPaletteVars } from './utils';
+import { hoverColorMap, SideNavBackground, localPaletteVars } from './utils';
 
 export type SideNavContainerProps = PropsWithChildren<{
 	'aria-label': string;
-	variant: SideNavVariant;
+	background: SideNavBackground;
 }>;
 
 export const SideNavContainer = ({
 	'aria-label': ariaLabel,
 	children,
-	variant,
+	background,
 }: SideNavContainerProps) => {
-	const { hover } = variantMap[variant];
+	const hover = hoverColorMap[background];
 	return (
 		<Box
 			as="aside"
 			aria-label={ariaLabel}
+			background={background}
 			css={mq({
 				...packs.print.hidden,
 				[localPaletteVars.hover]: mapResponsiveProp(

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -13,12 +13,11 @@ export const SideNavContainer = ({
 	children,
 	variant,
 }: SideNavContainerProps) => {
-	const { background, hover } = variantMap[variant];
+	const { hover } = variantMap[variant];
 	return (
 		<Box
 			as="aside"
 			aria-label={ariaLabel}
-			background={background}
 			css={mq({
 				...packs.print.hidden,
 				[localPaletteVars.hover]: mapResponsiveProp(

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -13,12 +13,11 @@ export const SideNavContainer = ({
 	children,
 	variant,
 }: SideNavContainerProps) => {
-	const { palette, background, hover } = variantMap[variant];
+	const { background, hover } = variantMap[variant];
 	return (
 		<Box
 			as="aside"
 			aria-label={ariaLabel}
-			palette={palette}
 			background={background}
 			css={mq({
 				...packs.print.hidden,

--- a/packages/side-nav/src/utils.ts
+++ b/packages/side-nav/src/utils.ts
@@ -38,11 +38,9 @@ export const useSideNavIds = () => {
 
 export const variantMap = {
 	default: {
-		background: 'body',
 		hover: 'shade',
 	},
 	alt: {
-		background: 'bodyAlt',
 		hover: 'shadeAlt',
 	},
 } as const;

--- a/packages/side-nav/src/utils.ts
+++ b/packages/side-nav/src/utils.ts
@@ -36,32 +36,14 @@ export const useSideNavIds = () => {
 	};
 };
 
-const defaultStyles = {
-	background: 'body',
-	hover: 'shade',
-} as const;
-
-const altStyles = {
-	background: 'bodyAlt',
-	hover: 'shadeAlt',
-} as const;
-
 export const variantMap = {
-	light: {
-		palette: 'light',
-		...defaultStyles,
+	default: {
+		background: 'body',
+		hover: 'shade',
 	},
-	lightAlt: {
-		palette: 'light',
-		...altStyles,
-	},
-	dark: {
-		palette: 'dark',
-		...defaultStyles,
-	},
-	darkAlt: {
-		palette: 'dark',
-		...altStyles,
+	alt: {
+		background: 'bodyAlt',
+		hover: 'shadeAlt',
 	},
 } as const;
 

--- a/packages/side-nav/src/utils.ts
+++ b/packages/side-nav/src/utils.ts
@@ -36,13 +36,9 @@ export const useSideNavIds = () => {
 	};
 };
 
-export const variantMap = {
-	default: {
-		hover: 'shade',
-	},
-	alt: {
-		hover: 'shadeAlt',
-	},
+export const hoverColorMap = {
+	body: 'shade',
+	bodyAlt: 'shadeAlt',
 } as const;
 
-export type SideNavVariant = keyof typeof variantMap;
+export type SideNavBackground = keyof typeof hoverColorMap;


### PR DESCRIPTION
## Describe your changes
Our `SideNav` component internally sets its palette. That means that if it's parent changes palette from light to dark, the SideNav does not change (pictured)
<img width="525" alt="image" src="https://user-images.githubusercontent.com/12689383/178656087-f0743dc0-be84-419f-a148-945a2d98d674.png">

This PR changes the props to remove palette setting.
**Before:** `variant: 'light' | 'lightAlt' | 'dark' | 'darkAlt`

**After:** `background: 'body' | 'bodyAlt`

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

