### PR TITLE
HeroBanner: Add background prop

### DIFF
--- a/.changeset/quick-ravens-sparkle.md
+++ b/.changeset/quick-ravens-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/hero-banner': patch
+---
+
+HeroBanner respects parent palette context

--- a/.changeset/quick-ravens-sparkle.md
+++ b/.changeset/quick-ravens-sparkle.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/hero-banner': patch
+'@ag.ds-next/hero-banner': major
 ---
 
-HeroBanner respects parent palette context
+HeroBanner respects parent palette context. Add background prop.

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -19,7 +19,7 @@ export default function Homepage() {
 		<>
 			<DocumentTitle />
 			<AppLayout>
-				<HeroBanner variant="lightAlt">
+				<HeroBanner>
 					<HeroBannerTitleContainer>
 						<HeroBannerTitle>
 							Welcome to the Agriculture Design System (AgDS)

--- a/example-site/pages/category/index.tsx
+++ b/example-site/pages/category/index.tsx
@@ -16,7 +16,6 @@ export default function CategoryPage() {
 			<DocumentTitle title="Category" />
 			<AppLayout template={{ name: 'Category', slug: 'category' }}>
 				<HeroCategoryBanner
-					variant="lightAlt"
 					image={
 						<img
 							alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."

--- a/example-site/pages/category/subcategory/index.tsx
+++ b/example-site/pages/category/subcategory/index.tsx
@@ -16,7 +16,7 @@ export default function SubcategoryPage() {
 		<>
 			<DocumentTitle title="Subcategory" />
 			<AppLayout template={{ name: 'Subcategory', slug: 'subcategory' }}>
-				<HeroSubcategoryBanner variant="lightAlt">
+				<HeroSubcategoryBanner>
 					<Breadcrumbs
 						links={[
 							{ href: '/', label: 'Home' },

--- a/example-site/pages/index.tsx
+++ b/example-site/pages/index.tsx
@@ -21,7 +21,6 @@ export default function HomePage() {
 			<DocumentTitle title="Home" />
 			<AppLayout template={{ name: 'Home', slug: 'home' }}>
 				<HeroBanner
-					variant="lightAlt"
 					image={
 						<img
 							alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."

--- a/packages/hero-banner/docs/overview.mdx
+++ b/packages/hero-banner/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Hero Banner
 description: Hero banner are used to grab a user’s attention.
 group: Layout
-storybookPath: /story/layout-herobanner-herobanner--light-variant
+storybookPath: /story/layout-herobanner-herobanner--basic
 ---
 
 ## Hero Banner

--- a/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
@@ -5,6 +5,7 @@ import {
 	SearchBoxButton,
 } from '@ag.ds-next/search-box';
 import { Button, ButtonGroup } from '@ag.ds-next/button';
+import { Box } from '@ag.ds-next/box';
 import { HeroBanner, HeroBannerProps } from './HeroBanner';
 import {
 	HeroBannerSubtitle,
@@ -57,28 +58,40 @@ const commonArgs = {
 	),
 };
 
-export const LightVariant = Template.bind({});
-LightVariant.args = {
+export const BodyOnLight = Template.bind({});
+BodyOnLight.args = {
 	...commonArgs,
-	variant: 'light',
+	background: 'body',
 };
 
-export const LightAlt = Template.bind({});
-LightAlt.args = {
+export const BodyAltOnLight = Template.bind({});
+BodyAltOnLight.args = {
 	...commonArgs,
-	variant: 'lightAlt',
+	background: 'bodyAlt',
 };
 
-export const Dark = Template.bind({});
-Dark.args = {
+export const BodyOnDark: Story<
+	HeroBannerProps & { title: string; subtitle: string }
+> = (args) => (
+	<Box palette="dark" padding={1} background="body">
+		<Template {...args} />
+	</Box>
+);
+BodyOnDark.args = {
 	...commonArgs,
-	variant: 'dark',
+	background: 'body',
 };
 
-export const DarkAlt = Template.bind({});
-DarkAlt.args = {
+export const BodyAltOnDark: Story<
+	HeroBannerProps & { title: string; subtitle: string }
+> = (args) => (
+	<Box palette="dark" padding={1} background="body">
+		<Template {...args} />
+	</Box>
+);
+BodyAltOnDark.args = {
 	...commonArgs,
-	variant: 'darkAlt',
+	background: 'bodyAlt',
 };
 
 export const Buttons = Template.bind({});

--- a/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
@@ -27,9 +27,12 @@ export default {
 	},
 } as ComponentMeta<typeof HeroBanner>;
 
-const Template: Story<HeroBannerProps & { title: string; subtitle: string }> = (
-	args
-) => (
+type HeroBannerStoryProps = HeroBannerProps & {
+	title: string;
+	subtitle: string;
+};
+
+const Template: Story<HeroBannerStoryProps> = (args) => (
 	<HeroBanner {...args}>
 		<HeroBannerTitleContainer>
 			<HeroBannerTitle>{args.title}</HeroBannerTitle>
@@ -58,40 +61,20 @@ const commonArgs = {
 	),
 };
 
-export const BodyOnLight = Template.bind({});
-BodyOnLight.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	...commonArgs,
-	background: 'body',
 };
 
-export const BodyAltOnLight = Template.bind({});
-BodyAltOnLight.args = {
-	...commonArgs,
-	background: 'bodyAlt',
-};
-
-export const BodyOnDark: Story<
-	HeroBannerProps & { title: string; subtitle: string }
-> = (args) => (
-	<Box palette="dark" padding={1} background="body">
+export const OnBodyAlt: Story<HeroBannerStoryProps> = (args) => (
+	<Box paddingY={3} background="bodyAlt">
 		<Template {...args} />
 	</Box>
 );
-BodyOnDark.args = {
+OnBodyAlt.storyName = 'On bodyAlt background';
+OnBodyAlt.args = {
 	...commonArgs,
 	background: 'body',
-};
-
-export const BodyAltOnDark: Story<
-	HeroBannerProps & { title: string; subtitle: string }
-> = (args) => (
-	<Box palette="dark" padding={1} background="body">
-		<Template {...args} />
-	</Box>
-);
-BodyAltOnDark.args = {
-	...commonArgs,
-	background: 'bodyAlt',
 };
 
 export const Buttons = Template.bind({});

--- a/packages/hero-banner/src/HeroBanner/HeroBanner.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBanner.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, ReactNode } from 'react';
-import { HeroBannerVariant } from '../utils';
+import { HeroBannerBackground } from '../utils';
 import { HeroBannerContent } from './HeroBannerContent';
 import { HeroBannerMobileImage } from './HeroBannerMobileImage';
 import { HeroBannerContainer } from './HeroBannerContainer';
@@ -7,18 +7,18 @@ import { HeroBannerContainer } from './HeroBannerContainer';
 export type HeroBannerProps = PropsWithChildren<{
 	/** The hero image */
 	image?: ReactNode;
-	/** The palette of the component */
-	variant?: HeroBannerVariant;
+	/** The background of the component */
+	background?: HeroBannerBackground;
 }>;
 
 export const HeroBanner = ({
 	image,
-	variant = 'lightAlt',
+	background = 'bodyAlt',
 	children,
 }: HeroBannerProps) => (
-	<HeroBannerContainer variant={variant}>
+	<HeroBannerContainer background={background}>
 		{image ? <HeroBannerMobileImage>{image}</HeroBannerMobileImage> : null}
-		<HeroBannerContent variant={variant} image={image}>
+		<HeroBannerContent background={background} image={image}>
 			{children}
 		</HeroBannerContent>
 	</HeroBannerContainer>

--- a/packages/hero-banner/src/HeroBanner/HeroBannerContainer.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBannerContainer.tsx
@@ -10,11 +10,10 @@ export const HeroBannerContainer = ({
 	children,
 	variant,
 }: HeroBannerContainerProps) => {
-	const { palette, background } = variantMap[variant];
+	const { background } = variantMap[variant];
 	return (
 		<Box
 			as="section"
-			palette={palette}
 			background={background}
 			css={{ position: 'relative', overflow: 'hidden' }}
 		>

--- a/packages/hero-banner/src/HeroBanner/HeroBannerContainer.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBannerContainer.tsx
@@ -1,16 +1,15 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
-import { HeroBannerVariant, variantMap } from '../utils';
+import { HeroBannerBackground } from '../utils';
 
 export type HeroBannerContainerProps = PropsWithChildren<{
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroBannerContainer = ({
 	children,
-	variant,
+	background,
 }: HeroBannerContainerProps) => {
-	const { background } = variantMap[variant];
 	return (
 		<Box
 			as="section"

--- a/packages/hero-banner/src/HeroBanner/HeroBannerContent.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBannerContent.tsx
@@ -1,18 +1,18 @@
 import { PropsWithChildren, ReactNode } from 'react';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { Content } from '@ag.ds-next/content';
-import { HeroBannerVariant } from '../utils';
+import { HeroBannerBackground } from '../utils';
 import { HeroBannerImage } from './HeroBannerImage';
 
 export type HeroBannerContentProps = PropsWithChildren<{
 	image?: ReactNode;
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroBannerContent = ({
 	children,
 	image,
-	variant,
+	background,
 }: HeroBannerContentProps) => {
 	return (
 		<Content>
@@ -27,7 +27,7 @@ export const HeroBannerContent = ({
 					{children}
 				</Stack>
 				{image ? (
-					<HeroBannerImage variant={variant}>{image}</HeroBannerImage>
+					<HeroBannerImage background={background}>{image}</HeroBannerImage>
 				) : null}
 			</Flex>
 		</Content>

--- a/packages/hero-banner/src/HeroBanner/HeroBannerImage.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBannerImage.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
 import { boxPalette } from '@ag.ds-next/core';
-import { HeroBannerBackground, variantMap } from '../utils';
+import { HeroBannerBackground, backgroundMap } from '../utils';
 
 export type HeroBannerImageProps = PropsWithChildren<{
 	background: HeroBannerBackground;
@@ -11,7 +11,7 @@ export const HeroBannerImage = ({
 	children,
 	background,
 }: HeroBannerImageProps) => {
-	const backgroundVar = variantMap[background];
+	const backgroundVar = backgroundMap[background];
 	return (
 		<Box
 			display={['none', 'none', 'block']}

--- a/packages/hero-banner/src/HeroBanner/HeroBannerImage.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBannerImage.tsx
@@ -1,17 +1,17 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
 import { boxPalette } from '@ag.ds-next/core';
-import { HeroBannerVariant, variantMap } from '../utils';
+import { HeroBannerBackground, variantMap } from '../utils';
 
 export type HeroBannerImageProps = PropsWithChildren<{
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroBannerImage = ({
 	children,
-	variant,
+	background,
 }: HeroBannerImageProps) => {
-	const { backgroundVar } = variantMap[variant];
+	const backgroundVar = variantMap[background];
 	return (
 		<Box
 			display={['none', 'none', 'block']}

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, Story } from '@storybook/react';
+import { Box } from '@ag.ds-next/box';
 import {
 	HeroCategoryBanner,
 	HeroCategoryBannerProps,
@@ -41,28 +42,40 @@ const commonArgs = {
 	),
 };
 
-export const LightVariant = Template.bind({});
-LightVariant.args = {
+export const BodyOnLight = Template.bind({});
+BodyOnLight.args = {
 	...commonArgs,
-	variant: 'light',
+	background: 'body',
 };
 
-export const LightAlt = Template.bind({});
-LightAlt.args = {
+export const BodyAltOnLight = Template.bind({});
+BodyAltOnLight.args = {
 	...commonArgs,
-	variant: 'lightAlt',
+	background: 'bodyAlt',
 };
 
-export const Dark = Template.bind({});
-Dark.args = {
+export const BodyOnDark: Story<
+	HeroCategoryBannerProps & { title: string; subtitle: string }
+> = (args) => (
+	<Box palette="dark" padding={1} background="body">
+		<Template {...args} />
+	</Box>
+);
+BodyOnDark.args = {
 	...commonArgs,
-	variant: 'dark',
+	background: 'body',
 };
 
-export const DarkAlt = Template.bind({});
-DarkAlt.args = {
+export const BodyAltOnDark: Story<
+	HeroCategoryBannerProps & { title: string; subtitle: string }
+> = (args) => (
+	<Box palette="dark" padding={1} background="body">
+		<Template {...args} />
+	</Box>
+);
+BodyAltOnDark.args = {
 	...commonArgs,
-	variant: 'darkAlt',
+	background: 'bodyAlt',
 };
 
 export const Buttons = Template.bind({});

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
@@ -22,9 +22,12 @@ export default {
 	},
 } as ComponentMeta<typeof HeroCategoryBanner>;
 
-const Template: Story<
-	HeroCategoryBannerProps & { title: string; subtitle: string }
-> = (args) => (
+type HeroCategoryBannerStoryProps = HeroCategoryBannerProps & {
+	title: string;
+	subtitle: string;
+};
+
+const Template: Story<HeroCategoryBannerStoryProps> = (args) => (
 	<HeroCategoryBanner {...args}>
 		<HeroCategoryBannerTitle>{args.title}</HeroCategoryBannerTitle>
 		<HeroCategoryBannerSubtitle>{args.subtitle}</HeroCategoryBannerSubtitle>
@@ -42,40 +45,20 @@ const commonArgs = {
 	),
 };
 
-export const BodyOnLight = Template.bind({});
-BodyOnLight.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	...commonArgs,
-	background: 'body',
 };
 
-export const BodyAltOnLight = Template.bind({});
-BodyAltOnLight.args = {
-	...commonArgs,
-	background: 'bodyAlt',
-};
-
-export const BodyOnDark: Story<
-	HeroCategoryBannerProps & { title: string; subtitle: string }
-> = (args) => (
-	<Box palette="dark" padding={1} background="body">
+export const OnBodyAlt: Story<HeroCategoryBannerStoryProps> = (args) => (
+	<Box paddingY={3} background="bodyAlt">
 		<Template {...args} />
 	</Box>
 );
-BodyOnDark.args = {
+OnBodyAlt.storyName = 'On bodyAlt background';
+OnBodyAlt.args = {
 	...commonArgs,
 	background: 'body',
-};
-
-export const BodyAltOnDark: Story<
-	HeroCategoryBannerProps & { title: string; subtitle: string }
-> = (args) => (
-	<Box palette="dark" padding={1} background="body">
-		<Template {...args} />
-	</Box>
-);
-BodyAltOnDark.args = {
-	...commonArgs,
-	background: 'bodyAlt',
 };
 
 export const Buttons = Template.bind({});

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, ReactNode } from 'react';
-import { HeroBannerVariant } from '../utils';
+import { HeroBannerBackground } from '../utils';
 import { HeroCategoryBannerContent } from './HeroCategoryBannerContent';
 import { HeroCategoryBannerMobileImage } from './HeroCategoryBannerMobileImage';
 import { HeroCategoryBannerContainer } from './HeroCategoryBannerContainer';
@@ -7,20 +7,20 @@ import { HeroCategoryBannerContainer } from './HeroCategoryBannerContainer';
 export type HeroCategoryBannerProps = PropsWithChildren<{
 	/** The hero image */
 	image?: ReactNode;
-	/** The palette of the component */
-	variant?: HeroBannerVariant;
+	/** The background of the component */
+	background?: HeroBannerBackground;
 }>;
 
 export const HeroCategoryBanner = ({
 	children,
 	image,
-	variant = 'lightAlt',
+	background = 'bodyAlt',
 }: HeroCategoryBannerProps) => (
-	<HeroCategoryBannerContainer variant={variant}>
+	<HeroCategoryBannerContainer background={background}>
 		{image ? (
 			<HeroCategoryBannerMobileImage>{image}</HeroCategoryBannerMobileImage>
 		) : null}
-		<HeroCategoryBannerContent variant={variant} image={image}>
+		<HeroCategoryBannerContent background={background} image={image}>
 			{children}
 		</HeroCategoryBannerContent>
 	</HeroCategoryBannerContainer>

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerContainer.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerContainer.tsx
@@ -10,11 +10,10 @@ export const HeroCategoryBannerContainer = ({
 	children,
 	variant,
 }: HeroCategoryBannerContainerProps) => {
-	const { palette, background } = variantMap[variant];
+	const { background } = variantMap[variant];
 	return (
 		<Box
 			as="section"
-			palette={palette}
 			background={background}
 			css={{ position: 'relative', overflow: 'hidden' }}
 		>

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerContainer.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerContainer.tsx
@@ -1,16 +1,15 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
-import { HeroBannerVariant, variantMap } from '../utils';
+import { HeroBannerBackground } from '../utils';
 
 export type HeroCategoryBannerContainerProps = PropsWithChildren<{
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroCategoryBannerContainer = ({
 	children,
-	variant,
+	background,
 }: HeroCategoryBannerContainerProps) => {
-	const { background } = variantMap[variant];
 	return (
 		<Box
 			as="section"

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerContent.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerContent.tsx
@@ -1,18 +1,18 @@
 import { PropsWithChildren, ReactNode } from 'react';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { Content } from '@ag.ds-next/content';
-import { HeroBannerVariant } from '../utils';
+import { HeroBannerBackground } from '../utils';
 import { HeroCategoryBannerImage } from './HeroCategoryBannerImage';
 
 export type HeroCategoryBannerContentProps = PropsWithChildren<{
 	image?: ReactNode;
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroCategoryBannerContent = ({
 	children,
 	image,
-	variant,
+	background,
 }: HeroCategoryBannerContentProps) => {
 	return (
 		<Content>
@@ -27,7 +27,7 @@ export const HeroCategoryBannerContent = ({
 					{children}
 				</Stack>
 				{image ? (
-					<HeroCategoryBannerImage variant={variant}>
+					<HeroCategoryBannerImage background={background}>
 						{image}
 					</HeroCategoryBannerImage>
 				) : null}

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerImage.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerImage.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
 import { boxPalette } from '@ag.ds-next/core';
-import { HeroBannerBackground, variantMap } from '../utils';
+import { HeroBannerBackground, backgroundMap } from '../utils';
 
 export type HeroCategoryBannerImageProps = PropsWithChildren<{
 	background: HeroBannerBackground;
@@ -11,7 +11,7 @@ export const HeroCategoryBannerImage = ({
 	children,
 	background,
 }: HeroCategoryBannerImageProps) => {
-	const backgroundVar = variantMap[background];
+	const backgroundVar = backgroundMap[background];
 	return (
 		<Box
 			display={['none', 'none', 'block']}

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerImage.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBannerImage.tsx
@@ -1,17 +1,17 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
 import { boxPalette } from '@ag.ds-next/core';
-import { HeroBannerVariant, variantMap } from '../utils';
+import { HeroBannerBackground, variantMap } from '../utils';
 
 export type HeroCategoryBannerImageProps = PropsWithChildren<{
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroCategoryBannerImage = ({
 	children,
-	variant,
+	background,
 }: HeroCategoryBannerImageProps) => {
-	const { backgroundVar } = variantMap[variant];
+	const backgroundVar = variantMap[background];
 	return (
 		<Box
 			display={['none', 'none', 'block']}

--- a/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBanner.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentMeta, Story } from '@storybook/react';
 import { Breadcrumbs } from '@ag.ds-next/breadcrumbs';
+import { Box } from '@ag.ds-next/box';
 import {
 	HeroSubcategoryBanner,
 	HeroSubcategoryBannerProps,
@@ -33,26 +34,42 @@ const Template: Story<
 	</HeroSubcategoryBanner>
 );
 
-export const LightVariant = Template.bind({});
-LightVariant.args = {
+const commonArgs = {
 	title: 'Subcategory banner title - xxl/display (H1)',
-	variant: 'light',
 };
 
-export const LightAlt = Template.bind({});
-LightAlt.args = {
-	title: 'Subcategory banner title - xxl/display (H1)',
-	variant: 'lightAlt',
+export const BodyOnLight = Template.bind({});
+BodyOnLight.args = {
+	...commonArgs,
+	background: 'body',
 };
 
-export const Dark = Template.bind({});
-Dark.args = {
-	title: 'Subcategory banner title - xxl/display (H1)',
-	variant: 'dark',
+export const BodyAltOnLight = Template.bind({});
+BodyAltOnLight.args = {
+	...commonArgs,
+	background: 'bodyAlt',
 };
 
-export const DarkAlt = Template.bind({});
-DarkAlt.args = {
-	title: 'Subcategory banner title - xxl/display (H1)',
-	variant: 'darkAlt',
+export const BodyOnDark: Story<
+	HeroSubcategoryBannerProps & { title: string; subtitle: string }
+> = (args) => (
+	<Box palette="dark" padding={1} background="body">
+		<Template {...args} />
+	</Box>
+);
+BodyOnDark.args = {
+	...commonArgs,
+	background: 'body',
+};
+
+export const BodyAltOnDark: Story<
+	HeroSubcategoryBannerProps & { title: string; subtitle: string }
+> = (args) => (
+	<Box palette="dark" padding={1} background="body">
+		<Template {...args} />
+	</Box>
+);
+BodyAltOnDark.args = {
+	...commonArgs,
+	background: 'bodyAlt',
 };

--- a/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBanner.stories.tsx
@@ -19,9 +19,12 @@ export default {
 	},
 } as ComponentMeta<typeof HeroSubcategoryBanner>;
 
-const Template: Story<
-	HeroSubcategoryBannerProps & { title: string; subtitle: string }
-> = (args) => (
+type HeroSubcategoryBannerStoryProps = HeroSubcategoryBannerProps & {
+	title: string;
+	subtitle: string;
+};
+
+const Template: Story<HeroSubcategoryBannerStoryProps> = (args) => (
 	<HeroSubcategoryBanner {...args}>
 		<Breadcrumbs
 			links={[
@@ -38,38 +41,18 @@ const commonArgs = {
 	title: 'Subcategory banner title - xxl/display (H1)',
 };
 
-export const BodyOnLight = Template.bind({});
-BodyOnLight.args = {
+export const Basic = Template.bind({});
+Basic.args = {
 	...commonArgs,
-	background: 'body',
 };
 
-export const BodyAltOnLight = Template.bind({});
-BodyAltOnLight.args = {
-	...commonArgs,
-	background: 'bodyAlt',
-};
-
-export const BodyOnDark: Story<
-	HeroSubcategoryBannerProps & { title: string; subtitle: string }
-> = (args) => (
-	<Box palette="dark" padding={1} background="body">
+export const OnBodyAlt: Story<HeroSubcategoryBannerStoryProps> = (args) => (
+	<Box paddingY={3} background="bodyAlt">
 		<Template {...args} />
 	</Box>
 );
-BodyOnDark.args = {
+OnBodyAlt.storyName = 'On bodyAlt background';
+OnBodyAlt.args = {
 	...commonArgs,
 	background: 'body',
-};
-
-export const BodyAltOnDark: Story<
-	HeroSubcategoryBannerProps & { title: string; subtitle: string }
-> = (args) => (
-	<Box palette="dark" padding={1} background="body">
-		<Template {...args} />
-	</Box>
-);
-BodyAltOnDark.args = {
-	...commonArgs,
-	background: 'bodyAlt',
 };

--- a/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBanner.tsx
+++ b/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBanner.tsx
@@ -1,18 +1,18 @@
 import { PropsWithChildren } from 'react';
-import { HeroBannerVariant } from '../utils';
+import { HeroBannerBackground } from '../utils';
 import { HeroSubcategoryBannerContainer } from './HeroSubcategoryBannerContainer';
 import { HeroSubcategoryBannerContent } from './HeroSubcategoryBannerContent';
 
 export type HeroSubcategoryBannerProps = PropsWithChildren<{
-	/** The palette of the component */
-	variant?: HeroBannerVariant;
+	/** The background of the component */
+	background?: HeroBannerBackground;
 }>;
 
 export const HeroSubcategoryBanner = ({
 	children,
-	variant = 'lightAlt',
+	background = 'bodyAlt',
 }: HeroSubcategoryBannerProps) => (
-	<HeroSubcategoryBannerContainer variant={variant}>
+	<HeroSubcategoryBannerContainer background={background}>
 		<HeroSubcategoryBannerContent>{children}</HeroSubcategoryBannerContent>
 	</HeroSubcategoryBannerContainer>
 );

--- a/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBannerContainer.tsx
+++ b/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBannerContainer.tsx
@@ -1,16 +1,15 @@
 import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
-import { HeroBannerVariant, variantMap } from '../utils';
+import { HeroBannerBackground } from '../utils';
 
 export type HeroSubcategoryBannerContainerProps = PropsWithChildren<{
-	variant: HeroBannerVariant;
+	background: HeroBannerBackground;
 }>;
 
 export const HeroSubcategoryBannerContainer = ({
 	children,
-	variant,
+	background,
 }: HeroSubcategoryBannerContainerProps) => {
-	const { background } = variantMap[variant];
 	return (
 		<Box as="section" background={background}>
 			{children}

--- a/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBannerContainer.tsx
+++ b/packages/hero-banner/src/HeroSubcategoryBanner/HeroSubcategoryBannerContainer.tsx
@@ -10,9 +10,9 @@ export const HeroSubcategoryBannerContainer = ({
 	children,
 	variant,
 }: HeroSubcategoryBannerContainerProps) => {
-	const { palette, background } = variantMap[variant];
+	const { background } = variantMap[variant];
 	return (
-		<Box as="section" palette={palette} background={background}>
+		<Box as="section" background={background}>
 			{children}
 		</Box>
 	);

--- a/packages/hero-banner/src/utils.ts
+++ b/packages/hero-banner/src/utils.ts
@@ -1,20 +1,6 @@
 export const variantMap = {
-	light: {
-		background: 'body',
-		backgroundVar: 'backgroundBody',
-	},
-	lightAlt: {
-		background: 'bodyAlt',
-		backgroundVar: 'backgroundBodyAlt',
-	},
-	dark: {
-		background: 'body',
-		backgroundVar: 'backgroundBody',
-	},
-	darkAlt: {
-		background: 'bodyAlt',
-		backgroundVar: 'backgroundBodyAlt',
-	},
+	body: 'backgroundBody',
+	bodyAlt: 'backgroundBodyAlt',
 } as const;
 
-export type HeroBannerVariant = keyof typeof variantMap;
+export type HeroBannerBackground = keyof typeof variantMap;

--- a/packages/hero-banner/src/utils.ts
+++ b/packages/hero-banner/src/utils.ts
@@ -1,21 +1,17 @@
 export const variantMap = {
 	light: {
-		palette: 'light',
 		background: 'body',
 		backgroundVar: 'backgroundBody',
 	},
 	lightAlt: {
-		palette: 'light',
 		background: 'bodyAlt',
 		backgroundVar: 'backgroundBodyAlt',
 	},
 	dark: {
-		palette: 'dark',
 		background: 'body',
 		backgroundVar: 'backgroundBody',
 	},
 	darkAlt: {
-		palette: 'dark',
 		background: 'bodyAlt',
 		backgroundVar: 'backgroundBodyAlt',
 	},

--- a/packages/hero-banner/src/utils.ts
+++ b/packages/hero-banner/src/utils.ts
@@ -1,6 +1,6 @@
-export const variantMap = {
+export const backgroundMap = {
 	body: 'backgroundBody',
 	bodyAlt: 'backgroundBodyAlt',
 } as const;
 
-export type HeroBannerBackground = keyof typeof variantMap;
+export type HeroBannerBackground = keyof typeof backgroundMap;


### PR DESCRIPTION
## Describe your changes

Our HeroBanner components internally sets palette. That means that if it's parent changes palette from light to dark, the HeroBanner does not change (pictured)

<img width="1435" alt="image" src="https://user-images.githubusercontent.com/12689383/178670698-13c59254-04ca-4c64-b0ee-1bc2b2f01c45.png">

We've replaced `variant` props (light, lightAlt, dark, darkAlt) with `background` (body, bodyAlt)

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook
