### PR TITLE
SubNav: Add background prop

### DIFF
--- a/.changeset/mean-cherries-sniff.md
+++ b/.changeset/mean-cherries-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/sub-nav': major
+---
+
+Replace variant prop with background. SubNav respects parent colour palette

--- a/packages/sub-nav/docs/overview.mdx
+++ b/packages/sub-nav/docs/overview.mdx
@@ -21,4 +21,4 @@ The `SubNav` component is designed to collapse down to a static vertical list on
 />
 ```
 
-The background of the `SubNav` must match the background it is being placed on. If `SubNav` is placed on 'bodyAlt' background, please set `background="bodyAlt"`.
+The background of the `SubNav` must match the background it is being placed on. For example, if `SubNav` is placed on a 'bodyAlt' background, please set the `background` prop to `bodyAlt`.

--- a/packages/sub-nav/docs/overview.mdx
+++ b/packages/sub-nav/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Sub Nav
 description: A horizontal list of links typically placed between the main navigation and page content.
 group: Navigation
-storybookPath: /story/navigation-subnav--light-variant
+storybookPath: /story/navigation-subnav--basic
 ---
 
 The `SubNav` component is a horizontal list of links that can accommodate up to 5 items. It is best suited for navigation to persistent links, or to reveal additional content on the same page. The `SubNav` component sometimes accommodates the third level of the information architecture, following the [Side Nav](/packages/navigation/side-nav) on a content page. If you need more space for longer lists, consider another form of navigation such as the [Side Nav](/packages/navigation/side-nav), [Link List](/packages/navigation/link-list), [Inpage Nav](/packages/navigation/inpage-nav) or [Card lists](/packages/layout/card#card-lists).

--- a/packages/sub-nav/docs/overview.mdx
+++ b/packages/sub-nav/docs/overview.mdx
@@ -9,6 +9,8 @@ The `SubNav` component is a horizontal list of links that can accommodate up to 
 
 The `SubNav` component is designed to collapse down to a static vertical list on smaller devices. Progressive disclosure should not be used to enclose the SubNav on small screens.
 
+The background of the `SubNav` must match the background it is being placed on. For example, if `SubNav` is placed on a 'bodyAlt' background, please set the `background` prop to `bodyAlt`.
+
 ```jsx live
 <SubNav
 	activePath="#usage"
@@ -20,5 +22,3 @@ The `SubNav` component is designed to collapse down to a static vertical list on
 	]}
 />
 ```
-
-The background of the `SubNav` must match the background it is being placed on. For example, if `SubNav` is placed on a 'bodyAlt' background, please set the `background` prop to `bodyAlt`.

--- a/packages/sub-nav/docs/overview.mdx
+++ b/packages/sub-nav/docs/overview.mdx
@@ -20,3 +20,5 @@ The `SubNav` component is designed to collapse down to a static vertical list on
 	]}
 />
 ```
+
+The background of the `SubNav` must match the background it is being placed on. If `SubNav` is placed on 'bodyAlt' background, please set `background="bodyAlt"`.

--- a/packages/sub-nav/src/SubNav.stories.tsx
+++ b/packages/sub-nav/src/SubNav.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Box } from '@ag.ds-next/box';
 import { SubNav } from './SubNav';
 
 export default {
@@ -13,18 +14,23 @@ const exampleLinks = [
 	{ href: '#accessibility', label: 'Accessibility' },
 ];
 
-const Template: ComponentStory<typeof SubNav> = (args) => <SubNav {...args} />;
-
-export const LightVariant = Template.bind({});
-LightVariant.args = {
-	variant: 'light',
+export const Basic: ComponentStory<typeof SubNav> = (args) => (
+	<SubNav {...args} />
+);
+Basic.args = {
+	background: 'body',
 	activePath: '#code',
 	links: exampleLinks,
 };
 
-export const LightAltVariant = Template.bind({});
-LightAltVariant.args = {
-	variant: 'lightAlt',
+export const OnBodyAlt: ComponentStory<typeof SubNav> = (args) => (
+	<Box padding={1.5} background="bodyAlt">
+		<SubNav {...args} />
+	</Box>
+);
+OnBodyAlt.storyName = 'on bodyAlt background';
+OnBodyAlt.args = {
+	background: 'bodyAlt',
 	activePath: '#code',
 	links: exampleLinks,
 };

--- a/packages/sub-nav/src/SubNav.stories.tsx
+++ b/packages/sub-nav/src/SubNav.stories.tsx
@@ -28,17 +28,3 @@ LightAltVariant.args = {
 	activePath: '#code',
 	links: exampleLinks,
 };
-
-export const DarkVariant = Template.bind({});
-DarkVariant.args = {
-	variant: 'dark',
-	activePath: '#code',
-	links: exampleLinks,
-};
-
-export const DarkAltVariant = Template.bind({});
-DarkAltVariant.args = {
-	variant: 'darkAlt',
-	activePath: '#code',
-	links: exampleLinks,
-};

--- a/packages/sub-nav/src/SubNav.stories.tsx
+++ b/packages/sub-nav/src/SubNav.stories.tsx
@@ -28,7 +28,7 @@ export const OnBodyAlt: ComponentStory<typeof SubNav> = (args) => (
 		<SubNav {...args} />
 	</Box>
 );
-OnBodyAlt.storyName = 'on bodyAlt background';
+OnBodyAlt.storyName = 'On bodyAlt background';
 OnBodyAlt.args = {
 	background: 'bodyAlt',
 	activePath: '#code',

--- a/packages/sub-nav/src/SubNav.tsx
+++ b/packages/sub-nav/src/SubNav.tsx
@@ -6,9 +6,9 @@ export type SubNavProps = PropsWithChildren<{
 	activePath?: string;
 	'aria-label'?: string;
 	id?: string;
-	/** The links SubNav should show */
+	/** The navigation list items. */
 	links: SubNavListLink[];
-	/** If the ProgressIndicator is placed on a page with 'bodyAlt' background, please set this to "bodyAlt". */
+	/** If the SubNav is placed on a page with 'bodyAlt' background, please set this to 'bodyAlt'. */
 	background?: SubNavContainerVariant;
 }>;
 

--- a/packages/sub-nav/src/SubNav.tsx
+++ b/packages/sub-nav/src/SubNav.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react';
-import { SubNavContainer, SubNavContainerVariant } from './SubNavContainer';
+import { SubNavContainer, SubNavBackground } from './SubNavContainer';
 import { SubNavList, SubNavListLink } from './SubNavList';
 
 export type SubNavProps = PropsWithChildren<{
@@ -9,7 +9,7 @@ export type SubNavProps = PropsWithChildren<{
 	/** The navigation list items. */
 	links: SubNavListLink[];
 	/** If the SubNav is placed on a page with 'bodyAlt' background, please set this to 'bodyAlt'. */
-	background?: SubNavContainerVariant;
+	background?: SubNavBackground;
 }>;
 
 export function SubNav({

--- a/packages/sub-nav/src/SubNav.tsx
+++ b/packages/sub-nav/src/SubNav.tsx
@@ -6,8 +6,10 @@ export type SubNavProps = PropsWithChildren<{
 	activePath?: string;
 	'aria-label'?: string;
 	id?: string;
+	/** The links SubNav should show */
 	links: SubNavListLink[];
-	variant?: SubNavContainerVariant;
+	/** If the ProgressIndicator is placed on a page with 'bodyAlt' background, please set this to "bodyAlt". */
+	background?: SubNavContainerVariant;
 }>;
 
 export function SubNav({
@@ -15,10 +17,10 @@ export function SubNav({
 	activePath,
 	id,
 	'aria-label': ariaLabel = 'secondary',
-	variant = 'light',
+	background = 'body',
 }: SubNavProps) {
 	return (
-		<SubNavContainer id={id} aria-label={ariaLabel} variant={variant}>
+		<SubNavContainer id={id} aria-label={ariaLabel} background={background}>
 			<SubNavList links={links} activePath={activePath} />
 		</SubNavContainer>
 	);

--- a/packages/sub-nav/src/SubNavContainer.tsx
+++ b/packages/sub-nav/src/SubNavContainer.tsx
@@ -5,25 +5,21 @@ import { localPalette, localPaletteVars } from './utils';
 
 const variantMap = {
 	light: {
-		palette: 'light',
 		background: 'body',
 		hover: 'shade',
 		bottomBar: boxPalette.backgroundBodyAlt,
 	},
 	lightAlt: {
-		palette: 'light',
 		background: 'bodyAlt',
 		hover: 'shadeAlt',
 		bottomBar: boxPalette.backgroundBodyAlt,
 	},
 	dark: {
-		palette: 'dark',
 		background: 'body',
 		hover: 'shade',
 		bottomBar: boxPalette.backgroundBodyAlt,
 	},
 	darkAlt: {
-		palette: 'dark',
 		background: 'bodyAlt',
 		hover: 'shadeAlt',
 		bottomBar: boxPalette.backgroundBodyAlt,
@@ -44,11 +40,10 @@ export function SubNavContainer({
 	children,
 	variant,
 }: SubNavContainerProps) {
-	const { palette, bottomBar, background, hover } = variantMap[variant];
+	const { bottomBar, background, hover } = variantMap[variant];
 	return (
 		<Box
 			as="nav"
-			palette={palette}
 			background={background}
 			id={id}
 			aria-label={ariaLabel}

--- a/packages/sub-nav/src/SubNavContainer.tsx
+++ b/packages/sub-nav/src/SubNavContainer.tsx
@@ -3,7 +3,7 @@ import { backgroundColorMap, Box } from '@ag.ds-next/box';
 import { boxPalette, packs } from '@ag.ds-next/core';
 import { localPalette, localPaletteVars } from './utils';
 
-const variantMap = {
+const backgroundMap = {
 	body: {
 		hover: 'shade',
 		bottomBar: boxPalette.backgroundBodyAlt,
@@ -14,12 +14,12 @@ const variantMap = {
 	},
 } as const;
 
-export type SubNavContainerVariant = keyof typeof variantMap;
+export type SubNavBackground = keyof typeof backgroundMap;
 
 export type SubNavContainerProps = PropsWithChildren<{
 	id?: string;
 	'aria-label': string;
-	background: SubNavContainerVariant;
+	background: SubNavBackground;
 }>;
 
 export function SubNavContainer({
@@ -28,7 +28,7 @@ export function SubNavContainer({
 	children,
 	background,
 }: SubNavContainerProps) {
-	const { bottomBar, hover } = variantMap[background];
+	const { bottomBar, hover } = backgroundMap[background];
 	return (
 		<Box
 			as="nav"

--- a/packages/sub-nav/src/SubNavContainer.tsx
+++ b/packages/sub-nav/src/SubNavContainer.tsx
@@ -4,25 +4,13 @@ import { boxPalette, packs } from '@ag.ds-next/core';
 import { localPalette, localPaletteVars } from './utils';
 
 const variantMap = {
-	light: {
-		background: 'body',
+	body: {
 		hover: 'shade',
 		bottomBar: boxPalette.backgroundBodyAlt,
 	},
-	lightAlt: {
-		background: 'bodyAlt',
+	bodyAlt: {
 		hover: 'shadeAlt',
-		bottomBar: boxPalette.backgroundBodyAlt,
-	},
-	dark: {
-		background: 'body',
-		hover: 'shade',
-		bottomBar: boxPalette.backgroundBodyAlt,
-	},
-	darkAlt: {
-		background: 'bodyAlt',
-		hover: 'shadeAlt',
-		bottomBar: boxPalette.backgroundBodyAlt,
+		bottomBar: boxPalette.backgroundBody,
 	},
 } as const;
 
@@ -31,16 +19,16 @@ export type SubNavContainerVariant = keyof typeof variantMap;
 export type SubNavContainerProps = PropsWithChildren<{
 	id?: string;
 	'aria-label': string;
-	variant: SubNavContainerVariant;
+	background: SubNavContainerVariant;
 }>;
 
 export function SubNavContainer({
 	id,
 	'aria-label': ariaLabel,
 	children,
-	variant,
+	background,
 }: SubNavContainerProps) {
-	const { bottomBar, background, hover } = variantMap[variant];
+	const { bottomBar, hover } = variantMap[background];
 	return (
 		<Box
 			as="nav"


### PR DESCRIPTION
## Describe your changes
- Replace 'variant' with 'background' prop
- Remove parent definition, so the colours change with parent context

<img width="828" alt="image" src="https://user-images.githubusercontent.com/12689383/178930587-90c56b29-8e6a-4b63-b475-3b0f3a2866d8.png">
<img width="700" alt="image" src="https://user-images.githubusercontent.com/12689383/178930657-7c3a6153-e1a9-4ec8-a086-6e17be44cc9d.png">

Include screenshots, photos or links if necessary.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook