### PR TITLE
Discuss: Add dark mode to docs site

### DIFF
--- a/docs/components/AppLayout.tsx
+++ b/docs/components/AppLayout.tsx
@@ -9,6 +9,11 @@ type AppLayoutProps = {
 };
 
 export const AppLayout = ({ children }: AppLayoutProps) => {
+	const isDarkModeOn =
+		typeof window !== 'undefined' &&
+		window.matchMedia &&
+		window.matchMedia('(prefers-color-scheme: dark)').matches;
+
 	return (
 		<>
 			<SkipLinks
@@ -20,7 +25,8 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
 			<Flex
 				flexDirection="column"
 				fontFamily="body"
-				palette="light"
+				palette={isDarkModeOn ? 'dark' : 'light'}
+				background="body"
 				minHeight="100vh"
 			>
 				<SiteHeader />


### PR DESCRIPTION
## Describe your changes
Use system dark-mode flag to enable the dark palette globally across the docs site.
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/12689383/179152513-88746ac2-ed34-4972-b31c-988830ca9215.png">

Include screenshots, photos or links if necessary.

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in package.json is set to 0.0.1
- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/designSystemComponents.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
