### PR TITLE
body: Allow consumers to keep vertical rhythm on specific elements

### DIFF
--- a/.changeset/moody-games-sort.md
+++ b/.changeset/moody-games-sort.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/body': patch
+---
+
+
+Allow consumers to keep vertical rhythm on specific elements using `bodyBlockClassname`

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -20,7 +20,7 @@ import {
 	useToggleState,
 } from '@ag.ds-next/core';
 import { Box, Flex } from '@ag.ds-next/box';
-import { unsetBodyStylesClassname } from '@ag.ds-next/body';
+import { unsetBodyStylesClassname, bodyBlockClassname } from '@ag.ds-next/body';
 import { Button, ButtonLink } from '@ag.ds-next/button';
 import { CopyIcon, ChevronDownIcon, ChevronUpIcon } from '@ag.ds-next/icon';
 import { designSystemComponents } from './designSystemComponents';
@@ -34,7 +34,7 @@ const PlaceholderImage = () => (
 	/>
 );
 
-const LiveCode = withLive((props: unknown) => {
+const LiveCode = withLive(function LiveCode(props: unknown) {
 	const { query } = useRouter();
 
 	// The types on `withLive` are kind of useless.
@@ -73,12 +73,7 @@ const LiveCode = withLive((props: unknown) => {
 	const codeId = `live-code-${id}`;
 
 	return (
-		<Box
-			border
-			rounded
-			borderColor="muted"
-			css={{ '&:not(:first-of-type)': { marginTop: mapSpacing(1.5) } }}
-		>
+		<Box border rounded borderColor="muted" className={bodyBlockClassname}>
 			<LivePreview
 				aria-label="Rendered code snippet example"
 				// Prevents body styles from being inherited in live code examples (except for the body example)

--- a/packages/body/src/Body.tsx
+++ b/packages/body/src/Body.tsx
@@ -19,6 +19,9 @@ export const Body = forwardRefWithAs<'div', BoxProps>(function Body(
 // Allow consumers to unset body styles from being inherited on specific elements
 export const unsetBodyStylesClassname = 'unset-agds-body-styles';
 
+// Allow consumers to keep vertical rhythm on specific elements
+export const bodyBlockClassname = 'agds-body-block';
+
 // Exclude tags which contain a className (generated from the CSS prop) or are a child of the unset class
 const notSelector = `:not([class]):not(.${unsetBodyStylesClassname} *)`;
 
@@ -33,6 +36,13 @@ export const bodyClass = css({
 		// Font grid
 		fontFamily: tokens.font.body,
 		...fontGrid('sm', 'default'),
+	},
+
+	/**
+	 * Body block
+	 */
+	[`* + .${bodyBlockClassname}:not(.${unsetBodyStylesClassname} *)`]: {
+		marginTop: mapSpacing(1.5),
 	},
 
 	/**


### PR DESCRIPTION
## Describe your changes

This PR exports a new variable `bodyBlockClassname`.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in package.json is set to 0.0.1
- [ ] Create changelog file (packages/component/CHANGELOG.md)
- [ ] Add components to Playroom (docs/playroom/components.js)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add to Docs for jsx live (docs/components/designSystemComponents.tsx)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
