### PR TITLE
FileUpload: New rejected file UI

### DIFF
--- a/.changeset/loud-lions-cheat.md
+++ b/.changeset/loud-lions-cheat.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/file-upload': minor
+---
+
+Refreshed UI for invalid files

--- a/packages/file-upload/src/FileRejection.stories.tsx
+++ b/packages/file-upload/src/FileRejection.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { FileRejection } from './FileRejection';
+
+export default {
+	title: 'forms/FileUpload/FileRejection',
+	component: FileRejection,
+} as ComponentMeta<typeof FileRejection>;
+
+const Template: ComponentStory<typeof FileRejection> = (args) => {
+	return <FileRejection {...args} />;
+};
+
+export const FileSize = Template.bind({});
+FileSize.args = {
+	message: 'File size exceeds 10MB',
+	fileName: 'ExampleFile.jpg',
+};
+
+export const InvalidType = Template.bind({});
+InvalidType.args = {
+	message: 'File must be one of the following types: jpg, png, gif',
+	fileName: 'ExampleFile.jpg',
+};

--- a/packages/file-upload/src/FileRejection.stories.tsx
+++ b/packages/file-upload/src/FileRejection.stories.tsx
@@ -14,10 +14,12 @@ export const FileSize = Template.bind({});
 FileSize.args = {
 	message: 'File size exceeds 10MB',
 	fileName: 'ExampleFile.jpg',
+	fileSize: 4580,
 };
 
 export const InvalidType = Template.bind({});
 InvalidType.args = {
 	message: 'File must be one of the following types: jpg, png, gif',
 	fileName: 'ExampleFile.jpg',
+	fileSize: 4580,
 };

--- a/packages/file-upload/src/FileRejection.tsx
+++ b/packages/file-upload/src/FileRejection.tsx
@@ -1,27 +1,55 @@
-import { ReactNode } from 'react';
-import { Flex } from '@ag.ds-next/box';
+import formatFileSize from 'filesize';
+import { Box, Flex, Stack } from '@ag.ds-next/box';
+import { Button } from '@ag.ds-next/button';
 import { globalPalette } from '@ag.ds-next/core';
 import { AlertFilledIcon } from '@ag.ds-next/icon';
 import { Text } from '@ag.ds-next/text';
 
 type FileRejectionProps = {
-	children: ReactNode;
+	fileName: string;
+	fileSize: number;
+	message: string;
+	onRemove: () => void;
 };
 
-export const FileRejection = ({ children }: FileRejectionProps) => {
+// TODO: Rename to FileUploadRejectedFile
+export const FileRejection = ({
+	fileName,
+	fileSize,
+	message,
+	onRemove,
+}: FileRejectionProps) => {
 	return (
 		<Flex
 			as="li"
 			gap={0.5}
-			alignItems="center"
+			alignItems="flex-start"
 			rounded
-			padding={1}
+			flexDirection="row"
+			justifyContent="space-between"
+			paddingY={1}
+			paddingLeft={1}
 			css={{
 				background: globalPalette.errorMuted,
 			}}
 		>
-			<AlertFilledIcon color="error" size="md" />
-			<Text color="error">{children}</Text>
+			<Flex gap={0.5}>
+				<Box flexShrink={1}>
+					<AlertFilledIcon color="error" size="md" />
+				</Box>
+				<Stack gap={0}>
+					<Text fontWeight="bold" color="error">
+						{message}
+					</Text>
+					<Text>{`${fileName} (${formatFileSize(fileSize)})`}</Text>
+				</Stack>
+			</Flex>
+
+			<Box flexShrink={0}>
+				<Button variant="tertiary" onClick={onRemove}>
+					Remove error
+				</Button>
+			</Box>
 		</Flex>
 	);
 };

--- a/packages/file-upload/src/FileRejection.tsx
+++ b/packages/file-upload/src/FileRejection.tsx
@@ -1,3 +1,4 @@
+import { MouseEventHandler } from 'react';
 import formatFileSize from 'filesize';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
 import { Button } from '@ag.ds-next/button';
@@ -9,7 +10,7 @@ type FileRejectionProps = {
 	fileName: string;
 	fileSize: number;
 	message: string;
-	onRemove: () => void;
+	onRemove: MouseEventHandler<HTMLButtonElement>;
 };
 
 // TODO: Rename to FileUploadRejectedFile
@@ -41,10 +42,11 @@ export const FileRejection = ({
 					<Text fontWeight="bold" color="error">
 						{message}
 					</Text>
-					<Text>{`${fileName} (${formatFileSize(fileSize)})`}</Text>
+					<Text>
+						{fileName} ({formatFileSize(fileSize)})
+					</Text>
 				</Stack>
 			</Flex>
-
 			<Box flexShrink={0}>
 				<Button variant="tertiary" onClick={onRemove}>
 					Remove error

--- a/packages/file-upload/src/FileUpload.stories.tsx
+++ b/packages/file-upload/src/FileUpload.stories.tsx
@@ -64,14 +64,14 @@ Valid.args = {
 	valid: true,
 };
 
-export const Multiple = Template.bind({});
-Multiple.args = {
+export const MultipleFiles = Template.bind({});
+MultipleFiles.args = {
 	label: 'Identity documents',
 	multiple: true,
 };
 
-export const AcceptedFormats = Template.bind({});
-AcceptedFormats.args = {
+export const OnlyAcceptedFormats = Template.bind({});
+OnlyAcceptedFormats.args = {
 	label: 'Identity documents',
 	required: true,
 	hint: 'May include images of your passport, drivers licence etc.',

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -56,6 +56,7 @@ type FileUploadRejection = {
 	id: string;
 	fileName: string;
 	fileSize: number;
+	code: string;
 	message: string;
 };
 
@@ -83,7 +84,9 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 		const filesPlural = multiple ? 'files' : 'file';
 		const maxSizeBytes = (maxSize || 0) * 1000;
 		const formattedMaxFileSize = formatFileSize(maxSizeBytes);
-		const [fileRejections, setRejections] = useState<FileUploadRejection[]>([]);
+		const [fileRejections, setFileRejections] = useState<FileUploadRejection[]>(
+			[]
+		);
 
 		const handleRemoveFile = (file: FileWithStatus) => {
 			const indexOfFile = value.indexOf(file);
@@ -91,7 +94,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 		};
 
 		const handleRemoveRejection = (errId: string) => {
-			setRejections(fileRejections.filter((err) => err.id !== errId));
+			setFileRejections(fileRejections.filter((err) => err.id !== errId));
 		};
 
 		const handleDropAccepted = (acceptedFiles: FileWithStatus[]) => {
@@ -122,7 +125,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 		});
 
 		const errorSummary = getErrorSummary(
-			RDrejections,
+			fileRejections,
 			formattedMaxFileSize,
 			maxFiles
 		);
@@ -146,10 +149,11 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 							formattedMaxFileSize,
 							acceptedFilesSummary
 						),
+						code: err.code,
 					})
 				);
 			});
-			setRejections(errs);
+			setFileRejections(errs);
 		}, [RDrejections, formattedMaxFileSize, acceptedFilesSummary]);
 
 		return (

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -169,7 +169,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 					const { color: _, ...rootProps } = getRootProps();
 
 					return (
-						<Stack gap={1} {...rootProps}>
+						<Stack gap={1.5} {...rootProps}>
 							<Flex
 								gap={1}
 								padding={1.5}

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -127,7 +127,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 					const { color: _, ...rootProps } = getRootProps();
 
 					return (
-						<Stack gap={0.5} {...rootProps}>
+						<Stack gap={1} {...rootProps}>
 							<Flex
 								gap={1}
 								padding={1.5}

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -230,35 +230,37 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 									Select {filesPlural}
 								</Button>
 							</Flex>
-							<Stack gap={0.5}>
-								{value?.length ? (
-									<Fragment>
-										<Text color="muted">{getFilesTotal(value)}</Text>
+							{value.length || fileRejections.length ? (
+								<Stack gap={0.5}>
+									{value.length ? (
+										<Fragment>
+											<Text color="muted">{getFilesTotal(value)}</Text>
+											<Stack as="ul" gap={0.5}>
+												{value.map((file, index) => (
+													<FileUploadFile
+														key={index}
+														name={file.name}
+														size={file.size}
+														status={file.status}
+														onRemove={() => handleRemoveFile(file)}
+													/>
+												))}
+											</Stack>
+										</Fragment>
+									) : null}
+									{fileRejections.length ? (
 										<Stack as="ul" gap={0.5}>
-											{value.map((file, index) => (
-												<FileUploadFile
-													key={index}
-													name={file.name}
-													size={file.size}
-													status={file.status}
-													onRemove={() => handleRemoveFile(file)}
+											{fileRejections.map(({ id, ...rejection }) => (
+												<FileRejection
+													key={id}
+													{...rejection}
+													onRemove={() => handleRemoveRejection(id)}
 												/>
 											))}
 										</Stack>
-									</Fragment>
-								) : null}
-								{fileRejections.length ? (
-									<Stack as="ul" gap={0.5}>
-										{fileRejections.map(({ id, ...rejection }) => (
-											<FileRejection
-												key={id}
-												{...rejection}
-												onRemove={() => handleRemoveRejection(id)}
-											/>
-										))}
-									</Stack>
-								) : null}
-							</Stack>
+									) : null}
+								</Stack>
+							) : null}
 						</Stack>
 					);
 				}}

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -175,33 +175,42 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 									{`Select ${filesPlural}`}
 								</Button>
 							</Flex>
-							{value?.length ? (
-								<Fragment>
-									<Text color="muted">{getFilesTotal(value)}</Text>
+							<Stack gap={0.5}>
+								{value?.length ? (
+									<Fragment>
+										<Text color="muted">{getFilesTotal(value)}</Text>
+										<Stack as="ul" gap={0.5}>
+											{value.map((file, index) => (
+												<FileUploadFile
+													name={file.name}
+													size={file.size}
+													status={file.status}
+													key={index}
+													onRemove={() => handleRemoveFile(file)}
+												/>
+											))}
+										</Stack>
+									</Fragment>
+								) : null}
+								{fileRejections.length ? (
 									<Stack as="ul" gap={0.5}>
-										{value.map((file, index) => (
-											<FileUploadFile
-												file={file}
-												key={index}
-												onRemove={() => handleRemoveFile(file)}
-											/>
-										))}
-									</Stack>
-								</Fragment>
-							) : null}
-							{fileRejections.length ? (
-								<Stack as="ul" gap={0.5}>
-									{fileRejections.map((err, index) => (
-										<FileRejection key={index}>
-											{getFileRejectionErrorMessage(
-												err,
+										{fileRejections.map((rejection, index) => {
+											const firstError = rejection.errors[0];
+
+											const errorMessage = getFileRejectionErrorMessage(
+												rejection,
 												formattedMaxFileSize,
 												acceptedFilesSummary
-											)}
-										</FileRejection>
-									))}
-								</Stack>
-							) : null}{' '}
+											);
+											return (
+												<FileRejection key={index}>
+													{errorMessage}
+												</FileRejection>
+											);
+										})}
+									</Stack>
+								) : null}
+							</Stack>
 						</Stack>
 					);
 				}}

--- a/packages/file-upload/src/FileUploadFile.stories.tsx
+++ b/packages/file-upload/src/FileUploadFile.stories.tsx
@@ -1,0 +1,33 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { FileUploadFile } from './FileUploadFile';
+
+export default {
+	title: 'forms/FileUpload/FileUploadFile',
+	component: FileUploadFile,
+} as ComponentMeta<typeof FileUploadFile>;
+
+export const Basic: ComponentStory<typeof FileUploadFile> = (args) => {
+	return <FileUploadFile {...args} />;
+};
+Basic.args = {
+	name: 'Example.jpg',
+	size: 2345,
+};
+
+export const Uploading: ComponentStory<typeof FileUploadFile> = (args) => {
+	return <FileUploadFile {...args} />;
+};
+Uploading.args = {
+	name: 'Example.jpg',
+	size: 2345,
+	status: 'uploading',
+};
+
+export const Success: ComponentStory<typeof FileUploadFile> = (args) => {
+	return <FileUploadFile {...args} />;
+};
+Success.args = {
+	name: 'Example.jpg',
+	size: 2345,
+	status: 'success',
+};

--- a/packages/file-upload/src/FileUploadFile.tsx
+++ b/packages/file-upload/src/FileUploadFile.tsx
@@ -6,15 +6,19 @@ import { Text } from '@ag.ds-next/text';
 import { Button } from '@ag.ds-next/button';
 import { LoadingDots } from '@ag.ds-next/loading';
 import { SuccessFilledIcon } from '@ag.ds-next/icon';
-import { FileWithStatus } from './utils';
+import { FileStatus } from './utils';
 
 type FileUploadFileProps = {
-	file: FileWithStatus;
+	name: string;
+	size: number;
+	status?: FileStatus;
 	onRemove: MouseEventHandler<HTMLButtonElement>;
 };
 
 export const FileUploadFile = ({
-	file: { status = 'none', size, name },
+	status = 'none',
+	size,
+	name,
 	onRemove,
 }: FileUploadFileProps) => {
 	return (

--- a/packages/file-upload/src/FileUploadFile.tsx
+++ b/packages/file-upload/src/FileUploadFile.tsx
@@ -15,6 +15,7 @@ type FileUploadFileProps = {
 	onRemove: MouseEventHandler<HTMLButtonElement>;
 };
 
+// TODO: Rename to FileUploadAcceptedFile
 export const FileUploadFile = ({
 	status = 'none',
 	size,

--- a/packages/file-upload/src/utils.tsx
+++ b/packages/file-upload/src/utils.tsx
@@ -1,8 +1,9 @@
 import formatFileSize from 'filesize';
 import type { FileRejection, FileWithPath } from 'react-dropzone';
 
+export type FileStatus = 'none' | 'uploading' | 'success';
 export type FileWithStatus = FileWithPath & {
-	status?: 'none' | 'uploading' | 'success';
+	status?: FileStatus;
 };
 
 export const getFilesTotal = (files: { size: number }[]) => {

--- a/packages/file-upload/src/utils.tsx
+++ b/packages/file-upload/src/utils.tsx
@@ -1,5 +1,5 @@
 import formatFileSize from 'filesize';
-import type { FileRejection, FileError, FileWithPath } from 'react-dropzone';
+import type { FileError, FileWithPath } from 'react-dropzone';
 
 export type FileStatus = 'none' | 'uploading' | 'success';
 export type FileWithStatus = FileWithPath & {
@@ -69,13 +69,13 @@ export const getFileRejectionErrorMessage = (
 };
 
 export const getErrorSummary = (
-	rejections: FileRejection[] | undefined,
+	rejections: FileError[],
 	formattedMaxFileSize: string,
 	maxFiles: number | undefined
 ) => {
 	if (!rejections?.length) return;
 
-	const firstError = rejections[0].errors[0];
+	const firstError = rejections[0];
 
 	if (firstError.code === 'too-many-files') {
 		return `You can not select more than ${maxFiles} files`;

--- a/packages/file-upload/src/utils.tsx
+++ b/packages/file-upload/src/utils.tsx
@@ -1,5 +1,5 @@
 import formatFileSize from 'filesize';
-import type { FileRejection, FileWithPath } from 'react-dropzone';
+import type { FileRejection, FileError, FileWithPath } from 'react-dropzone';
 
 export type FileStatus = 'none' | 'uploading' | 'success';
 export type FileWithStatus = FileWithPath & {
@@ -52,22 +52,20 @@ export const getAcceptedFilesSummary = (accept: FileFormats[] | undefined) => {
 };
 
 export const getFileRejectionErrorMessage = (
-	{ file, errors }: FileRejection,
+	{ code, message }: FileError,
 	formattedMaxFileSize: string,
 	acceptedFilesSummary: string | undefined
 ) => {
-	const { code, message } = errors[0];
 	if (code === 'file-too-large') {
-		return `${file.name} size exceeds ${formattedMaxFileSize}`;
+		return `File size exceeds ${formattedMaxFileSize}`;
 	}
 
 	if (code === 'file-invalid-type') {
-		if (!acceptedFilesSummary)
-			return `${file.name} must be an acceptable format`;
-		return `${file.name} must be one of the following types: ${acceptedFilesSummary}`;
+		if (!acceptedFilesSummary) return `File must be an acceptable format`;
+		return `File must be one of the following types: ${acceptedFilesSummary}`;
 	}
 
-	return `${file.name}: ${message}`;
+	return message;
 };
 
 export const getErrorSummary = (


### PR DESCRIPTION
## Describe your changes
- New UI for rejected files ([Product Backlog Item 261307](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/261307?McasTsid=26110))
- Increase spacing between drop zone and file list ([Product Backlog Item 262389](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/262389?McasTsid=26110))
- Enable removal (hiding) of errors
- Improve props for FileUploadFile component

## Testing notes
I recommend opening the "multiple images" Story for FileUpload in Storybook, and attempting to drag in a .pages file (or other) that is too large for the max size.

<img width="1095" alt="image" src="https://user-images.githubusercontent.com/12689383/179671117-bff38dd9-3ad7-4fb3-b399-8e787e09d915.png">


## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook
