### PR TITLE
Box: Add `columnGap` and `rowGap` props

### DIFF
--- a/.changeset/real-pugs-share.md
+++ b/.changeset/real-pugs-share.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/box': minor
+---
+
+Add support for `columnGap` and `rowGap` props

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -149,6 +149,8 @@ type LayoutProps = Partial<{
 		'stretch' | 'flex-start' | 'flex-end' | 'center' | 'baseline'
 	>;
 	gap: ResponsiveProp<Spacing>;
+	columnGap: ResponsiveProp<Spacing>;
+	rowGap: ResponsiveProp<Spacing>;
 	width: ResponsiveProp<number | string>;
 	minWidth: ResponsiveProp<number | string>;
 	maxWidth: ResponsiveProp<number | string>;
@@ -166,6 +168,8 @@ function layoutStyles({
 	justifyContent,
 	alignItems,
 	gap,
+	columnGap,
+	rowGap,
 	width,
 	minWidth,
 	maxWidth,
@@ -182,6 +186,8 @@ function layoutStyles({
 		justifyContent: mapResponsiveProp(justifyContent),
 		alignItems: mapResponsiveProp(alignItems),
 		gap: mapResponsiveProp(gap, mapSpacing),
+		columnGap: mapResponsiveProp(columnGap, mapSpacing),
+		rowGap: mapResponsiveProp(rowGap, mapSpacing),
 		width: mapResponsiveProp(width),
 		minWidth: mapResponsiveProp(minWidth),
 		maxWidth: mapResponsiveProp(maxWidth),
@@ -369,6 +375,8 @@ export function boxStyles({
 	justifyContent,
 	alignItems,
 	gap,
+	columnGap,
+	rowGap,
 	width,
 	minWidth,
 	maxWidth,
@@ -431,6 +439,8 @@ export function boxStyles({
 					justifyContent,
 					alignItems,
 					gap,
+					columnGap,
+					rowGap,
 					width,
 					minWidth,
 					maxWidth,


### PR DESCRIPTION
## Describe your changes

Add `columnGap` and `rowGap` props to Box component. Useful for both flexBox and grid.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
