### PR TITLE
side-nav: Make `titleLink` optional

### DIFF
--- a/.changeset/silent-swans-visit.md
+++ b/.changeset/silent-swans-visit.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/side-nav': patch
+---
+
+Converted `titleLink` into an optional prop

--- a/packages/side-nav/docs/overview.mdx
+++ b/packages/side-nav/docs/overview.mdx
@@ -12,6 +12,7 @@ On mobile and smaller viewports, the side navigation uses functionality from the
 ```jsx live
 <SideNav
 	activePath="#welcome"
+	collapseTitle="In this section"
 	title="SideNav"
 	titleLink="#"
 	items={[

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -91,9 +91,20 @@ OnBodyAlt.args = {
 };
 OnBodyAlt.storyName = 'On bodyAlt background';
 
+export const OptionalTitleLink: ComponentStory<typeof SideNav> = (args) => (
+	<SideNav {...args} />
+);
+OptionalTitleLink.args = {
+	...defaultArgs,
+	titleLink: undefined,
+	background: 'body',
+};
+
 export const Modular = () => (
 	<SideNavContainer background="body" aria-label="side navigation">
-		<SideNavTitle href="#">SideNav Title</SideNavTitle>
+		<SideNavTitle id="side-nav-modular-title" href="#" isCurrentPage={false}>
+			SideNav Title
+		</SideNavTitle>
 		<SideNavGroup>
 			<SideNavLink href="#one" label="One" />
 			<SideNavLink href="#two" label="Two" />

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -14,13 +14,21 @@ import { SideNavLink } from './SideNavLink';
 import { SideNavCollapseButton } from './SideNavCollapseButton';
 import { SideNavBackground, findBestMatch, useSideNavIds } from './utils';
 
-export type SideNavProps = LinkListProps & {
+export type SideNavProps = {
+	/** Describes the navigation element to assistive technologies. */
 	'aria-label'?: string;
+	/** Used for highlighting the active element. */
+	activePath: string;
+	/** Used as the title of the expand/collapse trigger on smaller screen sizes. */
 	collapseTitle: string;
-	/** If SideNav is placed on 'bodyAlt' background, please set this to "bodyAlt". */
+	/** If SideNav is placed on 'bodyAlt' background, please set this to 'bodyAlt'. */
 	background?: SideNavBackground;
+	/** The list of links. */
+	items: SideNavMenuItemType[];
+	/** The title is placed at the top of the list of links. */
 	title: ReactNode;
-	titleLink: string; // TODO: should this be optional
+	/** If provided, the title will be rendered as an anchor element. */
+	titleLink?: string;
 };
 
 export function SideNav({

--- a/packages/side-nav/src/SideNavTitle.tsx
+++ b/packages/side-nav/src/SideNavTitle.tsx
@@ -1,19 +1,23 @@
+import { PropsWithChildren } from 'react';
 import { Box } from '@ag.ds-next/box';
-import { LinkProps, packs, useLinkComponent } from '@ag.ds-next/core';
+import { packs, useLinkComponent } from '@ag.ds-next/core';
 import { localPalette } from './utils';
 
-export type SideNavTitleProps = LinkProps & {
-	isCurrentPage?: boolean;
-};
+export type SideNavTitleProps = PropsWithChildren<{
+	id: string;
+	href?: string;
+	isCurrentPage: boolean;
+}>;
 
-export const SideNavTitle = ({
+export function SideNavTitle({
 	children,
 	id,
 	isCurrentPage,
-	...props
-}: SideNavTitleProps) => {
+	href,
+}: SideNavTitleProps) {
 	const Link = useLinkComponent();
-	return (
+
+	if (href) {
 		<Box as="h2" id={id}>
 			<Box
 				as={Link}
@@ -24,8 +28,8 @@ export const SideNavTitle = ({
 				lineHeight="heading"
 				display="block"
 				focus
+				href={href}
 				aria-current={isCurrentPage ? 'page' : undefined}
-				{...props}
 				css={{
 					textDecoration: 'none',
 					'&:hover': {
@@ -36,6 +40,21 @@ export const SideNavTitle = ({
 			>
 				{children}
 			</Box>
+		</Box>;
+	}
+
+	return (
+		<Box
+			as="h2"
+			id={id}
+			display="block"
+			padding={1}
+			color="text"
+			fontSize="sm"
+			fontWeight="bold"
+			lineHeight="heading"
+		>
+			{children}
 		</Box>
 	);
-};
+}


### PR DESCRIPTION
## Describe your changes

Converted `titleLink` into an optional prop. This removes an old `TODO` that has been there since this component was created.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
