### PR TITLE
Storybook: Add examples of Cards, and Table with StatusBadge

### DIFF
--- a/packages/badge/src/StatusBadge.stories.tsx
+++ b/packages/badge/src/StatusBadge.stories.tsx
@@ -65,7 +65,7 @@ export const LanguageExamples = () => {
 	);
 };
 
-export const InTable: ComponentStory<typeof Table> = (args) => {
+export const InTable = () => {
 	const data = [
 		{
 			id: 'RE4321–2201–03',
@@ -102,7 +102,7 @@ export const InTable: ComponentStory<typeof Table> = (args) => {
 
 	return (
 		<TableWrapper>
-			<Table {...args}>
+			<Table>
 				<TableCaption>Corrective action requests (CAR)</TableCaption>
 				<TableHead>
 					<tr>

--- a/packages/badge/src/StatusBadge.stories.tsx
+++ b/packages/badge/src/StatusBadge.stories.tsx
@@ -1,5 +1,15 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Flex, Stack } from '@ag.ds-next/box';
+import {
+	Table,
+	TableBody,
+	TableCaption,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableWrapper,
+} from '@ag.ds-next/table';
+import { TextLink } from '@ag.ds-next/text-link';
 import { StatusBadge } from './StatusBadge';
 
 export default {
@@ -52,5 +62,75 @@ export const LanguageExamples = () => {
 				<StatusBadge tone="neutral" label="Draft" />
 			</Stack>
 		</Flex>
+	);
+};
+
+export const InTable: ComponentStory<typeof Table> = (args) => {
+	const data = [
+		{
+			id: 'RE4321–2201–03',
+			businessName: 'Orange Meat Works',
+			type: 'Record keeping—Minor',
+			status: 'Pending',
+		},
+		{
+			id: 'RE4321–2201–02',
+			businessName: 'Orange Meat Works',
+			type: 'Hygiene—Major',
+			status: 'Open',
+		},
+		{
+			id: 'RE4321–2201–01',
+			businessName: 'Molong Meat Works',
+			type: 'Record keeping—Minor',
+			status: 'Open',
+		},
+		{
+			id: 'RE4321–2201–00',
+			businessName: 'Orange Meat Works',
+			type: 'Record keeping—Minor',
+			status: 'Closed',
+		},
+	] as const;
+
+	const toneMapper = {
+		Closed: 'success',
+		Open: 'warning',
+		Pending: 'info',
+		Draft: 'neutral',
+	} as const;
+
+	return (
+		<TableWrapper>
+			<Table {...args}>
+				<TableCaption>Corrective action requests (CAR)</TableCaption>
+				<TableHead>
+					<tr>
+						<TableHeader>CAR number</TableHeader>
+						<TableHeader>Establishment name</TableHeader>
+						<TableHeader>Activity and severity</TableHeader>
+						<TableHeader>Status</TableHeader>
+						<TableHeader>Actions</TableHeader>
+					</tr>
+				</TableHead>
+				<TableBody>
+					{data.map(({ id, businessName, status, type }) => (
+						<tr key={id}>
+							<TableCell>{id}</TableCell>
+							<TableCell>{businessName}</TableCell>
+							<TableCell>{type}</TableCell>
+							<TableCell>
+								<StatusBadge tone={toneMapper[status]} label={status} />
+							</TableCell>
+							<TableCell>
+								<TextLink href={`#${id}`}>
+									{status == 'Closed' ? 'View' : 'Manage'}
+								</TextLink>
+							</TableCell>
+						</tr>
+					))}
+				</TableBody>
+			</Table>
+		</TableWrapper>
 	);
 };

--- a/packages/badge/src/StatusBadge.tsx
+++ b/packages/badge/src/StatusBadge.tsx
@@ -30,6 +30,7 @@ export const StatusBadge = ({ label, tone }: StatusBadgeProps) => {
 			border
 			css={{
 				overflow: 'hidden',
+				flexShrink: 0,
 				borderRadius,
 				borderColor,
 				'& svg': {

--- a/packages/badge/src/StatusBadge.tsx
+++ b/packages/badge/src/StatusBadge.tsx
@@ -30,7 +30,6 @@ export const StatusBadge = ({ label, tone }: StatusBadgeProps) => {
 			border
 			css={{
 				overflow: 'hidden',
-				flexShrink: 0,
 				borderRadius,
 				borderColor,
 				'& svg': {

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -293,24 +293,6 @@ export const Compositions = () => {
 						</CardInner>
 					</Card>
 
-					<Card>
-						<CardInner>
-							<Stack gap={0.5}>
-								<Flex justifyContent="space-between">
-									<Tags items={[{ label: '1034' }]} />
-									<Text color="muted">MEAT</Text>
-								</Flex>
-
-								<Text fontSize="lg" fontWeight="bold">
-									Orange Farmers Market
-								</Text>
-
-								<TextLink>Registrations</TextLink>
-								<TextLink>Insights</TextLink>
-							</Stack>
-						</CardInner>
-					</Card>
-
 					<Card shadow clickable>
 						<CardInner>
 							<Stack gap={1}>

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { VisuallyHidden } from '@ag.ds-next/a11y';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
-import { H1, H2, H3, Heading } from '@ag.ds-next/heading';
+import { H1, H2, Heading } from '@ag.ds-next/heading';
 import { ChevronRightIcon } from '@ag.ds-next/icon';
 import { Columns, Column } from '@ag.ds-next/columns';
 import { DirectionLink } from '@ag.ds-next/direction-link';

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -1,6 +1,8 @@
+import { Fragment } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { VisuallyHidden } from '@ag.ds-next/a11y';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
-import { Heading } from '@ag.ds-next/heading';
+import { H1, H2, H3, Heading } from '@ag.ds-next/heading';
 import { ChevronRightIcon } from '@ag.ds-next/icon';
 import { Columns, Column } from '@ag.ds-next/columns';
 import { DirectionLink } from '@ag.ds-next/direction-link';
@@ -8,6 +10,7 @@ import { Tags } from '@ag.ds-next/tags';
 import { Text } from '@ag.ds-next/text';
 import { TextLink } from '@ag.ds-next/text-link';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
+import { StatusBadge } from '@ag.ds-next/badge';
 import { Card } from './Card';
 import { CardInner } from './CardInner';
 import { CardLink } from './CardLink';
@@ -126,31 +129,77 @@ FeatureFooter.args = {
 	background: 'body',
 };
 
-const ExampleCard = () => (
-	<Card as="li">
-		<CardInner>
-			<Stack gap={1}>
-				<Heading as="h2" type="h3">
-					Card as `li`
-				</Heading>
-				<Text as="p">
-					Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptat
-				</Text>
-				<CardLink href="#">Learn more</CardLink>
-			</Stack>
-		</CardInner>
-	</Card>
-);
+export const CardListStory = () => {
+	const toneMapper = {
+		Closed: 'success',
+		Open: 'warning',
+		Pending: 'info',
+	} as const;
 
-export const CardListStory = () => (
-	<Columns cols={{ xs: 1, sm: 2, md: 3 }}>
-		<ExampleCard />
-		<ExampleCard />
-		<ExampleCard />
-		<ExampleCard />
-		<ExampleCard />
-	</Columns>
-);
+	const listData = [
+		{
+			id: 'RE4321–2201–03',
+			businessName: 'Orange Meat Works',
+			type: 'Record keeping—Minor',
+			status: 'Pending',
+		},
+		{
+			id: 'RE4321–2201–02',
+			businessName: 'Orange Meat Works',
+			type: 'Hygiene—Major',
+			status: 'Open',
+		},
+		{
+			id: 'RE4321–2201–01',
+			businessName: 'Orange Meat Works',
+			type: 'Record keeping—Minor',
+			status: 'Closed',
+		},
+	] as const;
+
+	return (
+		<Stack gap={1}>
+			<H1>Manage corrective action requests (CAR)</H1>
+			<Text>You may now manage your CARs online.</Text>
+			<H2>Active CARs</H2>
+			<Columns as="ul" gap={1} cols={{ xs: 1, sm: 2, md: 3 }}>
+				{listData.map((item) => (
+					<Card shadow clickable as="li" key={item.id}>
+						<CardInner>
+							<Stack gap={1} width="100%" flexWrap="wrap">
+								<Text fontSize="lg" fontWeight="bold">
+									<CardLink href={`#${item.id}`}>{item.businessName}</CardLink>
+								</Text>
+
+								<Flex justifyContent="space-between" alignItems="center">
+									<Text lineHeight="nospace" as="p">
+										<VisuallyHidden>Type: </VisuallyHidden>
+										{item.type}.
+									</Text>
+
+									<StatusBadge
+										tone={toneMapper[item.status]}
+										label={
+											<Fragment>
+												<VisuallyHidden>Status: </VisuallyHidden>
+												{item.status}
+											</Fragment>
+										}
+									/>
+								</Flex>
+
+								<Text color="muted" fontSize="xs">
+									<VisuallyHidden>CAR ID: </VisuallyHidden>
+									{item.id}
+								</Text>
+							</Stack>
+						</CardInner>
+					</Card>
+				))}
+			</Columns>
+		</Stack>
+	);
+};
 CardListStory.storyName = 'List of Cards';
 
 export const Compositions = () => {

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -2,7 +2,7 @@ import { Fragment } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { VisuallyHidden } from '@ag.ds-next/a11y';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
-import { H1, H2, Heading } from '@ag.ds-next/heading';
+import { H2, H3, Heading } from '@ag.ds-next/heading';
 import { ChevronRightIcon } from '@ag.ds-next/icon';
 import { Columns, Column } from '@ag.ds-next/columns';
 import { DirectionLink } from '@ag.ds-next/direction-link';
@@ -11,6 +11,7 @@ import { Text } from '@ag.ds-next/text';
 import { TextLink } from '@ag.ds-next/text-link';
 import { ExternalLinkIcon } from '@ag.ds-next/icon';
 import { StatusBadge } from '@ag.ds-next/badge';
+import { PageContent } from '@ag.ds-next/content';
 import { Card } from './Card';
 import { CardInner } from './CardInner';
 import { CardLink } from './CardLink';
@@ -140,64 +141,71 @@ export const CardListStory = () => {
 		{
 			id: 'RE4321–2201–03',
 			businessName: 'Orange Meat Works',
-			type: 'Record keeping—Minor',
+			type: 'Record keeping (Minor)',
 			status: 'Pending',
 		},
 		{
 			id: 'RE4321–2201–02',
 			businessName: 'Orange Meat Works',
-			type: 'Hygiene—Major',
+			type: 'Hygiene (Major)',
 			status: 'Open',
 		},
 		{
 			id: 'RE4321–2201–01',
 			businessName: 'Orange Meat Works',
-			type: 'Record keeping—Minor',
+			type: 'Record keeping (Minor)',
 			status: 'Closed',
 		},
 	] as const;
 
 	return (
-		<Stack gap={1}>
-			<H1>Manage corrective action requests (CAR)</H1>
-			<Text>You may now manage your CARs online.</Text>
-			<H2>Active CARs</H2>
-			<Columns as="ul" gap={1} cols={{ xs: 1, sm: 2, md: 3 }}>
-				{listData.map((item) => (
-					<Card shadow clickable as="li" key={item.id}>
-						<CardInner>
-							<Stack gap={1} width="100%" flexWrap="wrap">
-								<Text fontSize="lg" fontWeight="bold">
-									<CardLink href={`#${item.id}`}>{item.businessName}</CardLink>
-								</Text>
+		<PageContent>
+			<Stack gap={1.5}>
+				<H2>Active CARs</H2>
+				<Text as="p">You may now manage your CARs online.</Text>
+				<Columns as="ul" gap={1} cols={{ xs: 1, sm: 2, lg: 3 }}>
+					{listData.map((item) => (
+						<Card as="li" shadow clickable key={item.id}>
+							<CardInner>
+								<Stack gap={0.5} width="100%" flexWrap="wrap">
+									<H3>
+										<CardLink href={`#${item.id}`}>
+											{item.businessName}
+										</CardLink>
+									</H3>
 
-								<Flex justifyContent="space-between" alignItems="center">
-									<Text lineHeight="nospace" as="p">
+									<Text as="p">
 										<VisuallyHidden>Type: </VisuallyHidden>
-										{item.type}.
+										{item.type}
 									</Text>
 
-									<StatusBadge
-										tone={toneMapper[item.status]}
-										label={
-											<Fragment>
-												<VisuallyHidden>Status: </VisuallyHidden>
-												{item.status}
-											</Fragment>
-										}
-									/>
-								</Flex>
-
-								<Text color="muted" fontSize="xs">
-									<VisuallyHidden>CAR ID: </VisuallyHidden>
-									{item.id}
-								</Text>
-							</Stack>
-						</CardInner>
-					</Card>
-				))}
-			</Columns>
-		</Stack>
+									<Flex
+										gap={0.5}
+										flexWrap="wrap"
+										justifyContent="space-between"
+										alignItems="center"
+									>
+										<Text color="muted" fontSize="xs">
+											<VisuallyHidden>{'CAR ID: '}</VisuallyHidden>
+											{item.id}
+										</Text>
+										<StatusBadge
+											tone={toneMapper[item.status]}
+											label={
+												<Fragment>
+													<VisuallyHidden>{'Status: '}</VisuallyHidden>
+													{item.status}
+												</Fragment>
+											}
+										/>
+									</Flex>
+								</Stack>
+							</CardInner>
+						</Card>
+					))}
+				</Columns>
+			</Stack>
+		</PageContent>
 	);
 };
 CardListStory.storyName = 'List of Cards';


### PR DESCRIPTION
## Describe your changes
Original goal was to publish some examples where StatusBadge is used effectively in context - both in Cards and in a Table.

I got a bit side-tracked by doing some testing and [research on building accessible cards](https://inclusive-components.design/cards/). This thinking was captured in this Story but I can't say it's perfect. Would be great for someone to test further.

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/12689383/180704393-7b60193f-9e7b-44aa-9c1f-5900427d9078.png">

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/12689383/180704440-a884bfff-ca82-488f-af25-e95b748fd449.png">

Happy to discuss this further

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Create stories for Storybook
