### PR TITLE
core: Fix bug where default theme is not applied

### DIFF
--- a/.changeset/spicy-pillows-stare.md
+++ b/.changeset/spicy-pillows-stare.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/core': patch
+---
+
+Fixed bug in the `Core` component where if no theme was supplied, the default theme (GOLD) was not being applied.

--- a/packages/core/src/Core.tsx
+++ b/packages/core/src/Core.tsx
@@ -29,7 +29,7 @@ export function Core({
 				styles={[
 					{
 						':root': {
-							...(theme ? mergeTheme(goldTheme, theme) : goldTheme),
+							...mergeTheme(goldTheme, theme),
 							...generateFontGrid(),
 						},
 						// Reset the global theme in print mode to black & white

--- a/packages/core/src/theme.tsx
+++ b/packages/core/src/theme.tsx
@@ -38,11 +38,12 @@ export const themeVars = {
 export type Theme = Partial<Record<keyof typeof themeVars, string>>;
 
 type ThemeKey = keyof typeof themeVars;
-export function mergeTheme(defaultTheme: Theme, theme: Theme) {
+
+export function mergeTheme(defaultTheme: Theme, theme?: Theme) {
 	return Object.fromEntries(
 		Object.entries(themeVars).map(([key, variableName]) => [
 			variableName,
-			theme[key as ThemeKey] ?? defaultTheme[key as ThemeKey],
+			(theme && theme[key as ThemeKey]) ?? defaultTheme[key as ThemeKey],
 		])
 	);
 }


### PR DESCRIPTION
## Describe your changes

Fixed bug in the `Core` component where if no theme was supplied, the default theme (GOLD) was not being applied.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
