### PR TITLE
prose: add horizontal scrolling to `pre` tags

### DIFF
--- a/.changeset/happy-yaks-crash.md
+++ b/.changeset/happy-yaks-crash.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/prose': patch
+---
+
+Added horizontal scrolling to `pre` tags to prevent page overflow

--- a/packages/prose/src/Prose.tsx
+++ b/packages/prose/src/Prose.tsx
@@ -336,7 +336,7 @@ export const proseClass = css({
 		borderRadius: tokens.borderRadius,
 		backgroundColor: boxPalette.backgroundShade,
 		color: boxPalette.foregroundText,
-		whiteSpace: 'normal',
+		overflowX: 'auto',
 	},
 
 	/**

--- a/packages/prose/src/Prose.tsx
+++ b/packages/prose/src/Prose.tsx
@@ -327,12 +327,16 @@ export const proseClass = css({
 		fontFamily: tokens.font.monospace,
 		display: 'inline-block',
 		borderRadius: tokens.borderRadius,
-		backgroundColor: boxPalette.backgroundShade, // TODO: Check this did't break Docs code rendering
+		backgroundColor: boxPalette.backgroundShade,
 		color: boxPalette.foregroundText,
 	},
 
 	[`pre${notSelector}`]: {
 		fontFamily: tokens.font.monospace,
+		borderRadius: tokens.borderRadius,
+		backgroundColor: boxPalette.backgroundShade,
+		color: boxPalette.foregroundText,
+		whiteSpace: 'normal',
 	},
 
 	/**


### PR DESCRIPTION
## Describe your changes

Added horizontal scrolling to `pre` tags to prevent page overflow

### Screenshots

| Before      | After |
| ----------- | ----------- |
| <img width="321" alt="Screen Shot 2022-07-28 at 10 51 08 am" src="https://user-images.githubusercontent.com/6265154/181400381-cceec95a-dc2f-4318-9de5-a26b3d55cd81.png">      | <img width="319" alt="Screen Shot 2022-07-28 at 10 57 41 am" src="https://user-images.githubusercontent.com/6265154/181400390-b7f0a020-700c-4be2-9573-83961b892a48.png">       |

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
