### PR TITLE
SubNav: Update bottom bar colour

### DIFF
--- a/.changeset/gentle-eggs-cough.md
+++ b/.changeset/gentle-eggs-cough.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/sub-nav': patch
+---
+
+Updated bottom bar colour to `borderMuted`

--- a/packages/sub-nav/src/SubNavContainer.tsx
+++ b/packages/sub-nav/src/SubNavContainer.tsx
@@ -1,16 +1,14 @@
 import { PropsWithChildren } from 'react';
 import { backgroundColorMap, Box } from '@ag.ds-next/box';
 import { boxPalette, packs } from '@ag.ds-next/core';
-import { localPalette, localPaletteVars } from './utils';
+import { localPaletteVars } from './utils';
 
 const backgroundMap = {
 	body: {
 		hover: 'shade',
-		bottomBar: boxPalette.backgroundBodyAlt,
 	},
 	bodyAlt: {
 		hover: 'shadeAlt',
-		bottomBar: boxPalette.backgroundBody,
 	},
 } as const;
 
@@ -28,7 +26,7 @@ export function SubNavContainer({
 	children,
 	background,
 }: SubNavContainerProps) {
-	const { bottomBar, hover } = backgroundMap[background];
+	const { hover } = backgroundMap[background];
 	return (
 		<Box
 			as="nav"
@@ -38,7 +36,6 @@ export function SubNavContainer({
 			css={{
 				position: 'relative',
 				[localPaletteVars.linkHoverBg]: backgroundColorMap[hover],
-				[localPaletteVars.bottomBar]: bottomBar,
 				...packs.print.hidden,
 			}}
 		>
@@ -59,7 +56,7 @@ function BottomBar() {
 				left: 0,
 				right: 0,
 				width: '100%',
-				backgroundColor: localPalette.bottomBar,
+				backgroundColor: boxPalette.borderMuted,
 			}}
 		/>
 	);

--- a/packages/sub-nav/src/SubNavListItem.tsx
+++ b/packages/sub-nav/src/SubNavListItem.tsx
@@ -22,7 +22,7 @@ export function SubNavListItem({ children, active }: SubNavListItemProps) {
 			css={mq({
 				borderBottomColor: mapResponsiveProp([
 					boxPalette.borderMuted,
-					active ? boxPalette.foregroundAction : localPalette.bottomBar,
+					active ? boxPalette.foregroundAction : boxPalette.borderMuted,
 				]),
 				borderBottomWidth: mapResponsiveProp([
 					tokens.borderWidth.sm,


### PR DESCRIPTION
## Describe your changes

Updated bottom bar colour to `borderMuted`

<img width="1606" alt="Screen Shot 2022-08-05 at 10 31 33 am" src="https://user-images.githubusercontent.com/6265154/182977420-3c067657-6cc4-4f5e-a6f7-1c28ec8d479e.png">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
