### PR TITLE
breadcrumbs: Add mobile version

### DIFF
--- a/.changeset/nine-zoos-shop.md
+++ b/.changeset/nine-zoos-shop.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/breadcrumbs': minor
+---
+
+Added mobile variant which shows a link to the immediate parent.

--- a/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.stories.tsx
@@ -9,7 +9,11 @@ import {
 export default {
 	title: 'navigation/Breadcrumbs',
 	component: Breadcrumbs,
-	subcomponents: { BreadcrumbsContainer, BreadcrumbsItem, BreadcrumbsDivider },
+	subcomponents: {
+		BreadcrumbsContainer,
+		BreadcrumbsItem,
+		BreadcrumbsDivider,
+	},
 } as ComponentMeta<typeof Breadcrumbs>;
 
 const exampleLinks = [
@@ -28,9 +32,7 @@ Basic.args = {
 export const Modular = () => (
 	<BreadcrumbsContainer aria-label="breadcrumb">
 		<BreadcrumbsItem href="#one">One</BreadcrumbsItem>
-		<BreadcrumbsDivider />
 		<BreadcrumbsItem href="#two">Two</BreadcrumbsItem>
-		<BreadcrumbsDivider />
 		<BreadcrumbsItem>Three</BreadcrumbsItem>
 	</BreadcrumbsContainer>
 );

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -14,7 +14,7 @@ export const Breadcrumbs = ({
 }: BreadcrumbsProps) => (
 	<BreadcrumbsContainer aria-label={ariaLabel}>
 		{links.map(({ label, ...props }, index) => (
-			<BreadcrumbsItem key={index} isFirstItem={index === 0} {...props}>
+			<BreadcrumbsItem key={index} {...props}>
 				{label}
 				{index === links.length - 1 ? (
 					<VisuallyHidden> (current page)</VisuallyHidden>

--- a/packages/breadcrumbs/src/Breadcrumbs.tsx
+++ b/packages/breadcrumbs/src/Breadcrumbs.tsx
@@ -1,6 +1,5 @@
-import { Fragment, ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { VisuallyHidden } from '@ag.ds-next/a11y';
-import { BreadcrumbsDivider } from './BreadcrumbsDivider';
 import { BreadcrumbsContainer } from './BreadcrumbsContainer';
 import { BreadcrumbsItem, BreadcrumbsItemProps } from './BreadcrumbsItem';
 
@@ -15,15 +14,12 @@ export const Breadcrumbs = ({
 }: BreadcrumbsProps) => (
 	<BreadcrumbsContainer aria-label={ariaLabel}>
 		{links.map(({ label, ...props }, index) => (
-			<Fragment key={index}>
-				{index == 0 ? null : <BreadcrumbsDivider />}
-				<BreadcrumbsItem {...props}>
-					{label}
-					{index === links.length - 1 ? (
-						<VisuallyHidden> (current page)</VisuallyHidden>
-					) : null}
-				</BreadcrumbsItem>
-			</Fragment>
+			<BreadcrumbsItem key={index} isFirstItem={index === 0} {...props}>
+				{label}
+				{index === links.length - 1 ? (
+					<VisuallyHidden> (current page)</VisuallyHidden>
+				) : null}
+			</BreadcrumbsItem>
 		))}
 	</BreadcrumbsContainer>
 );

--- a/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
@@ -23,7 +23,7 @@ export const BreadcrumbsContainer = ({
 						display: 'none',
 					},
 				},
-				[tokens.mediaQuery.max.sm]: {
+				[tokens.mediaQuery.max.xs]: {
 					// In mobile, hide all items except the second last item
 					'li:not(:nth-last-of-type(2))': {
 						display: 'none',

--- a/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsContainer.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import { Flex } from '@ag.ds-next/box';
+import { tokens } from '@ag.ds-next/core';
 
 export type BreadcrumbsContainerProps = PropsWithChildren<{
 	'aria-label': string;
@@ -10,7 +11,30 @@ export const BreadcrumbsContainer = ({
 	'aria-label': ariaLabel,
 }: BreadcrumbsContainerProps) => (
 	<nav aria-label={ariaLabel}>
-		<Flex as="ol" gap={0.5} alignItems="center" flexWrap="wrap">
+		<Flex
+			as="ol"
+			gap={0.5}
+			alignItems="center"
+			flexWrap="wrap"
+			css={{
+				// In desktop, hide the `BreadcrumbsDivider` from the first item
+				[tokens.mediaQuery.min.sm]: {
+					'li:first-of-type > svg': {
+						display: 'none',
+					},
+				},
+				[tokens.mediaQuery.max.sm]: {
+					// In mobile, hide all items except the second last item
+					'li:not(:nth-last-of-type(2))': {
+						display: 'none',
+					},
+					// In mobile, rotate the `BreadcrumbsDivider` icon
+					'li > svg': {
+						transform: 'rotate(180deg)',
+					},
+				},
+			}}
+		>
 			{children}
 		</Flex>
 	</nav>

--- a/packages/breadcrumbs/src/BreadcrumbsItem.tsx
+++ b/packages/breadcrumbs/src/BreadcrumbsItem.tsx
@@ -1,15 +1,17 @@
-import { Box } from '@ag.ds-next/box';
+import { Flex } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { TextLink } from '@ag.ds-next/text-link';
 import { LinkProps } from '@ag.ds-next/core';
+import { BreadcrumbsDivider } from './BreadcrumbsDivider';
 
 export type BreadcrumbsItemProps = LinkProps;
 
 export const BreadcrumbsItem = (props: BreadcrumbsItemProps) => {
 	const { children, href } = props;
 	return (
-		<Box as="li">
+		<Flex as="li" alignItems="center" gap={0.5}>
+			<BreadcrumbsDivider />
 			{href ? <TextLink {...props} /> : <Text>{children}</Text>}
-		</Box>
+		</Flex>
 	);
 };


### PR DESCRIPTION
## Describe your changes

Added mobile variant which shows a link to the immediate parent.

<img width="1410" alt="Screen Shot 2022-08-08 at 4 50 22 pm" src="https://user-images.githubusercontent.com/6265154/183356796-bd6e9f5f-cfff-40e8-a161-54d55ee32f61.png">


## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
