### PR TITLE
docs: Add card list to guides page

### DIFF
--- a/docs/lib/mdx/guides.ts
+++ b/docs/lib/mdx/guides.ts
@@ -44,6 +44,7 @@ export async function getGuideList() {
 			getMarkdownData(guidePath(slug)).then(({ data }) => ({
 				order: data.order as number,
 				title: (data?.title ?? slug) as string,
+				description: (data.description ?? null) as string | null,
 				slug,
 			}))
 		)

--- a/docs/pages/guides/index.tsx
+++ b/docs/pages/guides/index.tsx
@@ -1,6 +1,10 @@
 import { normalize } from 'path';
 import { MDXRemote } from 'next-mdx-remote';
+import { Card, CardInner, CardLink } from '@ag.ds-next/card';
 import { Prose } from '@ag.ds-next/prose';
+import { Stack } from '@ag.ds-next/box';
+import { Heading } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
 import { getMarkdownData, serializeMarkdown } from '../../lib/mdxUtils';
 import { getGuideList } from '../../lib/mdx/guides';
 import { mdxComponents } from '../../components/mdxComponents';
@@ -26,6 +30,20 @@ export default function GuidesHome({ source, guideLinks }: StaticProps) {
 					<Prose>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Prose>
+					<Stack as="ul" gap={1.5}>
+						{guideLinks.map(({ href, label, description }) => (
+							<Card as="li" key={label} clickable shadow>
+								<CardInner>
+									<Stack gap={1}>
+										<Heading type="h3">
+											<CardLink href={href}>{label}</CardLink>
+										</Heading>
+										{description ? <Text as="p">{description}</Text> : null}
+									</Stack>
+								</CardInner>
+							</Card>
+						))}
+					</Stack>
 				</PageLayout>
 			</AppLayout>
 		</>
@@ -38,9 +56,10 @@ export async function getStaticProps() {
 	);
 	const source = await serializeMarkdown(content);
 	const guideList = await getGuideList();
-	const guideLinks = guideList.map(({ slug, title }) => ({
+	const guideLinks = guideList.map(({ slug, title, description }) => ({
 		href: `/guides/${slug}`,
 		label: title,
+		description,
 	}));
 
 	return {

--- a/guides/index.mdx
+++ b/guides/index.mdx
@@ -1,5 +1,1 @@
 # Guides
-
-- [Getting Started](./guides/getting-started)
-- [Forms](./guides/forms)
-- [Responsive Props](./guides/responsive-props)


### PR DESCRIPTION
## Describe your changes

Automatically populate the `guides` home page with the the list of guides.

<img width="1658" alt="Screen Shot 2022-08-09 at 3 44 28 pm" src="https://user-images.githubusercontent.com/6265154/183574013-02e15a74-34bb-45b0-b104-15af52fc8b27.png">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
