### PR TITLE
Header: Add 'small' size

### DIFF
--- a/.changeset/fifty-carrots-yawn.md
+++ b/.changeset/fifty-carrots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/header': minor
+---
+
+Add small size variant

--- a/packages/header/src/Header.stories.tsx
+++ b/packages/header/src/Header.stories.tsx
@@ -84,6 +84,12 @@ LightAltVariant.args = {
 	variant: 'lightAlt',
 };
 
+export const Small = Template.bind({});
+Small.args = {
+	...defaultArgs,
+	size: 'small',
+};
+
 export const LongSubline = Template.bind({});
 LongSubline.args = {
 	...defaultArgs,

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -10,6 +10,7 @@ export type HeaderProps = {
 	logo?: JSX.Element;
 	rightContent?: ReactNode;
 	subline?: string;
+	size?: 'small' | 'medium';
 	variant?: 'light' | 'lightAlt' | 'dark' | 'darkAlt';
 	href?: string;
 };
@@ -20,16 +21,18 @@ export function Header({
 	heading,
 	rightContent,
 	subline,
+	size = 'medium',
 	variant = 'darkAlt',
 	href = '/',
 }: HeaderProps) {
 	const hasRightContent = !!rightContent;
 	return (
-		<HeaderContainer variant={variant}>
+		<HeaderContainer variant={variant} size={size}>
 			<Column columnSpan={{ xs: 12, md: hasRightContent ? 8 : 12 }}>
 				<HeaderBrand
 					badgeLabel={badgeLabel}
 					logo={logo}
+					size={size}
 					href={href}
 					heading={heading}
 					subline={subline}

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react';
 import { Box, Flex, Stack } from '@ag.ds-next/box';
+import { tokens } from '@ag.ds-next/core';
 import { Text } from '@ag.ds-next/text';
 import { useLinkComponent, boxPalette, packs } from '@ag.ds-next/core';
 
@@ -61,6 +62,7 @@ export function HeaderBrand({
 						lineHeight="default"
 						fontSize={headingSizeMap[size]}
 						fontWeight="bold"
+						maxWidth={tokens.maxWidth.bodyText}
 					>
 						{heading}
 					</Text>
@@ -101,16 +103,16 @@ const HeaderBadge = ({ children }: HeaderBadgeProps) => {
 };
 
 const logoWidthMap = {
-	small: { xs: '11rem', sm: '11rem' },
+	small: { xs: '12rem', sm: '14rem' },
 	medium: { xs: '12rem', sm: '16rem' },
 };
 
 const headingSizeMap = {
-	small: 'sm',
+	small: { xs: 'md', sm: 'lg' },
 	medium: { xs: 'md', sm: 'xl' },
 };
 
 const subHeadingSizeMap = {
-	small: 'xs',
+	small: 'sm',
 	medium: { xs: 'sm', sm: 'md' },
 };

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -105,14 +105,14 @@ const HeaderBadge = ({ children }: HeaderBadgeProps) => {
 const logoWidthMap = {
 	small: { xs: '12rem', sm: '14rem' },
 	medium: { xs: '12rem', sm: '16rem' },
-};
+} as const;
 
 const headingSizeMap = {
 	small: { xs: 'md', sm: 'lg' },
 	medium: { xs: 'md', sm: 'xl' },
-};
+} as const;
 
 const subHeadingSizeMap = {
 	small: 'sm',
 	medium: { xs: 'sm', sm: 'md' },
-};
+} as const;

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -9,12 +9,14 @@ type HeaderBrandProps = {
 	heading: string;
 	subline?: string;
 	logo?: JSX.Element;
+	size: keyof typeof logoWidthMap;
 };
 
 export function HeaderBrand({
 	badgeLabel,
 	href = '/',
 	logo,
+	size,
 	heading,
 	subline,
 }: HeaderBrandProps) {
@@ -37,7 +39,7 @@ export function HeaderBrand({
 			{logo ? (
 				<Flex
 					alignItems="flex-start"
-					maxWidth={{ xs: '12rem', sm: '16rem' }}
+					maxWidth={logoWidthMap[size]}
 					css={{
 						' img, svg': { width: '100%' },
 						...packs.print.hidden,
@@ -57,7 +59,7 @@ export function HeaderBrand({
 				<Flex alignItems="flex-start" gap={0.5}>
 					<Text
 						lineHeight="default"
-						fontSize={{ xs: 'md', sm: 'xl' }}
+						fontSize={headingSizeMap[size]}
 						fontWeight="bold"
 					>
 						{heading}
@@ -65,7 +67,7 @@ export function HeaderBrand({
 					{badgeLabel && <HeaderBadge>{badgeLabel}</HeaderBadge>}
 				</Flex>
 				{subline && (
-					<Text color="muted" fontSize={{ xs: 'sm', sm: 'md' }}>
+					<Text color="muted" fontSize={subHeadingSizeMap[size]}>
 						{subline}
 					</Text>
 				)}
@@ -96,4 +98,19 @@ const HeaderBadge = ({ children }: HeaderBadgeProps) => {
 			{children}
 		</Box>
 	);
+};
+
+const logoWidthMap = {
+	small: { xs: '11rem', sm: '11rem' },
+	medium: { xs: '12rem', sm: '16rem' },
+};
+
+const headingSizeMap = {
+	small: 'sm',
+	medium: { xs: 'md', sm: 'xl' },
+};
+
+const subHeadingSizeMap = {
+	small: 'xs',
+	medium: { xs: 'sm', sm: 'md' },
 };

--- a/packages/header/src/HeaderContainer.tsx
+++ b/packages/header/src/HeaderContainer.tsx
@@ -22,18 +22,28 @@ const variantMap = {
 	},
 } as const;
 
+const paddingMap = {
+	small: { xs: 1, md: 0.75 },
+	medium: { xs: 1, md: 3 },
+} as const;
+
 type HeaderContainerProps = PropsWithChildren<{
 	variant: keyof typeof variantMap;
+	size: 'small' | 'medium';
 }>;
 
-export function HeaderContainer({ variant, children }: HeaderContainerProps) {
+export function HeaderContainer({
+	variant,
+	size,
+	children,
+}: HeaderContainerProps) {
 	return (
 		<Flex
 			as="header"
 			palette={variantMap[variant].palette}
 			background={variantMap[variant].background}
 			color="text"
-			paddingY={{ xs: 1, md: 3 }}
+			paddingY={paddingMap[size]}
 			justifyContent="center"
 		>
 			<Box

--- a/packages/header/src/HeaderContainer.tsx
+++ b/packages/header/src/HeaderContainer.tsx
@@ -23,7 +23,7 @@ const variantMap = {
 } as const;
 
 const paddingMap = {
-	small: { xs: 1, md: 0.75 },
+	small: { xs: 1, md: 1 },
 	medium: { xs: 1, md: 3 },
 } as const;
 


### PR DESCRIPTION
## Describe your changes

Enable a more compact header component, primarily for internal applications.

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/12689383/184279128-b4a7ae57-0910-42d9-bc6e-b93de473e778.png">

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook
