### PR TITLE
Rollback recent change that forces text color to LoadingDots

### DIFF
--- a/packages/loading/src/LoadingBlanketContainer.tsx
+++ b/packages/loading/src/LoadingBlanketContainer.tsx
@@ -12,6 +12,7 @@ export const LoadingBlanketContainer = ({
 }: LoadingBlanketContainerProps) => (
 	<Flex
 		palette="light"
+		color="text"
 		flexDirection="column"
 		justifyContent="center"
 		alignItems="center"

--- a/packages/loading/src/LoadingDots.tsx
+++ b/packages/loading/src/LoadingDots.tsx
@@ -1,11 +1,7 @@
 import { HTMLAttributes } from 'react';
 import { useTrail, animated } from '@react-spring/web';
 import { Box, Flex } from '@ag.ds-next/box';
-import {
-	boxPalette,
-	mapSpacing,
-	usePrefersReducedMotion,
-} from '@ag.ds-next/core';
+import { mapSpacing, usePrefersReducedMotion } from '@ag.ds-next/core';
 
 const loadingDotsSizes = {
 	sm: { gap: 0.5, dotSize: mapSpacing(0.5), dots: 3 },
@@ -68,7 +64,7 @@ export const LoadingDots = ({
 					height={dotSize}
 					width={dotSize}
 					style={style}
-					css={{ borderRadius: '50%', background: boxPalette.foregroundText }}
+					css={{ borderRadius: '50%', background: 'currentColor' }}
 				/>
 			))}
 		</Flex>


### PR DESCRIPTION
## Describe your changes
- Rollback recent change that forces text color in loading dots
- Ensure loading blanket applies text color

<img width="141" alt="image" src="https://user-images.githubusercontent.com/12689383/184280504-bc7d9269-7b17-4b56-9a84-22907361a459.png">

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook