### PR TITLE
Header: Rename `size` prop options

### DIFF
--- a/packages/header/src/Header.stories.tsx
+++ b/packages/header/src/Header.stories.tsx
@@ -50,7 +50,7 @@ BodyAltBackground.args = {
 export const Small = Template.bind({});
 Small.args = {
 	...defaultArgs,
-	size: 'small',
+	size: 'sm',
 };
 
 export const LongSubline = Template.bind({});

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -10,7 +10,7 @@ export type HeaderProps = {
 	logo?: JSX.Element;
 	rightContent?: ReactNode;
 	subline?: string;
-	size?: 'small' | 'medium';
+	size?: 'sm' | 'md';
 	background?: 'body' | 'bodyAlt';
 	href?: string;
 };
@@ -21,7 +21,7 @@ export function Header({
 	heading,
 	rightContent,
 	subline,
-	size = 'medium',
+	size = 'md',
 	background = 'body',
 	href = '/',
 }: HeaderProps) {

--- a/packages/header/src/HeaderBrand.tsx
+++ b/packages/header/src/HeaderBrand.tsx
@@ -103,16 +103,16 @@ const HeaderBadge = ({ children }: HeaderBadgeProps) => {
 };
 
 const logoWidthMap = {
-	small: { xs: '12rem', sm: '14rem' },
-	medium: { xs: '12rem', sm: '16rem' },
+	sm: { xs: '12rem', sm: '14rem' },
+	md: { xs: '12rem', sm: '16rem' },
 } as const;
 
 const headingSizeMap = {
-	small: { xs: 'md', sm: 'lg' },
-	medium: { xs: 'md', sm: 'xl' },
+	sm: { xs: 'md', sm: 'lg' },
+	md: { xs: 'md', sm: 'xl' },
 } as const;
 
 const subHeadingSizeMap = {
-	small: 'sm',
-	medium: { xs: 'sm', sm: 'md' },
+	sm: 'sm',
+	md: { xs: 'sm', sm: 'md' },
 } as const;

--- a/packages/header/src/HeaderContainer.tsx
+++ b/packages/header/src/HeaderContainer.tsx
@@ -4,13 +4,13 @@ import { tokens } from '@ag.ds-next/core';
 import { Columns } from '@ag.ds-next/columns';
 
 const paddingMap = {
-	small: { xs: 1, md: 1 },
-	medium: { xs: 1, md: 3 },
+	sm: { xs: 1, md: 1 },
+	md: { xs: 1, md: 3 },
 } as const;
 
 type HeaderContainerProps = PropsWithChildren<{
 	background: 'body' | 'bodyAlt';
-	size: 'small' | 'medium';
+	size: keyof typeof paddingMap;
 }>;
 
 export function HeaderContainer({


### PR DESCRIPTION
## Describe your changes

Follow up of #638 

Renames the options in the `size` prop from `small | medium` to `sm | md` for consistency.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
