### PR TITLE
control-input: fix indicator shrinking and label alignment

### DIFF
--- a/.changeset/tame-beans-build.md
+++ b/.changeset/tame-beans-build.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/control-input': patch
+---
+
+- Prevented the checkbox and radio indicator for shrinking
+- Updated alignment of labels to ensure multi-line labels are aligned vertically

--- a/packages/control-input/src/Checkbox.tsx
+++ b/packages/control-input/src/Checkbox.tsx
@@ -52,7 +52,9 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 					size={size}
 					valid={valid}
 				/>
-				<ControlLabel disabled={disabled}>{children}</ControlLabel>
+				<ControlLabel disabled={disabled} size={size}>
+					{children}
+				</ControlLabel>
 			</ControlContainer>
 		);
 	}

--- a/packages/control-input/src/CheckboxIndicator.tsx
+++ b/packages/control-input/src/CheckboxIndicator.tsx
@@ -22,6 +22,7 @@ export const CheckboxIndicator = ({
 			alignItems="center"
 			width={width}
 			height={height}
+			flexShrink={0}
 			css={{
 				borderWidth,
 				borderStyle: 'solid',

--- a/packages/control-input/src/ControlContainer.tsx
+++ b/packages/control-input/src/ControlContainer.tsx
@@ -11,7 +11,7 @@ export const ControlContainer = ({
 }: ControlContainerProps) => (
 	<Flex
 		as="label"
-		alignItems="center"
+		alignItems="flex-start"
 		color="text"
 		gap={0.5}
 		inline

--- a/packages/control-input/src/ControlLabel.tsx
+++ b/packages/control-input/src/ControlLabel.tsx
@@ -1,12 +1,33 @@
 import { PropsWithChildren } from 'react';
 import { Text } from '@ag.ds-next/text';
+import { ControlSize } from './utils';
 
 export type ControlLabelProps = PropsWithChildren<{
 	disabled?: boolean;
+	size: ControlSize;
 }>;
 
-export const ControlLabel = ({ children, disabled }: ControlLabelProps) => (
-	<Text flexGrow={1} color={disabled ? 'muted' : 'text'}>
-		{children}
-	</Text>
-);
+const paddingTopMap = {
+	sm: 0,
+	md: '0.2rem',
+} as const;
+
+export const ControlLabel = ({
+	children,
+	disabled,
+	size,
+}: ControlLabelProps) => {
+	const paddingTop = paddingTopMap[size];
+	return (
+		<Text
+			flexGrow={1}
+			color={disabled ? 'muted' : 'text'}
+			css={{
+				// Ensures the label is vertically aligned with the indicator across multiple lines.
+				paddingTop,
+			}}
+		>
+			{children}
+		</Text>
+	);
+};

--- a/packages/control-input/src/Radio.tsx
+++ b/packages/control-input/src/Radio.tsx
@@ -46,7 +46,9 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 				size={size}
 				valid={valid}
 			/>
-			<ControlLabel disabled={disabled}>{children}</ControlLabel>
+			<ControlLabel disabled={disabled} size={size}>
+				{children}
+			</ControlLabel>
 		</ControlContainer>
 	);
 });

--- a/packages/control-input/src/RadioIndicator.tsx
+++ b/packages/control-input/src/RadioIndicator.tsx
@@ -22,6 +22,7 @@ export const RadioIndicator = ({
 			alignItems="center"
 			width={width}
 			height={height}
+			flexShrink={0}
 			css={{
 				borderWidth,
 				borderRadius: '100%',


### PR DESCRIPTION
## Describe your changes

- Prevented the checkbox and radio indicator for shrinking
- Updated alignment of labels to ensure multi-line labels are aligned vertically

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)


