### PR TITLE
Align buttons and inputs to 8px baseline grid

### DIFF
--- a/.changeset/pretty-shoes-move.md
+++ b/.changeset/pretty-shoes-move.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text-input': patch
+---
+
+Fixed typo in styles

--- a/.changeset/rich-experts-refuse.md
+++ b/.changeset/rich-experts-refuse.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/button': patch
+---
+
+Adjusted `text` variant styles

--- a/.changeset/shy-camels-allow.md
+++ b/.changeset/shy-camels-allow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/core': minor
+---
+
+Adjusted height and line-height of controls

--- a/.changeset/shy-camels-allow.md
+++ b/.changeset/shy-camels-allow.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/core': minor
+'@ag.ds-next/core': patch
 ---
 
-Adjusted height and line-height of controls
+Adjusted height and line-height of buttons and text inputs to align better to an 8px baseline grid.

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -1,10 +1,4 @@
-import {
-	packs,
-	boxPalette,
-	tokens,
-	mapSpacing,
-	fontGrid,
-} from '@ag.ds-next/core';
+import { packs, boxPalette, tokens, mapSpacing } from '@ag.ds-next/core';
 
 const variants = {
 	primary: {
@@ -47,8 +41,6 @@ const variants = {
 		},
 	},
 	text: {
-		// Size does not change between sizes in this variant
-		...fontGrid('sm', 'default'),
 		height: 'auto',
 		paddingLeft: 0,
 		paddingRight: 0,

--- a/packages/button/src/styles.tsx
+++ b/packages/button/src/styles.tsx
@@ -1,4 +1,10 @@
-import { packs, boxPalette, tokens, mapSpacing } from '@ag.ds-next/core';
+import {
+	packs,
+	boxPalette,
+	tokens,
+	mapSpacing,
+	fontGrid,
+} from '@ag.ds-next/core';
 
 const variants = {
 	primary: {
@@ -41,17 +47,18 @@ const variants = {
 		},
 	},
 	text: {
+		// Size does not change between sizes in this variant
+		...fontGrid('sm', 'default'),
 		height: 'auto',
 		paddingLeft: 0,
 		paddingRight: 0,
+		borderWidth: 0,
 		background: 'transparent',
-		borderColor: 'transparent',
 		color: boxPalette.foregroundAction,
 		...packs.underline,
 
 		'&:not(:disabled):hover': {
 			background: 'transparent',
-			borderColor: 'transparent',
 			color: boxPalette.foregroundText,
 			textDecoration: 'none',
 		},
@@ -97,9 +104,6 @@ export function buttonStyles({
 	size: ButtonSize;
 }) {
 	return {
-		...sizes[size],
-		...variants[variant],
-
 		appearance: 'none',
 		boxSizing: 'border-box',
 		position: 'relative',
@@ -124,5 +128,8 @@ export function buttonStyles({
 		},
 
 		'&:focus': packs.outline,
+
+		...sizes[size],
+		...variants[variant],
 	} as const;
 }

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -19,12 +19,12 @@ const control = {
 
 const input = {
 	sm: {
-		...fontGrid('xs', 'default'),
+		...fontGrid('sm', 'default'),
 		height: '2rem', // 32 px
 	},
 	md: {
 		...fontGrid('sm', 'default'),
-		height: '2.875rem', // 46 px
+		height: '3em', // 48 px
 	},
 };
 

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -19,11 +19,11 @@ const control = {
 
 const input = {
 	sm: {
-		...fontGrid('xs', 'nospace'),
-		height: '2.125rem', // 34 px
+		...fontGrid('xs', 'default'),
+		height: '2rem', // 32 px
 	},
 	md: {
-		...fontGrid('sm', 'nospace'),
+		...fontGrid('sm', 'default'),
 		height: '2.875rem', // 46 px
 	},
 };

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -120,10 +120,9 @@ export const textInputStyles = ({
 			: undefined),
 
 		...(multiline && {
-			lineHeight: tokens.lineHeight.default,
 			paddingTop: mapSpacing(0.5),
 			paddingBottom: mapSpacing(0.5),
-			height: 'auto,',
+			height: 'auto',
 			minHeight: '6rem',
 		}),
 


### PR DESCRIPTION
## Describe your changes

- Adjusted height and line-height of buttons and text inputs to align better to an 8px baseline grid.
- Adjusted `sm` button font size
- Adjusted text button styles

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
