### PR TITLE
hero-banner: a11y fix

### DIFF
--- a/.changeset/pretty-bottles-call.md
+++ b/.changeset/pretty-bottles-call.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/hero-banner': patch
+---
+
+Improved a11y in examples by setting example image to be decorative.

--- a/docs/pages/templates/[slug]/index.tsx
+++ b/docs/pages/templates/[slug]/index.tsx
@@ -39,8 +39,8 @@ export default function TemplateOverviewPage({
 				<Prose id="page-content">
 					<Box border borderColor="muted" css={{ img: { display: 'block' } }}>
 						<img
-							role="presentation"
 							src={`/agds-next/img/templates/${template.slug}.png`}
+							role="presentation"
 							alt=""
 						/>
 					</Box>

--- a/docs/pages/templates/index.tsx
+++ b/docs/pages/templates/index.tsx
@@ -65,8 +65,8 @@ const TemplateCard = ({
 				</CardInner>
 				<img
 					src={`/agds-next/img/templates/${slug}.png`}
-					alt=""
 					role="presentation"
+					alt=""
 					height="auto"
 					width="100%"
 					css={mq({

--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -551,10 +551,11 @@ items={[
 		name: 'Basic',
 		code: `<HeroBanner
     image={
-        <img
-            alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
-            src="/agds-next/img/placeholder/hero-banner.jpeg"
-        />
+      <img
+        src="/agds-next/img/placeholder/hero-banner.jpeg"
+        role="presentation" 
+        alt=""
+      />
     }
 >
     <HeroBannerTitleContainer>
@@ -573,8 +574,9 @@ items={[
 		code: `<HeroCategoryBanner
     image={
       <img
-        alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
         src="/agds-next/img/placeholder/hero-banner.jpeg"
+        role="presentation" 
+        alt=""
       />
     }
   >

--- a/example-site/pages/category/index.tsx
+++ b/example-site/pages/category/index.tsx
@@ -19,8 +19,9 @@ export default function CategoryPage() {
 				<HeroCategoryBanner
 					image={
 						<img
-							alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
 							src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+							role="presentation"
+							alt=""
 						/>
 					}
 				>

--- a/example-site/pages/index.tsx
+++ b/example-site/pages/index.tsx
@@ -23,8 +23,9 @@ export default function HomePage() {
 				<HeroBanner
 					image={
 						<img
-							alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
 							src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+							role="presentation"
+							alt=""
 						/>
 					}
 				>
@@ -80,7 +81,8 @@ export default function HomePage() {
 						</Stack>
 						<img
 							src="/agds-next/example-site/placeholder/hero-banner.jpeg"
-							alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
+							role="presentation"
+							alt=""
 							css={{ display: 'block', maxWidth: '100%' }}
 						/>
 					</Columns>
@@ -94,9 +96,9 @@ export default function HomePage() {
 								<Card as="li" key={idx} clickable shadow>
 									<img
 										src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+										role="presentation"
 										alt=""
 										css={{ width: '100%' }}
-										role="presentation"
 									/>
 									<CardInner>
 										<Stack gap={1}>

--- a/packages/hero-banner/docs/overview.mdx
+++ b/packages/hero-banner/docs/overview.mdx
@@ -13,8 +13,9 @@ Use the `HeroBanner` components on home or landing pages.
 <HeroBanner
 	image={
 		<img
-			alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
 			src="/agds-next/img/placeholder/hero-banner.jpeg"
+			role="presentation"
+			alt=""
 		/>
 	}
 >
@@ -35,7 +36,7 @@ Use the `HeroBanner` components on home or landing pages.
 
 ### Image selection
 
-Images in this component are automatically resized to fit their container using the [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property. Because of this it is important to use image at an appropriate image ratio. You can reference the image size and ratio of our [example image](/agds-next/img/placeholder/hero-banner.jpeg). Images should be also accompanied by descriptive alternative text using the [alt tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-alt).
+Images in this component are automatically resized to fit their container using the [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property. Because of this it is important to use image at an appropriate image ratio. You can reference the image size and ratio of our [example image](/agds-next/img/placeholder/hero-banner.jpeg).
 
 ## Hero Category Banner
 
@@ -45,8 +46,9 @@ Use the `HeroCategoryBanner` components for top level category pages.
 <HeroCategoryBanner
 	image={
 		<img
-			alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
 			src="/agds-next/img/placeholder/hero-banner.jpeg"
+			role="presentation"
+			alt=""
 		/>
 	}
 >

--- a/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
@@ -48,7 +48,8 @@ const commonArgs = {
 	image: (
 		<img
 			src="https://steelthreads.github.io/agds-next/img/placeholder/hero-banner.jpeg"
-			alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
+			role="presentation"
+			alt=""
 		/>
 	),
 	children: (

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
@@ -40,7 +40,8 @@ const commonArgs = {
 	image: (
 		<img
 			src="https://steelthreads.github.io/agds-next/img/placeholder/hero-banner.jpeg"
-			alt="Harvester in a golden field of wheat emptying grain into a chaser bin moving alongside it."
+			role="presentation"
+			alt=""
 		/>
 	),
 };


### PR DESCRIPTION
## Describe your changes

Improved a11y in examples by setting example image to be decorative. This can be done by setting `alt=""` and `role="presentation`. https://www.w3.org/WAI/tutorials/images/decorative/

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [ ] Create stories for Storybook