### PR TITLE
a11y: update external link callout screen reader text

### DIFF
--- a/.changeset/early-carpets-clap.md
+++ b/.changeset/early-carpets-clap.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/a11y': patch
+---
+
+Improved a11y of `ExternalLinkCallout` by updating screen reader text.

--- a/packages/a11y/docs/overview.mdx
+++ b/packages/a11y/docs/overview.mdx
@@ -38,6 +38,6 @@ Use the `ExternalLinkCallout` component to announce to a screenreader user that 
 </TextLink>
 ```
 
-> link, "Visit the Design System (Opens in a new Tab)"
+> link, "Visit the Design System, opens in a new tab"
 
 For links in body text, we recommend reaching for the `TextLinkExternal` component in the [Text package](text#TextLinkExternal) instead.

--- a/packages/a11y/src/ExternalLinkCallout.tsx
+++ b/packages/a11y/src/ExternalLinkCallout.tsx
@@ -1,5 +1,5 @@
 import { VisuallyHidden } from './VisuallyHidden';
 
 export const ExternalLinkCallout = () => {
-	return <VisuallyHidden> (opens in a new tab)</VisuallyHidden>;
+	return <VisuallyHidden>, opens in a new tab</VisuallyHidden>;
 };


### PR DESCRIPTION
## Describe your changes

Some screen readers will announce the parenthesis as “left parenthesis” “right parenthesis” adding unneeded verbosity to the link text which may confuse some users.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
