### PR TITLE
side-nav: improve a11y

### DIFF
--- a/.changeset/ninety-mayflies-brake.md
+++ b/.changeset/ninety-mayflies-brake.md
@@ -2,5 +2,5 @@
 '@ag.ds-next/side-nav': patch
 ---
 
-- Removed `aria-haspopup="menu"` to convert the ARIA Menu Button to a simple disclosure widget.
-- Removed `role="menu"` from the `<ul>` as this was only partially implemented.
+- Removed `aria-haspopup="menu"` to convert the ARIA Menu Button to a simple disclosure widget
+- Removed `role="menu"` from the `<ul>` as this was only partially implemented

--- a/.changeset/ninety-mayflies-brake.md
+++ b/.changeset/ninety-mayflies-brake.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/side-nav': patch
+---
+
+- Removed `aria-haspopup="menu"` to convert the ARIA Menu Button to a simple disclosure widget.
+- Removed `role="menu"` from the `<ul>` as this was only partially implemented.

--- a/packages/side-nav/src/SideNavCollapseButton.tsx
+++ b/packages/side-nav/src/SideNavCollapseButton.tsx
@@ -35,7 +35,6 @@ export const SideNavCollapseButton = ({
 			as={BaseButton}
 			aria-controls={ariaControls}
 			aria-expanded={isOpen}
-			aria-haspopup="menu"
 			onClick={onClick}
 			id={id}
 			color="action"

--- a/packages/side-nav/src/SideNavGroup.tsx
+++ b/packages/side-nav/src/SideNavGroup.tsx
@@ -9,12 +9,7 @@ export const SideNavGroup = ({ children }: SideNavGroupProps) => {
 	const value = depth + 1;
 	return (
 		<LinkListContext.Provider value={value}>
-			<Box
-				as="ul"
-				role="menu"
-				borderTop
-				borderColor={value > 1 ? 'muted' : 'border'}
-			>
+			<Box as="ul" borderTop borderColor={value > 1 ? 'muted' : 'border'}>
 				{children}
 			</Box>
 		</LinkListContext.Provider>


### PR DESCRIPTION
## Describe your changes

- Removed `aria-haspopup="menu"`  to convert the ARIA Menu Button to a simple [disclosure widget](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/).
- Removed `role="menu"` from the `<ul>` as this was only partially implemented.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook