### PR TITLE
main-nav: update open and close button aria label

### DIFF
--- a/.changeset/many-rice-sin.md
+++ b/.changeset/many-rice-sin.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/main-nav': patch
+---
+
+Improved a11y by updating aria labels for the open and close buttons

--- a/packages/main-nav/src/MenuButtons.tsx
+++ b/packages/main-nav/src/MenuButtons.tsx
@@ -44,7 +44,7 @@ export function OpenButton({ onClick }: MainNavButtonProps) {
 			onClick={onClick}
 			aria-controls="main-nav-dialog"
 			aria-expanded="false"
-			aria-label="Menu"
+			aria-label="Open main menu"
 		>
 			<svg
 				width="24"
@@ -70,7 +70,7 @@ export function CloseButton({ onClick }: MainNavButtonProps) {
 			onClick={onClick}
 			aria-controls="main-nav-dialog"
 			aria-expanded="true"
-			aria-label="Close"
+			aria-label="Close main menu"
 		>
 			<svg
 				width="24"

--- a/packages/main-nav/src/MenuButtons.tsx
+++ b/packages/main-nav/src/MenuButtons.tsx
@@ -44,7 +44,7 @@ export function OpenButton({ onClick }: MainNavButtonProps) {
 			onClick={onClick}
 			aria-controls="main-nav-dialog"
 			aria-expanded="false"
-			aria-label="Open main navigation"
+			aria-label="Menu"
 		>
 			<svg
 				width="24"
@@ -70,7 +70,7 @@ export function CloseButton({ onClick }: MainNavButtonProps) {
 			onClick={onClick}
 			aria-controls="main-nav-dialog"
 			aria-expanded="true"
-			aria-label="Close main navigation"
+			aria-label="Close"
 		>
 			<svg
 				width="24"


### PR DESCRIPTION
## Describe your changes

On the main navigation the visible label for the hamburger menu is different from its label in code. 

Speech recognition software users may not be able to reference the element directly because its visible label doesn’t match its code label.

![Screen Shot 2022-09-01 at 10 47 39 am](https://user-images.githubusercontent.com/6265154/187809432-d0b6c6ab-11ab-498b-bf87-ec8f50fc85db.png)

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook