### PR TITLE
Improve windows high contrast mode a11y

### DIFF
--- a/.changeset/neat-bobcats-think.md
+++ b/.changeset/neat-bobcats-think.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/box': patch
+---
+
+Added new prop `highContrastOutline`

--- a/.changeset/short-deers-smile.md
+++ b/.changeset/short-deers-smile.md
@@ -1,0 +1,10 @@
+---
+'@ag.ds-next/badge': patch
+'@ag.ds-next/callout': patch
+'@ag.ds-next/date-picker': patch
+'@ag.ds-next/loading': patch
+'@ag.ds-next/page-alert': patch
+'@ag.ds-next/skeleton': patch
+---
+
+Improved a11y in windows high contrast mode

--- a/packages/badge/src/IndicatorDot.tsx
+++ b/packages/badge/src/IndicatorDot.tsx
@@ -16,6 +16,7 @@ export const IndicatorDot = ({
 	return (
 		<Box
 			aria-label={ariaLabel}
+			highContrastOutline
 			css={{ width: 8, height: 8, borderRadius: 4, backgroundColor }}
 		/>
 	);

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -337,7 +337,10 @@ export const focusStyles = {
 	},
 };
 
-type HighContrastProps = Partial<{ highContrastOutline: boolean }>;
+type HighContrastProps = Partial<{
+	/** If true, a solid outline will be visible in windows high contrast mode. */
+	highContrastOutline: boolean;
+}>;
 export const highContrastOutline = {
 	outline: `1px solid transparent`,
 };

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -337,10 +337,16 @@ export const focusStyles = {
 	},
 };
 
+type HighContrastProps = Partial<{ highContrastOutline: boolean }>;
+export const highContrastOutline = {
+	outline: `1px solid transparent`,
+};
+
 export type BoxProps = PaletteProps &
 	ColorProps &
 	BorderProps &
 	FocusProps &
+	HighContrastProps &
 	TypographyProps &
 	LayoutProps &
 	LinkProps &

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -341,8 +341,8 @@ type HighContrastProps = Partial<{
 	/** If true, a solid outline will be visible in windows high contrast mode. */
 	highContrastOutline: boolean;
 }>;
-export const highContrastOutline = {
-	outline: `1px solid transparent`,
+export const highContrastOutlineStyles = {
+	outline: '1px solid transparent',
 };
 
 export type BoxProps = PaletteProps &
@@ -401,9 +401,10 @@ export function boxStyles({
 	fontWeight,
 	fontFamily,
 	fontSize,
+	lineHeight,
 	focus,
 	link,
-	lineHeight,
+	highContrastOutline,
 	...restProps
 }: BoxProps) {
 	return [
@@ -476,6 +477,7 @@ export function boxStyles({
 
 				...(link ? linkStyles : undefined),
 				...(focus ? focusStyles : undefined),
+				...(highContrastOutline ? highContrastOutlineStyles : undefined),
 			}),
 		]),
 		restProps,

--- a/packages/call-to-action/src/CallToAction.tsx
+++ b/packages/call-to-action/src/CallToAction.tsx
@@ -47,7 +47,6 @@ export const CallToAction = ({
 	return (
 		<Flex
 			inline
-			highContrastOutline
 			onMouseEnter={() => setMouseOver(true)}
 			onMouseLeave={() => setMouseOver(false)}
 			css={{ alignSelf: 'flex-start' }}

--- a/packages/call-to-action/src/CallToAction.tsx
+++ b/packages/call-to-action/src/CallToAction.tsx
@@ -47,6 +47,7 @@ export const CallToAction = ({
 	return (
 		<Flex
 			inline
+			highContrastOutline
 			onMouseEnter={() => setMouseOver(true)}
 			onMouseLeave={() => setMouseOver(false)}
 			css={{ alignSelf: 'flex-start' }}

--- a/packages/callout/src/Callout.tsx
+++ b/packages/callout/src/Callout.tsx
@@ -24,6 +24,7 @@ export const Callout = ({
 		padding={1.5}
 		borderLeft
 		borderLeftWidth="xl"
+		highContrastOutline
 	>
 		{title ? <CalloutTitle>{title}</CalloutTitle> : null}
 		{children}

--- a/packages/date-picker/src/reactDayPickerStyles.ts
+++ b/packages/date-picker/src/reactDayPickerStyles.ts
@@ -6,7 +6,7 @@ import {
 	tokens,
 } from '@ag.ds-next/core';
 import { visuallyHiddenStyles } from '@ag.ds-next/a11y';
-import { highContrastOutline } from '@ag.ds-next/box';
+import { highContrastOutlineStyles } from '@ag.ds-next/box';
 
 const cellSize = '2.875rem';
 
@@ -119,7 +119,7 @@ export const reactDayPickerStyles = (range: boolean) =>
 		},
 		".rdp-day_selected:not([aria-disabled='true']), .rdp-day_selected:focus:not([aria-disabled='true']), .rdp-day_selected:active:not([aria-disabled='true']), .rdp-day_selected:hover:not([aria-disabled='true']), .rdp-day_selected:hover:not([aria-disabled='true'])":
 			{
-				...highContrastOutline,
+				...highContrastOutlineStyles,
 				backgroundColor: boxPalette.foregroundAction,
 				color: boxPalette.backgroundBody,
 			},

--- a/packages/date-picker/src/reactDayPickerStyles.ts
+++ b/packages/date-picker/src/reactDayPickerStyles.ts
@@ -6,6 +6,7 @@ import {
 	tokens,
 } from '@ag.ds-next/core';
 import { visuallyHiddenStyles } from '@ag.ds-next/a11y';
+import { highContrastOutline } from '@ag.ds-next/box';
 
 const cellSize = '2.875rem';
 
@@ -118,6 +119,7 @@ export const reactDayPickerStyles = (range: boolean) =>
 		},
 		".rdp-day_selected:not([aria-disabled='true']), .rdp-day_selected:focus:not([aria-disabled='true']), .rdp-day_selected:active:not([aria-disabled='true']), .rdp-day_selected:hover:not([aria-disabled='true']), .rdp-day_selected:hover:not([aria-disabled='true'])":
 			{
+				...highContrastOutline,
 				backgroundColor: boxPalette.foregroundAction,
 				color: boxPalette.backgroundBody,
 			},

--- a/packages/loading/src/LoadingDots.tsx
+++ b/packages/loading/src/LoadingDots.tsx
@@ -63,6 +63,7 @@ export const LoadingDots = ({
 					key={idx}
 					height={dotSize}
 					width={dotSize}
+					highContrastOutline
 					style={style}
 					css={{ borderRadius: '50%', background: 'currentColor' }}
 				/>

--- a/packages/page-alert/src/PageAlert.tsx
+++ b/packages/page-alert/src/PageAlert.tsx
@@ -32,6 +32,7 @@ export const PageAlert = forwardRef<HTMLDivElement, PageAlertProps>(
 				tabIndex={tabIndex}
 				rounded
 				focus
+				highContrastOutline
 				css={{ backgroundColor: bg }}
 			>
 				<Flex

--- a/packages/skeleton/src/SkeletonBox.tsx
+++ b/packages/skeleton/src/SkeletonBox.tsx
@@ -48,6 +48,7 @@ export const SkeletonBox = ({
 			lineHeight={lineHeight}
 			height={height}
 			width={width}
+			highContrastOutline
 			rounded
 			style={style}
 			css={{


### PR DESCRIPTION
## Describe your changes

- Added new `highContrastOutline` prop to our box component. This applies a transparent outline which will be visible in windows high contrast mode.
- Applied new prop to a few components which need to be improved in high contrast mode

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file