### PR TITLE
control-group: Improve a11y

### DIFF
--- a/.changeset/giant-beds-push.md
+++ b/.changeset/giant-beds-push.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/control-input': patch
+---
+
+Improve accessibilty by connecting the `hint` and `message` via `aria-describedby`.

--- a/packages/control-input/docs/overview.mdx
+++ b/packages/control-input/docs/overview.mdx
@@ -58,13 +58,13 @@ Add a border around the control inputs to indicate valid or invalid selections.
 ```jsx live
 <ControlGroup label="Invalid example" message="Select an option" invalid>
 	<Radio checked={false} invalid>
-		Radio label A
+		Phone
 	</Radio>
 	<Radio checked={true} invalid>
-		Radio label B
+		Tablet
 	</Radio>
 	<Radio checked={false} invalid>
-		Radio label C
+		Laptop
 	</Radio>
 </ControlGroup>
 ```
@@ -72,13 +72,13 @@ Add a border around the control inputs to indicate valid or invalid selections.
 ```jsx live
 <ControlGroup label="Valid example" valid>
 	<Radio checked={false} valid>
-		Radio label A
+		Phone
 	</Radio>
 	<Radio checked={true} valid>
-		Radio label B
+		Tablet
 	</Radio>
 	<Radio checked={false} valid>
-		Radio label C
+		Laptop
 	</Radio>
 </ControlGroup>
 ```

--- a/packages/control-input/docs/overview.mdx
+++ b/packages/control-input/docs/overview.mdx
@@ -10,7 +10,7 @@ storybookPath: /story/forms-checkbox--basic
 Check boxes allow users to select one or more items.
 
 ```jsx live
-<ControlGroup>
+<ControlGroup label="Example">
 	<Checkbox checked={false}>Phone</Checkbox>
 	<Checkbox checked={true}>Tablet</Checkbox>
 </ControlGroup>
@@ -21,7 +21,7 @@ Check boxes allow users to select one or more items.
 Radio inputs allow users to select one item at a time.
 
 ```jsx live
-<ControlGroup>
+<ControlGroup label="Example">
 	<Radio checked={false}>Phone</Radio>
 	<Radio checked={true}>Tablet</Radio>
 </ControlGroup>
@@ -32,7 +32,7 @@ Radio inputs allow users to select one item at a time.
 Inline checkbox options can sometimes be difficult to scan. Users may find it challenging to determine with which label the checkbox option corresponds: the one before the checkbox or the one after. Vertical positioning of checkbox, with one choice per line, eliminates this potential cause for confusion.
 
 ```jsx live
-<ControlGroup block>
+<ControlGroup label="Block example" block>
 	<Checkbox checked={false}>Phone</Checkbox>
 	<Checkbox checked={true}>Tablet</Checkbox>
 	<Checkbox checked={true}>Laptop</Checkbox>
@@ -44,7 +44,7 @@ Inline checkbox options can sometimes be difficult to scan. Users may find it ch
 Vertically stacked radio buttons.
 
 ```jsx live
-<ControlGroup block>
+<ControlGroup label="Block example" block>
 	<Radio checked={false}>Phone</Radio>
 	<Radio checked={false}>Tablet</Radio>
 	<Radio checked={true}>Laptop</Radio>
@@ -56,12 +56,29 @@ Vertically stacked radio buttons.
 Add a border around the control inputs to indicate valid or invalid selections.
 
 ```jsx live
-<ControlGroup>
-	<Radio checked={false} valid>
-		Phone
+<ControlGroup label="Invalid example" message="Select an option" invalid>
+	<Radio checked={false} invalid>
+		Radio label A
 	</Radio>
 	<Radio checked={true} invalid>
-		Tablet
+		Radio label B
+	</Radio>
+	<Radio checked={false} invalid>
+		Radio label C
+	</Radio>
+</ControlGroup>
+```
+
+```jsx live
+<ControlGroup label="Valid example" valid>
+	<Radio checked={false} valid>
+		Radio label A
+	</Radio>
+	<Radio checked={true} valid>
+		Radio label B
+	</Radio>
+	<Radio checked={false} valid>
+		Radio label C
 	</Radio>
 </ControlGroup>
 ```
@@ -71,7 +88,7 @@ Add a border around the control inputs to indicate valid or invalid selections.
 Disabled control inputs can be used to indicate inputs that are no longer valid or expired.
 
 ```jsx live
-<ControlGroup>
+<ControlGroup label="Disabled example">
 	<Radio checked={false} disabled>
 		Phone
 	</Radio>
@@ -86,7 +103,7 @@ Disabled control inputs can be used to indicate inputs that are no longer valid 
 Smaller versions of control inputs.
 
 ```jsx live
-<ControlGroup>
+<ControlGroup label="Small example">
 	<Radio checked={false} size="sm">
 		Phone
 	</Radio>

--- a/packages/control-input/package.json
+++ b/packages/control-input/package.json
@@ -5,7 +5,8 @@
 	"module": "dist/ag.ds-next-control-input.esm.js",
 	"license": "MIT",
 	"dependencies": {
-		"@babel/runtime": "^7.4.5"
+		"@babel/runtime": "^7.4.5",
+		"@reach/auto-id": "^0.16.0"
 	},
 	"peerDependencies": {
 		"@ag.ds-next/a11y": "1.2.1",

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from 'react';
+import { useId } from '@reach/auto-id';
 import { Flex, Stack } from '@ag.ds-next/box';
 import { mapSpacing } from '@ag.ds-next/core';
 import {
@@ -34,28 +35,54 @@ export const ControlGroup = ({
 	label,
 	message,
 	required = false,
-}: ControlGroupProps) => (
-	<FieldContainer invalid={invalid} id={id}>
-		<fieldset css={{ padding: 0, margin: 0, border: 'none' }}>
-			{label ? (
-				<FieldLabel as="legend" required={required}>
-					{label}
-				</FieldLabel>
-			) : null}
-			<Stack gap={0.5} css={{ marginTop: label ? mapSpacing(0.5) : undefined }}>
-				{hint ? <FieldHint>{hint}</FieldHint> : null}
-				{message && invalid ? (
-					<FieldMessage invalid={invalid}>{message}</FieldMessage>
+}: ControlGroupProps) => {
+	const { groupId, hintId, messageId } = useControlGroupIds(id);
+	const describedByIds = [
+		hint ? hintId : null,
+		message ? messageId : null,
+	].filter(Boolean);
+	const describedBy = describedByIds.length
+		? describedByIds.join(' ')
+		: undefined;
+	return (
+		<FieldContainer invalid={invalid} id={groupId}>
+			<fieldset
+				aria-describedby={describedBy}
+				css={{ padding: 0, margin: 0, border: 'none' }}
+			>
+				{label ? (
+					<FieldLabel as="legend" required={required}>
+						{label}
+					</FieldLabel>
 				) : null}
-				<Flex
-					gap={1}
-					flexDirection={block ? 'column' : 'row'}
-					width="100%"
-					paddingTop={0.5}
+				<Stack
+					gap={0.5}
+					css={{ marginTop: label ? mapSpacing(0.5) : undefined }}
 				>
-					{children}
-				</Flex>
-			</Stack>
-		</fieldset>
-	</FieldContainer>
-);
+					{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
+					{message && invalid ? (
+						<FieldMessage invalid={invalid} id={messageId}>
+							{message}
+						</FieldMessage>
+					) : null}
+					<Flex
+						gap={1}
+						flexDirection={block ? 'column' : 'row'}
+						width="100%"
+						paddingTop={0.5}
+					>
+						{children}
+					</Flex>
+				</Stack>
+			</fieldset>
+		</FieldContainer>
+	);
+};
+
+export const useControlGroupIds = (idProp?: string) => {
+	const autoId = useId(idProp);
+	const groupId = idProp ? idProp : `control-group-${autoId}`;
+	const hintId = `control-group-${autoId}-hint`;
+	const messageId = `control-group-${autoId}-message`;
+	return { groupId, hintId, messageId };
+};


### PR DESCRIPTION
## Describe your changes

Improve accessibilty of our control group component by connecting the "hint" and "message" field to the `fieldset` element.

An example of this pattern can be found on the gov uk website: https://design-system.service.gov.uk/components/error-message/

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file