### PR TITLE
MainNav: Address invalid HTML (DAGR-95)

### DIFF
--- a/.changeset/serious-vans-decide.md
+++ b/.changeset/serious-vans-decide.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/main-nav': patch
+---
+
+Accessibility improvements
+- List contains invalid elements (DAGR-95)

--- a/.changeset/serious-vans-decide.md
+++ b/.changeset/serious-vans-decide.md
@@ -2,5 +2,5 @@
 '@ag.ds-next/main-nav': patch
 ---
 
-Accessibility improvements
-- List contains invalid elements (DAGR-95)
+- Accessibility improvements: List contains invalid elements (DAGR-95)
+- Removed `aria-label` prop as this is now baked into the component

--- a/packages/main-nav/src/MainNav.tsx
+++ b/packages/main-nav/src/MainNav.tsx
@@ -6,7 +6,6 @@ import { findBestMatch, MainNavBackground } from './utils';
 export type MainNavProps = PropsWithChildren<{
 	activePath?: string;
 	background?: MainNavBackground;
-	'aria-label'?: string;
 	id?: string;
 	items?: NavListItem[];
 	secondaryItems?: NavListItem[];
@@ -18,7 +17,6 @@ export function MainNav({
 	items,
 	secondaryItems,
 	id,
-	'aria-label': ariaLabel = 'main',
 }: MainNavProps) {
 	const bestMatch = findBestMatch(
 		[...(items || []), ...(secondaryItems || [])],
@@ -28,17 +26,22 @@ export function MainNav({
 		<NavContainer
 			background={background}
 			id={id}
-			aria-label={ariaLabel}
 			hasItems={items && items.length > 0}
 			rightContent={
 				<NavList
+					aria-label="secondary"
 					items={secondaryItems}
 					activePath={bestMatch}
 					type="secondary"
 				/>
 			}
 		>
-			<NavList items={items} activePath={bestMatch} type="primary" />
+			<NavList
+				aria-label="main"
+				items={items}
+				activePath={bestMatch}
+				type="primary"
+			/>
 		</NavContainer>
 	);
 }

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -74,12 +74,7 @@ export function NavContainer({
 		>
 			{menuVisiblyOpen ? <LockScroll /> : null}
 			<BottomBar />
-			<Flex
-				as="nav"
-				justifyContent="center"
-				css={{ position: 'relative' }}
-				aria-label={ariaLabel}
-			>
+			<Flex justifyContent="center" css={{ position: 'relative' }}>
 				<Flex
 					justifyContent="space-between"
 					alignItems="center"
@@ -90,9 +85,13 @@ export function NavContainer({
 					{hasItems ? <OpenButton onClick={open} /> : null}
 					<FocusLock returnFocus disabled={!menuVisiblyOpen}>
 						<div
-							role={menuVisiblyOpen ? 'dialog' : 'none'}
-							aria-label="Main navigation"
-							aria-modal={menuVisiblyOpen ? 'true' : 'false'}
+							{...(menuVisiblyOpen
+								? {
+										role: 'dialog',
+										'aria-label': 'Main navigation',
+										'aria-modal': 'true',
+								  }
+								: null)}
 							id="main-nav-dialog"
 							onKeyDown={handleEscape}
 							css={{
@@ -114,6 +113,8 @@ export function NavContainer({
 						>
 							<CloseButton onClick={close} />
 							<Flex
+								as="nav"
+								aria-label={ariaLabel}
 								justifyContent="space-between"
 								width="100%"
 								flexDirection={{ xs: 'column', lg: 'row' }}

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -26,7 +26,6 @@ import {
 import { CloseButton, OpenButton } from './MenuButtons';
 
 export type NavContainerProps = PropsWithChildren<{
-	'aria-label': string;
 	background?: MainNavBackground;
 	hasItems?: boolean;
 	id?: string;
@@ -36,7 +35,6 @@ export type NavContainerProps = PropsWithChildren<{
 export function NavContainer({
 	id,
 	rightContent,
-	'aria-label': ariaLabel,
 	children,
 	background = 'body',
 	hasItems,
@@ -112,15 +110,7 @@ export function NavContainer({
 							}}
 						>
 							<CloseButton onClick={close} />
-							<Flex
-								as="nav"
-								aria-label={ariaLabel}
-								justifyContent="space-between"
-								width="100%"
-								flexDirection={{ xs: 'column', lg: 'row' }}
-							>
-								{children}
-							</Flex>
+							{children}
 						</div>
 					</FocusLock>
 					{rightContent}

--- a/packages/main-nav/src/NavList.tsx
+++ b/packages/main-nav/src/NavList.tsx
@@ -21,15 +21,21 @@ export type NavListItem = (NavListLink | NavListButton) & {
 };
 
 export type NavListProps = {
+	'aria-label': string;
 	activePath: string;
 	items?: NavListItem[];
 	type: 'primary' | 'secondary';
 };
 
-export function NavList({ activePath, items, type }: NavListProps) {
+export function NavList({
+	'aria-label': ariaLabel,
+	activePath,
+	items,
+	type,
+}: NavListProps) {
 	const Link = useLinkComponent();
 	return (
-		<NavListContainer type={type}>
+		<NavListContainer aria-label={ariaLabel} type={type}>
 			{items?.map(({ label, endElement, ...item }, index) => {
 				if ('href' in item) {
 					const active = item.href === activePath;
@@ -66,34 +72,49 @@ export function NavList({ activePath, items, type }: NavListProps) {
 }
 
 type NavListContainerProps = PropsWithChildren<{
+	'aria-label': string;
 	type: NavListType;
 }>;
 
-function NavListContainer({ children, type }: NavListContainerProps) {
+function NavListContainer({
+	'aria-label': ariaLabel,
+	children,
+	type,
+}: NavListContainerProps) {
 	if (type === 'primary') {
 		return (
 			<Flex
-				as="ul"
+				as="nav"
+				justifyContent="space-between"
+				width="100%"
 				flexDirection={{ xs: 'column', lg: 'row' }}
-				flexWrap="wrap"
-				alignItems="stretch"
-				css={{
-					[tokens.mediaQuery.max.md]: {
-						'& > li': {
-							borderTopWidth: tokens.borderWidth.sm,
-							borderTopStyle: 'solid',
-							borderTopColor: boxPalette.border,
-						},
-					},
-				}}
+				aria-label={ariaLabel}
 			>
-				{children}
+				<Flex
+					as="ul"
+					flexDirection={{ xs: 'column', lg: 'row' }}
+					flexWrap="wrap"
+					alignItems="stretch"
+					css={{
+						[tokens.mediaQuery.max.md]: {
+							'& > li': {
+								borderTopWidth: tokens.borderWidth.sm,
+								borderTopStyle: 'solid',
+								borderTopColor: boxPalette.border,
+							},
+						},
+					}}
+				>
+					{children}
+				</Flex>
 			</Flex>
 		);
 	}
 	return (
-		<Flex as="ul" height="100%">
-			{children}
+		<Flex as="nav" height="100%" aria-label={ariaLabel}>
+			<Flex as="ul" height="100%">
+				{children}
+			</Flex>
 		</Flex>
 	);
 }


### PR DESCRIPTION
## Describe your changes
Address issues with invalid HTML picked up in an accessibility audit. (DAGR-95)

- Ensure the role="dialog" and aria-modal="true" is completely removed on viewport sizes where it does not apply
- Avoid using aria-label on generic elements like a `<div/>`
- Remove role="none" on the `<div/>`
- Moved the parent <nav> element found higher up in the DOM to instead be a child of the dialog/main navigation container rather than a parent.

[Product Backlog Item 296763](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/296763?McasTsid=26110): DAGR 95 - parsing errors may effect assistive tech in MainNav

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook
