### PR TITLE
Loading: Improve accessibility for screenreader users (DAGR-70)

### DIFF
--- a/.changeset/fair-pens-talk.md
+++ b/.changeset/fair-pens-talk.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/loading': minor
+---
+
+New `label` prop. Replaces `aria-label`.

--- a/.changeset/nervous-months-suffer.md
+++ b/.changeset/nervous-months-suffer.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/button': patch
+'@ag.ds-next/file-upload': patch
+---
+
+Update internal usage of LoadingDots

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -55,7 +55,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 				{loading ? (
 					<Fragment>
 						<HiddenText>{children}</HiddenText>
-						<CenteredLoading aria-label={loadingLabel} size={size} />
+						<CenteredLoading label={loadingLabel} size={size} />
 					</Fragment>
 				) : (
 					children
@@ -95,7 +95,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 				{loading ? (
 					<Fragment>
 						<HiddenText>{children}</HiddenText>
-						<CenteredLoading aria-label={loadingLabel} size={size} />
+						<CenteredLoading label={loadingLabel} size={size} />
 					</Fragment>
 				) : (
 					children

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -113,14 +113,14 @@ const HiddenText = ({ children }: { children: ReactNode }) => (
 );
 
 const CenteredLoading = ({
-	'aria-label': ariaLabel,
+	label,
 	size,
 }: {
-	'aria-label': string;
+	label: string;
 	size: ButtonSize;
 }) => (
 	<LoadingDots
-		aria-label={ariaLabel}
+		label={label}
 		aria-live="assertive"
 		size={loadingSize[size]}
 		css={{

--- a/packages/file-upload/src/FileUploadFile.tsx
+++ b/packages/file-upload/src/FileUploadFile.tsx
@@ -45,7 +45,7 @@ export const FileUploadFile = ({
 			<Box flexShrink={0}>
 				{status === 'uploading' ? (
 					<Box paddingY={1} paddingX={1.5}>
-						<LoadingDots aria-label="uploading" />
+						<LoadingDots label="uploading" />
 					</Box>
 				) : (
 					<Button

--- a/packages/loading/docs/overview.mdx
+++ b/packages/loading/docs/overview.mdx
@@ -33,8 +33,8 @@ The `LoadingDots` component can be used on it's own, for example when fetching d
 
 ```jsx live
 <Stack gap={2} alignItems="center">
-	<LoadingDots size="sm" aria-label="Loading" role="status" />
-	<LoadingDots size="md" aria-label="Loading" role="status" />
-	<LoadingDots size="lg" aria-label="Loading" role="status" />
+	<LoadingDots size="sm" label="Loading" role="status" />
+	<LoadingDots size="md" label="Loading" role="status" />
+	<LoadingDots size="lg" label="Loading" role="status" />
 </Stack>
 ```

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -5,19 +5,19 @@
 	"module": "dist/ag.ds-next-loading.esm.js",
 	"license": "MIT",
 	"peerDependencies": {
+		"@ag.ds-next/a11y": "^1.2.1",
 		"@ag.ds-next/box": "7.0.0",
 		"@ag.ds-next/content": "9.0.0",
 		"@ag.ds-next/core": "4.0.0",
-		"@ag.ds-next/loading": "^6.0.0",
 		"@ag.ds-next/text": "10.0.0",
 		"@emotion/react": "^11.7.0",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0"
 	},
 	"devDependencies": {
+		"@ag.ds-next/a11y": "*",
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/content": "*",
 		"@ag.ds-next/core": "*",
-		"@ag.ds-next/loading": "*",
 		"@ag.ds-next/text": "*",
 		"@emotion/react": "^11.7.0",
 		"react": "18.1.0"

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -8,6 +8,7 @@
 		"@ag.ds-next/box": "7.0.0",
 		"@ag.ds-next/content": "9.0.0",
 		"@ag.ds-next/core": "4.0.0",
+		"@ag.ds-next/loading": "^6.0.0",
 		"@ag.ds-next/text": "10.0.0",
 		"@emotion/react": "^11.7.0",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0"
@@ -16,6 +17,7 @@
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/content": "*",
 		"@ag.ds-next/core": "*",
+		"@ag.ds-next/loading": "*",
 		"@ag.ds-next/text": "*",
 		"@emotion/react": "^11.7.0",
 		"react": "18.1.0"

--- a/packages/loading/src/LoadingBlanket.stories.tsx
+++ b/packages/loading/src/LoadingBlanket.stories.tsx
@@ -116,8 +116,8 @@ export const Modular = () => (
 		<FullScreenContent />
 		<LoadingBlanketContainer fullScreen>
 			<LoadingBlanketContent>
-				<LoadingDots aria-label="loading" role="status" size="lg" />
-				<LoadingBlanketLabel>Loading</LoadingBlanketLabel>
+				<LoadingDots size="lg" />
+				<LoadingBlanketLabel role="status">Loading</LoadingBlanketLabel>
 			</LoadingBlanketContent>
 		</LoadingBlanketContainer>
 	</Box>

--- a/packages/loading/src/LoadingBlanket.stories.tsx
+++ b/packages/loading/src/LoadingBlanket.stories.tsx
@@ -117,7 +117,7 @@ export const Modular = () => (
 		<LoadingBlanketContainer fullScreen>
 			<LoadingBlanketContent>
 				<LoadingDots size="lg" />
-				<LoadingBlanketLabel role="status">Loading</LoadingBlanketLabel>
+				<LoadingBlanketLabel>Loading</LoadingBlanketLabel>
 			</LoadingBlanketContent>
 		</LoadingBlanketContainer>
 	</Box>

--- a/packages/loading/src/LoadingBlanket.tsx
+++ b/packages/loading/src/LoadingBlanket.tsx
@@ -18,7 +18,7 @@ export const LoadingBlanket = ({
 	<LoadingBlanketContainer fullScreen={fullScreen}>
 		<LoadingBlanketContent>
 			<LoadingDots size={fullScreen ? 'lg' : 'md'} />
-			<LoadingBlanketLabel role="status">{label}</LoadingBlanketLabel>
+			<LoadingBlanketLabel>{label}</LoadingBlanketLabel>
 		</LoadingBlanketContent>
 	</LoadingBlanketContainer>
 );

--- a/packages/loading/src/LoadingBlanket.tsx
+++ b/packages/loading/src/LoadingBlanket.tsx
@@ -18,7 +18,7 @@ export const LoadingBlanket = ({
 	<LoadingBlanketContainer fullScreen={fullScreen}>
 		<LoadingBlanketContent>
 			<LoadingDots
-				aria-label="loading"
+				label="loading"
 				role="status"
 				size={fullScreen ? 'lg' : 'md'}
 			/>

--- a/packages/loading/src/LoadingBlanket.tsx
+++ b/packages/loading/src/LoadingBlanket.tsx
@@ -17,12 +17,8 @@ export const LoadingBlanket = ({
 }: LoadingBlanketProps) => (
 	<LoadingBlanketContainer fullScreen={fullScreen}>
 		<LoadingBlanketContent>
-			<LoadingDots
-				label="loading"
-				role="status"
-				size={fullScreen ? 'lg' : 'md'}
-			/>
-			<LoadingBlanketLabel>{label}</LoadingBlanketLabel>
+			<LoadingDots size={fullScreen ? 'lg' : 'md'} />
+			<LoadingBlanketLabel role="status">{label}</LoadingBlanketLabel>
 		</LoadingBlanketContent>
 	</LoadingBlanketContainer>
 );

--- a/packages/loading/src/LoadingBlanketLabel.tsx
+++ b/packages/loading/src/LoadingBlanketLabel.tsx
@@ -3,14 +3,10 @@ import { Text } from '@ag.ds-next/text';
 
 export type LoadingBlanketLabelProps = {
 	children: ReactNode;
-	role?: 'status';
 };
 
-export const LoadingBlanketLabel = ({
-	children,
-	role,
-}: LoadingBlanketLabelProps) => (
-	<Text fontSize="lg" fontWeight="bold" lineHeight="heading" role={role}>
+export const LoadingBlanketLabel = ({ children }: LoadingBlanketLabelProps) => (
+	<Text fontSize="lg" fontWeight="bold" lineHeight="heading" role="status">
 		{children}
 	</Text>
 );

--- a/packages/loading/src/LoadingBlanketLabel.tsx
+++ b/packages/loading/src/LoadingBlanketLabel.tsx
@@ -3,10 +3,14 @@ import { Text } from '@ag.ds-next/text';
 
 export type LoadingBlanketLabelProps = {
 	children: ReactNode;
+	role?: 'status';
 };
 
-export const LoadingBlanketLabel = ({ children }: LoadingBlanketLabelProps) => (
-	<Text fontSize="lg" fontWeight="bold" lineHeight="heading">
+export const LoadingBlanketLabel = ({
+	children,
+	role,
+}: LoadingBlanketLabelProps) => (
+	<Text fontSize="lg" fontWeight="bold" lineHeight="heading" role={role}>
 		{children}
 	</Text>
 );

--- a/packages/loading/src/LoadingDots.stories.tsx
+++ b/packages/loading/src/LoadingDots.stories.tsx
@@ -11,6 +11,6 @@ export const LoadingDots: ComponentStory<typeof LoadingDotsComp> = (args) => (
 );
 LoadingDots.args = {
 	size: 'md',
-	'aria-label': 'Loading',
+	label: 'loading',
 	role: 'status',
 };

--- a/packages/loading/src/LoadingDots.tsx
+++ b/packages/loading/src/LoadingDots.tsx
@@ -2,6 +2,7 @@ import { HTMLAttributes } from 'react';
 import { useTrail, animated } from '@react-spring/web';
 import { Box, Flex } from '@ag.ds-next/box';
 import { mapSpacing, usePrefersReducedMotion } from '@ag.ds-next/core';
+import { VisuallyHidden } from '@ag.ds-next/a11y';
 
 const loadingDotsSizes = {
 	sm: { gap: 0.5, dotSize: mapSpacing(0.5), dots: 3 },
@@ -17,7 +18,7 @@ type DivProps = HTMLAttributes<HTMLDivElement>;
 
 export type LoadingDotsProps = {
 	/** Describes the loading element to assistive technologies. */
-	'aria-label'?: DivProps['aria-label'];
+	label?: string;
 	/** Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region. */
 	'aria-live'?: DivProps['aria-live'];
 	/** ARIA roles provide semantic meaning to content. */
@@ -29,7 +30,7 @@ export type LoadingDotsProps = {
 };
 
 export const LoadingDots = ({
-	'aria-label': ariaLabel,
+	label,
 	'aria-live': ariaLive,
 	role,
 	className,
@@ -54,10 +55,11 @@ export const LoadingDots = ({
 		<Flex
 			gap={gap}
 			className={className}
-			aria-label={ariaLabel}
 			aria-live={ariaLive}
+			aria-atomic="false"
 			role={role}
 		>
+			{label && <VisuallyHidden>{label}</VisuallyHidden>}
 			{trail.map((style, idx) => (
 				<AnimatedBox
 					key={idx}
@@ -66,6 +68,7 @@ export const LoadingDots = ({
 					highContrastOutline
 					style={style}
 					css={{ borderRadius: '50%', background: 'currentColor' }}
+					aria-hidden="true"
 				/>
 			))}
 		</Flex>


### PR DESCRIPTION
## Describe your changes

- Loading Dots: Replace aria-label with visually hidden text (DAGR-70). This prop is optional as there could be better ways to show a composition is loading (like the text inside of a loading blanket)

## Checklist

- [x] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
