### PR TITLE
Hide pictograms from screenreaders

### DIFF
--- a/docs/components/PictogramCard.tsx
+++ b/docs/components/PictogramCard.tsx
@@ -19,7 +19,7 @@ export const PictogramCard = ({
 			padding={1}
 			background="shade"
 		>
-			<img src={getPictogram(pictogram).src} alt={`Pictogram of ${title}`} />
+			<img src={getPictogram(pictogram).src} alt="" aria-hidden="true" />
 		</Flex>
 		<CardInner>
 			<CardLink {...props}>


### PR DESCRIPTION
## Describe your changes

The pictogram alt text seen in our packages list are more irritating than helpful when using a screenreader

before:
```
heading level 2, forms
pictogram of button
button, link
pictogram of control input
control input, link
```

after:
```
heading level 2, forms
button, link
control input, link
date picker, link
```