### PR TITLE
modal: fixed accessibilty bug in VoiceOver iOS

### DIFF
--- a/.changeset/tiny-rockets-tap.md
+++ b/.changeset/tiny-rockets-tap.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/modal': minor
+---
+
+Fixed accessibilty bug in VoiceOver iOS

--- a/.changeset/tiny-rockets-tap.md
+++ b/.changeset/tiny-rockets-tap.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/modal': minor
 ---
 
-Fixed accessibilty bug in VoiceOver iOS
+Fixed accessibilty bug in VoiceOver iOS (DAGR-75)

--- a/packages/modal/src/Modal.tsx
+++ b/packages/modal/src/Modal.tsx
@@ -1,4 +1,11 @@
-import { Fragment, FunctionComponent, KeyboardEvent, useCallback } from 'react';
+import {
+	Fragment,
+	FunctionComponent,
+	KeyboardEvent,
+	useCallback,
+	useEffect,
+	useRef,
+} from 'react';
 import { Global } from '@emotion/react';
 import { createPortal } from 'react-dom';
 import { ModalCover } from './ModalCover';
@@ -11,10 +18,13 @@ export type ModalProps = ModalPanelProps & {
 export const Modal: FunctionComponent<ModalProps> = ({
 	actions,
 	children,
-	isOpen,
+	isOpen = false,
 	onDismiss,
 	title,
 }) => {
+	const coverRef = useRef<HTMLDivElement>(null);
+
+	// Close the modal when the user presses the escape key
 	const handleEscape = useCallback(
 		(e: KeyboardEvent<HTMLDivElement>) => {
 			if (isOpen && e.code === 'Escape') {
@@ -26,12 +36,44 @@ export const Modal: FunctionComponent<ModalProps> = ({
 		[isOpen, onDismiss]
 	);
 
+	// The following `useEffect` will add `aria-hidden="true"` to every direct child of the `body` element when the modal is opened.
+	// This is because `aria-modal` is not yet supported by all browsers (https://a11ysupport.io/tech/aria/aria-modal_attribute).
+	// This fixes a bug in certain devices where focus is not trapped correctly such as VoiceOver on iOS.
+	// This has been inspired by Reach UI (https://github.com/reach/reach-ui/blob/main/packages/dialog/src/index.tsx)
+	useEffect(() => {
+		if (!isOpen || !coverRef.current) return;
+
+		const rootNodes: Element[] = [];
+		const originalAttrs: (string | null)[] = [];
+
+		document.querySelectorAll('body > *').forEach(function (node) {
+			if (node === coverRef.current) return;
+			const attr = node.getAttribute('aria-hidden');
+			const alreadyHidden = attr !== null && attr !== 'false';
+			if (alreadyHidden) return;
+			rootNodes.push(node);
+			originalAttrs.push(attr);
+			node.setAttribute('aria-hidden', 'true');
+		});
+
+		return () => {
+			rootNodes.forEach((node, index) => {
+				const originalValue = originalAttrs[index];
+				if (originalValue === null) {
+					node.removeAttribute('aria-hidden');
+				} else {
+					node.setAttribute('aria-hidden', originalValue);
+				}
+			});
+		};
+	}, [isOpen]);
+
 	if (!isOpen) return null;
 
 	return createPortal(
 		<Fragment>
 			<LockScroll />
-			<ModalCover onKeyDown={handleEscape}>
+			<ModalCover ref={coverRef} onKeyDown={handleEscape}>
 				<ModalPanel onDismiss={onDismiss} title={title} actions={actions}>
 					{children}
 				</ModalPanel>

--- a/packages/modal/src/ModalCover.tsx
+++ b/packages/modal/src/ModalCover.tsx
@@ -1,23 +1,28 @@
-import { KeyboardEventHandler, PropsWithChildren } from 'react';
+import { forwardRef, KeyboardEventHandler, PropsWithChildren } from 'react';
 
 export type ModalCoverProps = PropsWithChildren<{
 	onKeyDown: KeyboardEventHandler<HTMLDivElement>;
 }>;
 
-export const ModalCover = ({ children, onKeyDown }: ModalCoverProps) => (
-	<div
-		css={{
-			position: 'fixed',
-			top: 0,
-			left: 0,
-			bottom: 0,
-			right: 0,
-			backgroundColor: `rgba(0, 0, 0, 0.8)`,
-			zIndex: 100,
-			overflowY: 'auto',
-		}}
-		onKeyDown={onKeyDown}
-	>
-		{children}
-	</div>
+export const ModalCover = forwardRef<HTMLDivElement, ModalCoverProps>(
+	function ModalCover({ children, onKeyDown }, ref) {
+		return (
+			<div
+				ref={ref}
+				css={{
+					position: 'fixed',
+					top: 0,
+					left: 0,
+					bottom: 0,
+					right: 0,
+					backgroundColor: `rgba(0, 0, 0, 0.8)`,
+					zIndex: 100,
+					overflowY: 'auto',
+				}}
+				onKeyDown={onKeyDown}
+			>
+				{children}
+			</div>
+		);
+	}
 );


### PR DESCRIPTION
## Describe your changes

For VoiceOver on iOS when the modal is open, focus is not trapped inside of the modal. A screen-reader user can navigate away from the modal content and continue to navigate the parent page.

In this PR I have added `aria-hidden="true"` to every direct child of the `body` element when the modal is opened.  This is because `aria-modal` is not yet supported by [all browsers](https://a11ysupport.io/tech/aria/aria-modal_attribute).

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn changeset` to create a changeset file