### PR TITLE
Add aria-label to Icons (DAGR-72/DAGR-81/DAGR-88)

### DIFF
--- a/.changeset/eleven-stingrays-refuse.md
+++ b/.changeset/eleven-stingrays-refuse.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/field': patch
+---
+
+Add `aria-label` to error icons (DAGR-72)

--- a/.changeset/sharp-bobcats-deny.md
+++ b/.changeset/sharp-bobcats-deny.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/page-alert': patch
+---
+
+Add `aria-label` to icons (DAGR-88)

--- a/.changeset/tiny-ads-enjoy.md
+++ b/.changeset/tiny-ads-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/icon': patch
+---
+
+Add support for `aria-label` and `aria-hidden` props

--- a/.changeset/tiny-eagles-learn.md
+++ b/.changeset/tiny-eagles-learn.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/file-upload': patch
+---
+
+Add aria-label to icon (DAGR-81)

--- a/.changeset/tiny-eagles-learn.md
+++ b/.changeset/tiny-eagles-learn.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/file-upload': patch
 ---
 
-Add aria-label to icon (DAGR-81)
+Add `aria-label` to icons (DAGR-81)

--- a/packages/field/src/FieldMessage.tsx
+++ b/packages/field/src/FieldMessage.tsx
@@ -16,7 +16,12 @@ export const FieldMessage = ({
 	<Flex gap={0.5} alignItems="center">
 		{invalid ? (
 			<Box flexShrink={0}>
-				<AlertFilledIcon color="error" size="md" />
+				<AlertFilledIcon
+					color="error"
+					size="md"
+					aria-label="Error"
+					aria-hidden={false}
+				/>
 			</Box>
 		) : null}
 		<Text

--- a/packages/field/src/FieldMessage.tsx
+++ b/packages/field/src/FieldMessage.tsx
@@ -20,7 +20,8 @@ export const FieldMessage = ({
 					color="error"
 					size="md"
 					aria-label="Error"
-					aria-hidden={false}
+					aria-hidden="false"
+					css={{ display: 'block' }}
 				/>
 			</Box>
 		) : null}

--- a/packages/file-upload/src/FileRejection.tsx
+++ b/packages/file-upload/src/FileRejection.tsx
@@ -35,8 +35,14 @@ export const FileRejection = ({
 			}}
 		>
 			<Flex gap={0.5}>
-				<Box flexShrink={1}>
-					<AlertFilledIcon color="error" size="md" />
+				<Box flexShrink={0}>
+					<AlertFilledIcon
+						color="error"
+						size="md"
+						aria-hidden="false"
+						aria-label="Error"
+						css={{ display: 'block' }}
+					/>
 				</Box>
 				<Stack gap={0}>
 					<Text fontWeight="bold" color="error">

--- a/packages/file-upload/src/FileUploadFile.tsx
+++ b/packages/file-upload/src/FileUploadFile.tsx
@@ -35,12 +35,13 @@ export const FileUploadFile = ({
 		>
 			<Flex alignItems="center" gap={0.5}>
 				{status == 'success' && (
-					<Box flexShrink={1}>
+					<Box flexShrink={0}>
 						<SuccessFilledIcon
 							color="success"
 							size="md"
 							aria-hidden="false"
-							aria-label="Uploaded file"
+							aria-label="Success"
+							css={{ display: 'block' }}
 						/>
 					</Box>
 				)}

--- a/packages/file-upload/src/FileUploadFile.tsx
+++ b/packages/file-upload/src/FileUploadFile.tsx
@@ -27,6 +27,7 @@ export const FileUploadFile = ({
 			rounded
 			alignItems="center"
 			as="li"
+			aria-label={`${status === 'success' ? 'Uploaded file' : 'File'}. ${name}`}
 			paddingY={0.5}
 			paddingLeft={1}
 			justifyContent="space-between"
@@ -35,7 +36,12 @@ export const FileUploadFile = ({
 			<Flex alignItems="center" gap={0.5}>
 				{status == 'success' && (
 					<Box flexShrink={1}>
-						<SuccessFilledIcon color="success" size="md" />
+						<SuccessFilledIcon
+							color="success"
+							size="md"
+							aria-hidden="false"
+							aria-label="Uploaded file"
+						/>
 					</Box>
 				)}
 				<Text css={{ wordBreak: 'break-all' }}>

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -20,6 +20,8 @@ type IconSize = keyof typeof iconSizes;
 type NativeSvgProps = SVGAttributes<SVGSVGElement>;
 
 export type IconProps = {
+	'aria-hidden'?: NativeSvgProps['aria-hidden'];
+	'aria-label'?: NativeSvgProps['aria-label'];
 	className?: string;
 	color?: IconColor;
 	size?: IconSize;
@@ -29,6 +31,8 @@ export type IconProps = {
 
 export const createIcon = (children: ReactNode, name: string) => {
 	const Icon = ({
+		'aria-hidden': ariaHidden = 'true',
+		'aria-label': ariaLabel,
 		className,
 		size = 'md',
 		color,
@@ -38,7 +42,6 @@ export const createIcon = (children: ReactNode, name: string) => {
 		const resolvedSize = mapSpacing(iconSizes[size]);
 		return (
 			<svg
-				aria-hidden="true"
 				// Note the width and height attribute is a fallback for older browsers. This may not be required and could potentially be removed.
 				width="24"
 				height="24"
@@ -59,6 +62,8 @@ export const createIcon = (children: ReactNode, name: string) => {
 				role="img"
 				style={style}
 				className={className}
+				aria-hidden={ariaHidden}
+				aria-label={ariaLabel}
 			>
 				{children}
 			</svg>

--- a/packages/page-alert/src/PageAlert.tsx
+++ b/packages/page-alert/src/PageAlert.tsx
@@ -23,7 +23,7 @@ export type PageAlertProps = PropsWithChildren<{
 
 export const PageAlert = forwardRef<HTMLDivElement, PageAlertProps>(
 	function PageAlert({ id, role, children, title, tone, tabIndex }, ref) {
-		const { fg, bg, Icon } = pageAlertToneMap[tone];
+		const { fg, bg, icon } = pageAlertToneMap[tone];
 		return (
 			<Flex
 				ref={ref}
@@ -45,7 +45,7 @@ export const PageAlert = forwardRef<HTMLDivElement, PageAlertProps>(
 						color: boxPalette.backgroundBody,
 					}}
 				>
-					<Icon />
+					{icon}
 				</Flex>
 				<Flex padding={1.5} gap={1} flexDirection="column">
 					{title ? <PageAlertTitle>{title}</PageAlertTitle> : null}
@@ -60,21 +60,21 @@ const pageAlertToneMap = {
 	success: {
 		fg: boxPalette.systemSuccess,
 		bg: boxPalette.systemSuccessMuted,
-		Icon: SuccessFilledIcon,
+		icon: <SuccessFilledIcon aria-hidden="false" aria-label="Success" />,
 	},
 	error: {
 		fg: boxPalette.systemError,
 		bg: boxPalette.systemErrorMuted,
-		Icon: AlertFilledIcon,
+		icon: <AlertFilledIcon aria-hidden="false" aria-label="Error" />,
 	},
 	info: {
 		fg: boxPalette.systemInfo,
 		bg: boxPalette.systemInfoMuted,
-		Icon: InfoFilledIcon,
+		icon: <InfoFilledIcon aria-hidden="false" aria-label="Information" />,
 	},
 	warning: {
 		fg: boxPalette.systemWarning,
 		bg: boxPalette.systemWarningMuted,
-		Icon: WarningFilledIcon,
+		icon: <WarningFilledIcon aria-hidden="false" aria-label="Warning" />,
 	},
 };


### PR DESCRIPTION
## Describe your changes

- Icon: Add support for `aria-label` and `aria-hidden`
- Field: Add aria-label to icon (DAGR-72)
- FileUpload: Add aria-label to icon (DAGR-81)

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
