### PR TITLE
footer: update headings in examples (DAGR93)

### DIFF
--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -3,7 +3,7 @@ const snippets = [
 		group: 'Boilerplate',
 		name: 'One',
 		code: `<Box dark><Header background="bodyAlt" logo={<Logo />} heading="Export Service" />
-    <MainNav items={[{ label: "Hello", href: "#" }]} variant='agriculture' /></Box>
+    <MainNav items={[{ label: "Hello", href: "#" }]} /></Box>
     <PageContent as="main">
       <Prose>
         <h1>Page heading</h1>
@@ -44,7 +44,7 @@ const snippets = [
 	{
 		group: 'Footer',
 		name: 'Basic',
-		code: `<Box dark><Footer>
+		code: `<Box dark><Footer background="bodyAlt">
     <nav aria-label="footer">
       <LinkList
         horizontal
@@ -69,7 +69,7 @@ const snippets = [
 	{
 		group: 'Footer',
 		name: 'Complex',
-		code: `<Box dark><Footer variant="agriculture">
+		code: `<Box dark><Footer background="bodyAlt">
     <nav aria-label="footer">
       <Columns>
         <Column columnSpan={{ xs: 12, sm: 6, lg: 3  }}>

--- a/docs/playroom/snippets.js
+++ b/docs/playroom/snippets.js
@@ -74,7 +74,7 @@ const snippets = [
       <Columns>
         <Column columnSpan={{ xs: 12, sm: 6, lg: 3  }}>
           <Stack gap={0.5}>
-            <H3>Section</H3>
+            <Heading as="h2" type="h3">Section</Heading>
             <LinkList
               links={[
                 { href: "#", label: "Link 1" },
@@ -86,7 +86,7 @@ const snippets = [
         </Column>
         <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
           <Stack gap={0.5}>
-            <H3>Section</H3>
+            <Heading as="h2" type="h3">Section</Heading>
             <LinkList
               links={[
                 { href: "#", label: "Link 1" },
@@ -98,7 +98,7 @@ const snippets = [
         </Column>
         <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
           <Stack gap={0.5}>
-            <H3>Section</H3>
+            <Heading as="h2" type="h3">Section</Heading>
             <LinkList
               links={[
                 { href: "#", label: "Link 1" },
@@ -110,7 +110,7 @@ const snippets = [
         </Column>
         <Column columnSpan={{ xs: 12, sm: 6, lg: 3 }}>
           <Stack gap={0.5}>
-            <H3>Section</H3>
+            <Heading as="h2" type="h3">Section</Heading>
             <LinkList
               links={[
                 { href: "#", label: "Link 1" },

--- a/packages/footer/docs/overview.mdx
+++ b/packages/footer/docs/overview.mdx
@@ -15,7 +15,9 @@ The footer at the bottom of a page. Usually contains copyright information and l
 		<Columns>
 			<Column columnSpan={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
 				<Stack gap={0.5}>
-					<Heading type="h3">Section title</Heading>
+					<Heading as="h2" type="h3">
+						Section title
+					</Heading>
 					<LinkList
 						links={[
 							{ href: '#', label: 'A really long link title' },
@@ -27,7 +29,9 @@ The footer at the bottom of a page. Usually contains copyright information and l
 			</Column>
 			<Column columnSpan={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
 				<Stack gap={0.5}>
-					<H3>Section</H3>
+					<Heading as="h2" type="h3">
+						Section
+					</Heading>
 					<LinkList
 						links={[
 							{ href: '#', label: 'Link 1' },
@@ -39,7 +43,9 @@ The footer at the bottom of a page. Usually contains copyright information and l
 			</Column>
 			<Column columnSpan={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
 				<Stack gap={0.5}>
-					<Heading type="h3">Section</Heading>
+					<Heading as="h2" type="h3">
+						Section
+					</Heading>
 					<LinkList
 						links={[
 							{ href: '#', label: 'Link 1' },
@@ -51,7 +57,9 @@ The footer at the bottom of a page. Usually contains copyright information and l
 			</Column>
 			<Column columnSpan={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
 				<Stack gap={0.5}>
-					<Heading type="h3">Section</Heading>
+					<Heading as="h2" type="h3">
+						Section
+					</Heading>
 					<LinkList
 						links={[
 							{ href: '#', label: 'Link 1' },

--- a/packages/footer/src/Footer.stories.tsx
+++ b/packages/footer/src/Footer.stories.tsx
@@ -4,7 +4,7 @@ import { tokens } from '@ag.ds-next/core';
 import { Logo } from '@ag.ds-next/ag-branding';
 import { Box, Stack } from '@ag.ds-next/box';
 import { Columns, Column } from '@ag.ds-next/columns';
-import { H3 } from '@ag.ds-next/heading';
+import { Heading } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
 import { LinkList } from '@ag.ds-next/link-list';
 import { Footer, FooterDivider } from './';
@@ -63,7 +63,9 @@ const AgComplexFooter: ComponentStory<typeof Footer> = (args) => {
 				<Columns>
 					<Column columnSpan={columnSpanning}>
 						<Stack gap={0.5}>
-							<H3>Section</H3>
+							<Heading as="h2" type="h3">
+								Section
+							</Heading>
 							<LinkList
 								links={[
 									{ href: '#', label: 'Link 1' },
@@ -75,7 +77,9 @@ const AgComplexFooter: ComponentStory<typeof Footer> = (args) => {
 					</Column>
 					<Column columnSpan={columnSpanning}>
 						<Stack gap={0.5}>
-							<H3>Section</H3>
+							<Heading as="h2" type="h3">
+								Section
+							</Heading>
 							<LinkList
 								links={[
 									{ href: '#', label: 'Link 1' },
@@ -87,7 +91,9 @@ const AgComplexFooter: ComponentStory<typeof Footer> = (args) => {
 					</Column>
 					<Column columnSpan={columnSpanning}>
 						<Stack gap={0.5}>
-							<H3>Section</H3>
+							<Heading as="h2" type="h3">
+								Section
+							</Heading>
 							<LinkList
 								links={[
 									{ href: '#', label: 'Link 1' },
@@ -99,7 +105,9 @@ const AgComplexFooter: ComponentStory<typeof Footer> = (args) => {
 					</Column>
 					<Column columnSpan={columnSpanning}>
 						<Stack gap={0.5}>
-							<H3>Section</H3>
+							<Heading as="h2" type="h3">
+								Section
+							</Heading>
 							<LinkList
 								links={[
 									{ href: '#', label: 'Link 1' },


### PR DESCRIPTION
## Describe your changes

While the heading elements are nested inside of a `<footer>` the heading level assignment of `H3` may impact the page's heading hierarchy for screen reader users. If there are `H2` elements higher up in the page, screen reader users may think this content is a child of that content from a document structure perspective.

No changeset required as not making any changes to code.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing