### PR TITLE
card: Improve a11y when using `CardLink` (DAGR91)

### DIFF
--- a/.changeset/quiet-ways-complain.md
+++ b/.changeset/quiet-ways-complain.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/card': patch
+---
+
+Improve a11y when using `CardLink` (DAGR 91)

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -35,31 +35,30 @@ export const Basic: ComponentStory<typeof Card> = (args) => (
 						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
 						voluptat
 					</Text>
-					<CardLink href="#">
-						Linking out
-						<ChevronRightIcon weight="bold" size="sm" />
-					</CardLink>
 				</Stack>
 			</CardInner>
 		</Card>
 	</Box>
 );
-Basic.args = {
-	clickable: true,
-	shadow: true,
-};
+Basic.args = {};
 
 export const Link: ComponentStory<typeof Card> = (args) => (
 	<Box maxWidth={300}>
 		<Card {...args}>
 			<CardInner>
-				<Heading as="h2" type="h3" paddingBottom={1}>
-					Card heading
-				</Heading>
-				<CardLink href="#">
-					Linking out
-					<ChevronRightIcon weight="bold" size="sm" />
-				</CardLink>
+				<Stack gap={1}>
+					<Heading as="h2" type="h3">
+						Card heading
+					</Heading>
+					<Text as="p">
+						Lorem ipsum dolor, sit amet consectetur adipisicing elit. In,
+						voluptat
+					</Text>
+					<CardLink href="#">
+						Linking out
+						<ChevronRightIcon weight="bold" size="sm" />
+					</CardLink>
+				</Stack>
 			</CardInner>
 		</Card>
 	</Box>

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -44,10 +44,14 @@ export const Basic: ComponentStory<typeof Card> = (args) => (
 		</Card>
 	</Box>
 );
+Basic.args = {
+	clickable: true,
+	shadow: true,
+};
 
 export const Link: ComponentStory<typeof Card> = (args) => (
 	<Box maxWidth={300}>
-		<Card shadow clickable {...args}>
+		<Card {...args}>
 			<CardInner>
 				<Heading as="h2" type="h3" paddingBottom={1}>
 					Card heading
@@ -60,6 +64,10 @@ export const Link: ComponentStory<typeof Card> = (args) => (
 		</Card>
 	</Box>
 );
+Link.args = {
+	clickable: true,
+	shadow: true,
+};
 
 export const FeatureHeader: ComponentStory<typeof Card> = (args) => (
 	<Columns>

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -34,7 +34,7 @@ export const Card = ({
 	// This code ensures that when `CardLink` is used, the text within the card is selectable and the entire card is clickable
 	// Please read more about this technique here: https://inclusive-components.design/cards/#theredundantclickevent
 	const onMouseUp = (event: MouseEvent<HTMLDivElement>) => {
-		if (!mousedownTimer.current) return;
+		if (!clickable || !mousedownTimer.current) return;
 
 		const cardLinkEl = event.currentTarget.querySelector(
 			`[${cardLinkDataAttr}]`

--- a/packages/card/src/Card.tsx
+++ b/packages/card/src/Card.tsx
@@ -1,6 +1,7 @@
-import { PropsWithChildren, ElementType } from 'react';
-import { Box } from '@ag.ds-next/box';
+import { PropsWithChildren, ElementType, useRef, MouseEvent } from 'react';
+import { Box, linkStyles } from '@ag.ds-next/box';
 import { packs } from '@ag.ds-next/core';
+import { cardLinkDataAttr } from './CardLink';
 
 export type CardProps = PropsWithChildren<{
 	as?: ElementType;
@@ -24,9 +25,30 @@ export const Card = ({
 	shadow,
 	clickable,
 }: CardProps) => {
+	const mousedownTimer = useRef<number>();
+
+	const onMouseDown = () => {
+		mousedownTimer.current = new Date().getTime();
+	};
+
+	// This code ensures that when `CardLink` is used, the text within the card is selectable and the entire card is clickable
+	// Please read more about this technique here: https://inclusive-components.design/cards/#theredundantclickevent
+	const onMouseUp = (event: MouseEvent<HTMLDivElement>) => {
+		if (!mousedownTimer.current) return;
+
+		const cardLinkEl = event.currentTarget.querySelector(
+			`[${cardLinkDataAttr}]`
+		) as HTMLAnchorElement | null | undefined;
+		if (!cardLinkEl) return;
+
+		if (new Date().getTime() - mousedownTimer.current < 200) cardLinkEl.click();
+	};
+
 	return (
 		<Box
 			as={as} // Note: this should be an li when used in a card list
+			onMouseDown={onMouseDown}
+			onMouseUp={onMouseUp}
 			display="block"
 			border
 			borderColor="muted"
@@ -38,6 +60,8 @@ export const Card = ({
 				overflow: 'hidden',
 
 				...(clickable && {
+					cursor: 'pointer',
+					[`&:hover [${cardLinkDataAttr}]`]: linkStyles['&:hover'],
 					// If any element inside the card receives focus, add a focus ring around the wrapper card div
 					'&:focus-within': packs.outline,
 				}),

--- a/packages/card/src/CardLink.tsx
+++ b/packages/card/src/CardLink.tsx
@@ -3,6 +3,8 @@ import { linkStyles } from '@ag.ds-next/box';
 
 export type CardLinkProps = LinkProps;
 
+export const cardLinkDataAttr = 'data-agds-card-link';
+
 export const CardLink = (props: CardLinkProps) => {
 	const Link = useLinkComponent();
 	return (
@@ -16,16 +18,9 @@ export const CardLink = (props: CardLinkProps) => {
 					'&:focus': {
 						outline: 'none',
 					},
-					'&:after': {
-						content: '""',
-						position: 'absolute',
-						top: 0,
-						right: 0,
-						bottom: 0,
-						left: 0,
-					},
 				},
 			]}
+			{...{ [cardLinkDataAttr]: true }}
 			{...props}
 		/>
 	);


### PR DESCRIPTION
## Describe your changes

his PR ensures that when `CardLink` is used, the text within the card is selectable and the entire card is clickable. Please read more about this technique here: https://inclusive-components.design/cards/#theredundantclickevent

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook