### PR TITLE
Pagination: Read out current page for PaginationButtons (DAGR-102)

### DIFF
--- a/.changeset/tender-cows-think.md
+++ b/.changeset/tender-cows-think.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/pagination': patch
+---
+
+Accessibility improvements
+- Read out 'current page' in `PaginationItemPageButton` (DAGR-102)
+- Read out 'ellipsis' in `PaginationItemSeperator`

--- a/packages/pagination/src/PaginationItemPage.tsx
+++ b/packages/pagination/src/PaginationItemPage.tsx
@@ -57,6 +57,7 @@ export function PaginationItemPageButton({
 			<Flex
 				as={BaseButton}
 				aria-label={`Go to page ${pageNumber}`}
+				aria-current={isActive ? 'page' : undefined}
 				onClick={onClick}
 				justifyContent="center"
 				alignItems="center"

--- a/packages/pagination/src/PaginationItemSeparator.tsx
+++ b/packages/pagination/src/PaginationItemSeparator.tsx
@@ -6,13 +6,12 @@ export function PaginationItemSeparator() {
 	return (
 		<Flex
 			as="li"
-			aria-hidden="true"
 			width={BUTTON_SIZE}
 			height={BUTTON_SIZE}
 			alignItems="center"
 			justifyContent="center"
 		>
-			<Text>...</Text>
+			<Text>&hellip;</Text>
 		</Flex>
 	);
 }


### PR DESCRIPTION
## Describe your changes

Accessibility improvements
- Read out 'current page' in `PaginationItemPageButton` (DAGR-102)
- Read out 'ellipsis' in `PaginationItemSeperator`


## Checklist

- [x] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
