### PR TITLE
ExternalLinkCallout: Update docs to discourage usage (DAGR-87)

### DIFF
--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -2,8 +2,6 @@ import { AnchorHTMLAttributes, HTMLAttributes, Fragment } from 'react';
 import Link from 'next/link';
 import { proseBlockClassname } from '@ag.ds-next/prose';
 import { PageAlert, PageAlertProps } from '@ag.ds-next/page-alert';
-import { Text } from '@ag.ds-next/text';
-import { TextLink } from '@ag.ds-next/text-link';
 import { slugify } from '../lib/slugify';
 import generatedComponentPropsData from '../__generated__/componentProps.json';
 import { Code } from './Code';
@@ -18,8 +16,6 @@ export const mdxComponents: Record<string, any> = {
 	pre: Fragment,
 	code: Code,
 	Fragment,
-	Text,
-	TextLink,
 	a: ({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
 		if (!href) return <a {...props} />;
 		return <Link href={href} {...props} />;

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -1,5 +1,14 @@
-import { AnchorHTMLAttributes, HTMLAttributes, Fragment } from 'react';
+import {
+	AnchorHTMLAttributes,
+	HTMLAttributes,
+	Fragment,
+	ReactNode,
+} from 'react';
 import Link from 'next/link';
+import { proseBlockClassname } from '@ag.ds-next/prose';
+import { PageAlert } from '@ag.ds-next/page-alert';
+import { Text } from '@ag.ds-next/text';
+import { TextLink } from '@ag.ds-next/text-link';
 import { slugify } from '../lib/slugify';
 import generatedComponentPropsData from '../__generated__/componentProps.json';
 import { Code } from './Code';
@@ -14,6 +23,8 @@ export const mdxComponents: Record<string, any> = {
 	pre: Fragment,
 	code: Code,
 	Fragment,
+	Text,
+	TextLink,
 	a: ({ href, ...props }: AnchorHTMLAttributes<HTMLAnchorElement>) => {
 		if (!href) return <a {...props} />;
 		return <Link href={href} {...props} />;
@@ -33,6 +44,16 @@ export const mdxComponents: Record<string, any> = {
 			</h3>
 		);
 	},
+	Info: ({ children }: { children: ReactNode }) => (
+		<div className={proseBlockClassname}>
+			<PageAlert tone="info">{children}</PageAlert>
+		</div>
+	),
+	Warning: ({ children }: { children: ReactNode }) => (
+		<div className={proseBlockClassname}>
+			<PageAlert tone="warning">{children}</PageAlert>
+		</div>
+	),
 	ComponentPropsTable: ({ name }: { name: string }) => {
 		if (!(name in generatedComponentPropsData)) {
 			return (

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -1,12 +1,7 @@
-import {
-	AnchorHTMLAttributes,
-	HTMLAttributes,
-	Fragment,
-	ReactNode,
-} from 'react';
+import { AnchorHTMLAttributes, HTMLAttributes, Fragment } from 'react';
 import Link from 'next/link';
 import { proseBlockClassname } from '@ag.ds-next/prose';
-import { PageAlert } from '@ag.ds-next/page-alert';
+import { PageAlert, PageAlertProps } from '@ag.ds-next/page-alert';
 import { Text } from '@ag.ds-next/text';
 import { TextLink } from '@ag.ds-next/text-link';
 import { slugify } from '../lib/slugify';
@@ -44,16 +39,12 @@ export const mdxComponents: Record<string, any> = {
 			</h3>
 		);
 	},
-	Info: ({ children }: { children: ReactNode }) => (
+	PageAlert: (props: PageAlertProps) => (
 		<div className={proseBlockClassname}>
-			<PageAlert tone="info">{children}</PageAlert>
+			<PageAlert {...props} />
 		</div>
 	),
-	Warning: ({ children }: { children: ReactNode }) => (
-		<div className={proseBlockClassname}>
-			<PageAlert tone="warning">{children}</PageAlert>
-		</div>
-	),
+
 	ComponentPropsTable: ({ name }: { name: string }) => {
 		if (!(name in generatedComponentPropsData)) {
 			return (

--- a/packages/a11y/docs/overview.mdx
+++ b/packages/a11y/docs/overview.mdx
@@ -32,13 +32,13 @@ function Example() {
 `ExternalLinkCallout` announces to a screenreader user that a link will open in a new tab.
 
 <PageAlert tone="warning">
-	<Text>
+	<p>
 		Please use the <strong>TextLinkExternal</strong> component from{' '}
-		<TextLink href="https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal">
+		<a href="https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal">
 			@ag.ds-next/text
-		</TextLink>{' '}
+		</a>{' '}
 		instead.
-	</Text>
+	</p>
 </PageAlert>
 
 As a rule, links that open in a new tab should indicate this visually with an icon. This is why we recommend using the [TextLinkExternal](https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal) component instead.

--- a/packages/a11y/docs/overview.mdx
+++ b/packages/a11y/docs/overview.mdx
@@ -29,15 +29,25 @@ function Example() {
 
 ## ExternalLinkCallout
 
-Use the `ExternalLinkCallout` component to announce to a screenreader user that a link will open in a new tab.
+Another version of [VisuallyHidden](#visuallyhidden), which announces to a screenreader user that a link will open in a new tab.
 
-```jsx live
+<Warning>
+	<Text>
+		Please use <strong>TextLinkExternal</strong> component from{' '}
+		<TextLink href="https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal">
+			@ag.ds-next/text
+		</TextLink>{' '}
+		instead.
+	</Text>
+</Warning>
+
+As a rule, links that open in a new tab should indicate this visually with an icon. This is why we recommend using the [TextLinkExternal](https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal) component instead.
+
+```jsx
+// A screenreader will read this out load as:
+// 'link, "Visit the Design System, opens in a new tab"'
 <TextLink href="#" target="_blank">
 	Visit the Design System
 	<ExternalLinkCallout />
 </TextLink>
 ```
-
-> link, "Visit the Design System, opens in a new tab"
-
-For links in body text, we recommend reaching for the `TextLinkExternal` component in the [Text package](text#TextLinkExternal) instead.

--- a/packages/a11y/docs/overview.mdx
+++ b/packages/a11y/docs/overview.mdx
@@ -29,11 +29,11 @@ function Example() {
 
 ## ExternalLinkCallout
 
-Another version of [VisuallyHidden](#visuallyhidden), which announces to a screenreader user that a link will open in a new tab.
+`ExternalLinkCallout` announces to a screenreader user that a link will open in a new tab.
 
 <Warning>
 	<Text>
-		Please use <strong>TextLinkExternal</strong> component from{' '}
+		Please use the <strong>TextLinkExternal</strong> component from{' '}
 		<TextLink href="https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal">
 			@ag.ds-next/text
 		</TextLink>{' '}

--- a/packages/a11y/docs/overview.mdx
+++ b/packages/a11y/docs/overview.mdx
@@ -31,7 +31,7 @@ function Example() {
 
 `ExternalLinkCallout` announces to a screenreader user that a link will open in a new tab.
 
-<Warning>
+<PageAlert tone="warning">
 	<Text>
 		Please use the <strong>TextLinkExternal</strong> component from{' '}
 		<TextLink href="https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal">
@@ -39,7 +39,7 @@ function Example() {
 		</TextLink>{' '}
 		instead.
 	</Text>
-</Warning>
+</PageAlert>
 
 As a rule, links that open in a new tab should indicate this visually with an icon. This is why we recommend using the [TextLinkExternal](https://steelthreads.github.io/agds-next/packages/navigation/text-link#TextLinkExternal) component instead.
 


### PR DESCRIPTION
## Describe your changes

- Update documentation of ExternalLinkCallout to discourage usage. [Old version here](https://steelthreads.github.io/agds-next/packages/foundations/a11y)
- Add 'PageAlert' component to docs site

<img width="863" alt="image" src="https://user-images.githubusercontent.com/12689383/189038012-432c37f4-e425-4a1a-a04c-ffc5afc2c3a4.png">

## Checklist

- [X] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [X] Write documentation (README.md)
- [ ] Create stories for Storybook
