### PR TITLE
field: improve screen reader experience when using secondary label (DAGR-71)

### DIFF
--- a/.changeset/slow-gorillas-tan.md
+++ b/.changeset/slow-gorillas-tan.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/field': patch
+---
+
+Improve screen reader experience when using `secondaryLabel`

--- a/.changeset/slow-gorillas-tan.md
+++ b/.changeset/slow-gorillas-tan.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/field': patch
 ---
 
-Improve screen reader experience when using `secondaryLabel`
+Improve screen reader experience when using `secondaryLabel` (DAGR-71)

--- a/packages/field/src/FieldLabel.tsx
+++ b/packages/field/src/FieldLabel.tsx
@@ -1,4 +1,5 @@
 import { ElementType, PropsWithChildren, useMemo } from 'react';
+import { Flex } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 
 export type FieldLabelProps = PropsWithChildren<{
@@ -20,9 +21,15 @@ export const FieldLabel = ({
 		if (!required) return `(optional)`;
 	}, [required, secondaryLabelProp]);
 	return (
-		<Text as={as} htmlFor={htmlFor} display="flex" gap={0.25} fontWeight="bold">
-			{children}
-			{secondaryLabel ? <Text color="muted">{secondaryLabel}</Text> : null}
-		</Text>
+		<Flex as={as} htmlFor={htmlFor} gap={0.25}>
+			<Text as="span" fontWeight="bold">
+				{children}
+			</Text>
+			{secondaryLabel ? (
+				<Text as="span" color="muted">
+					{secondaryLabel}
+				</Text>
+			) : null}
+		</Flex>
 	);
 };


### PR DESCRIPTION
## Describe your changes

There is currently an issue when using voice over on macos in safari. When interacting with form fields that have secondary text, such as required, optional, dd/mm/yyyy etc, safari doesn't read out the secondary label. For example:

- Code: `<TextInput label="Name" />`
- Rendered Label: `Name (Optional)`
- Safari VO: `Name, and 1 other item,  edit text`
- Chrome VO: `Name, optional,  edit text`

With the proposed changes, safari will read out the secondary label text as expected.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook