### PR TITLE
core: Add ThemeProvider

### DIFF
--- a/.changeset/green-eggs-guess.md
+++ b/.changeset/green-eggs-guess.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/core': minor
+'@ag.ds-next/core': patch
 ---
 
 Add `ThemeProvider` component to allow multiple themes per page

--- a/.changeset/green-eggs-guess.md
+++ b/.changeset/green-eggs-guess.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/core': minor
+---
+
+Add `ThemeProvider` component to allow multiple themes per page

--- a/packages/core/src/Core.tsx
+++ b/packages/core/src/Core.tsx
@@ -1,13 +1,11 @@
 import { PropsWithChildren } from 'react';
 import { Global } from '@emotion/react';
-import { goldTheme } from './goldTheme';
 import { CoreProvider, CoreProviderProps } from './CoreProvider';
-import { mergeTheme, Theme } from './theme';
+import { ThemeProvider } from './ThemeProvider';
+import { Theme } from './theme';
 import { boxPalette } from './boxPalette';
 import { tokens } from './tokens';
 import { generateFontGrid } from './utils/fontGrid';
-import { printTheme } from './printTheme';
-import { ThemeProvider } from './ThemeProvider';
 
 export type CoreProps = PropsWithChildren<
 	{
@@ -30,11 +28,6 @@ export function Core({
 				styles={[
 					{
 						':root': generateFontGrid(),
-						// Reset the global theme in print mode to black & white
-						// Note: Components can also contain print specific styles
-						'@media print': {
-							':root': mergeTheme(goldTheme, printTheme),
-						},
 					},
 					applyReset && {
 						// FIXME: apply the css reset

--- a/packages/core/src/Core.tsx
+++ b/packages/core/src/Core.tsx
@@ -3,10 +3,11 @@ import { Global } from '@emotion/react';
 import { goldTheme } from './goldTheme';
 import { CoreProvider, CoreProviderProps } from './CoreProvider';
 import { mergeTheme, Theme } from './theme';
-import { boxPalettes, boxPalette } from './boxPalette';
+import { boxPalette } from './boxPalette';
 import { tokens } from './tokens';
 import { generateFontGrid } from './utils/fontGrid';
 import { printTheme } from './printTheme';
+import { ThemeProvider } from './ThemeProvider';
 
 export type CoreProps = PropsWithChildren<
 	{
@@ -28,19 +29,12 @@ export function Core({
 			<Global
 				styles={[
 					{
-						':root': {
-							...mergeTheme(goldTheme, theme),
-							...generateFontGrid(),
-						},
+						':root': generateFontGrid(),
 						// Reset the global theme in print mode to black & white
 						// Note: Components can also contain print specific styles
 						'@media print': {
 							':root': mergeTheme(goldTheme, printTheme),
 						},
-					},
-					{
-						// Apply the light pallet by default
-						'body,html': boxPalettes.light,
 					},
 					applyReset && {
 						// FIXME: apply the css reset
@@ -53,7 +47,7 @@ export function Core({
 					},
 				]}
 			/>
-			{children}
+			<ThemeProvider theme={theme}>{children}</ThemeProvider>
 		</CoreProvider>
 	);
 }

--- a/packages/core/src/Core.tsx
+++ b/packages/core/src/Core.tsx
@@ -26,9 +26,7 @@ export function Core({
 		<CoreProvider linkComponent={linkComponent}>
 			<Global
 				styles={[
-					{
-						':root': generateFontGrid(),
-					},
+					{ ':root': generateFontGrid() },
 					applyReset && {
 						// FIXME: apply the css reset
 						'body, html': {

--- a/packages/core/src/ThemeProvider.tsx
+++ b/packages/core/src/ThemeProvider.tsx
@@ -2,6 +2,7 @@ import { PropsWithChildren } from 'react';
 import { goldTheme } from './goldTheme';
 import { mergeTheme, Theme } from './theme';
 import { boxPalettes } from './boxPalette';
+import { printTheme } from './printTheme';
 
 export type ThemeProviderProps = PropsWithChildren<{
 	theme?: Theme;
@@ -12,6 +13,11 @@ export function ThemeProvider({ children, theme }: ThemeProviderProps) {
 		<div
 			css={[
 				mergeTheme(goldTheme, theme),
+				{
+					// Reset the theme in print mode to black & white
+					// Note: Components can also contain print specific styles
+					'@media print': mergeTheme(goldTheme, printTheme),
+				},
 				// Apply the light pallet by default
 				boxPalettes.light,
 			]}

--- a/packages/core/src/ThemeProvider.tsx
+++ b/packages/core/src/ThemeProvider.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from 'react';
+import { goldTheme } from './goldTheme';
+import { mergeTheme, Theme } from './theme';
+import { boxPalettes } from './boxPalette';
+
+export type ThemeProviderProps = PropsWithChildren<{
+	theme?: Theme;
+}>;
+
+export function ThemeProvider({ children, theme }: ThemeProviderProps) {
+	return (
+		<div
+			css={[
+				mergeTheme(goldTheme, theme),
+				// Apply the light pallet by default
+				boxPalettes.light,
+			]}
+		>
+			{children}
+		</div>
+	);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Core';
 export * from './CoreProvider';
+export * from './ThemeProvider';
 export * from './tokens';
 export * from './packs';
 export * from './utils';


### PR DESCRIPTION
add theme provider

## Describe your changes

Problem with current `Core` component

```tsx
import { theme } from '@ag.ds-next/ag-branding';
import { Core } from '@ag.ds-next/core';

function Example() {
	// Both of these buttons are the same colour, even though we have specified multiple themes per page
	return (
		<Core theme={theme}>
			<Stack gap={1}>
				<Core theme={{ ...theme, lightForegroundAction: 'green' }}>
					<Button variant="primary">Primary</Button>
				</Core>
				<Button variant="primary">Primary</Button>
			</Stack>
		</Core>
	);
}
```


Example usage

```tsx
import { theme } from '@ag.ds-next/ag-branding';
import { ThemeProvider } from '@ag.ds-next/core';

function Example() {
	return (
		<Core theme={theme}>
			<Stack gap={1}>
				<ThemeProvider theme={{ ...theme, lightForegroundAction: 'green' }}>
					{/* This primary button will be green */}
					<Button variant="primary">Primary</Button>
				</ThemeProvider>

				{/* This primary button will be blue (as expected) */}
				<Button variant="primary">Primary</Button>
			</Stack>
		</Core>
	);
}
```

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
