### PR TITLE
Plop script: Add component to Docs site

### DIFF
--- a/scripts/plopfile.mjs
+++ b/scripts/plopfile.mjs
@@ -53,6 +53,13 @@ export default function newPackage(
 					'"dependencies": {\n"@ag.ds-next/{{packageName}}": "^0.0.1",\n',
 			});
 
+			actions.push({
+				type: 'append',
+				path: '../docs/components/designSystemComponents.tsx',
+				template:
+					'export { {{componentName}} } from "@ag.ds-next/{{packageName}}"\n',
+			});
+
 			return actions;
 		},
 	});


### PR DESCRIPTION
Automatically add a component to the `designSystemComponents.tsx` file when running `yarn new:package`.

There is a minor formatting issue with the extra new line above

<img width="377" alt="image" src="https://user-images.githubusercontent.com/12689383/191395660-ba142346-9e6b-4bd1-bd32-b746ac58db4b.png">
