### PR TITLE
example-form: Improve 404 page

### DIFF
--- a/example-form/pages/not-found.tsx
+++ b/example-form/pages/not-found.tsx
@@ -2,6 +2,7 @@ import { H1 } from '@ag.ds-next/heading';
 import { Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { TextLink } from '@ag.ds-next/text-link';
+import { tokens } from '@ag.ds-next/core';
 import { PageContent } from '@ag.ds-next/content';
 import { AppLayout } from '../components/AppLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
@@ -9,16 +10,15 @@ import { DocumentTitle } from '../components/DocumentTitle';
 export default function NotFoundPage() {
 	return (
 		<>
-			<DocumentTitle title="Error 404" />
+			<DocumentTitle title="Page not found" />
 			<AppLayout>
 				<PageContent as="main" id="main-content">
-					<Stack gap={1.5}>
-						<H1>Page not found</H1>
+					<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
+						<H1>Oops! This page does not exist.</H1>
 						<Text as="p" fontSize="md">
-							Check the web address is correct or go back to{' '}
-							<TextLink href="/">yourGov</TextLink>.
+							You have reached a page which is not part of the testing process.
+							Go back to the <TextLink href="/">yourGov home page</TextLink>.
 						</Text>
-						<Text>Error code: 404</Text>
 					</Stack>
 				</PageContent>
 			</AppLayout>


### PR DESCRIPTION
## Describe your changes

Updated the copy on the not found (fake 404) page for the `example-form`

<img width="1411" alt="Screen Shot 2022-09-27 at 2 12 41 pm" src="https://user-images.githubusercontent.com/6265154/192430265-71322b2a-a4dc-47d3-86d0-2906279c4872.png">
