### PR TITLE
main-nav: Improve focus trapping for screen readers (DAGR-109)

### DIFF
--- a/.changeset/polite-books-guess.md
+++ b/.changeset/polite-books-guess.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/box': minor
+'@ag.ds-next/core': minor
+---
+
+Added new hook `useBoxPalette` which returns the current palette for a specifc DOM element

--- a/.changeset/polite-books-guess.md
+++ b/.changeset/polite-books-guess.md
@@ -1,5 +1,4 @@
 ---
-'@ag.ds-next/box': minor
 '@ag.ds-next/core': minor
 ---
 

--- a/.changeset/polite-books-guess.md
+++ b/.changeset/polite-books-guess.md
@@ -3,4 +3,4 @@
 '@ag.ds-next/core': minor
 ---
 
-Added new hook `useBoxPalette` which returns the current palette for a specifc DOM element
+Added new hook `useBoxPalette` which returns the current palette for a specific DOM element

--- a/.changeset/swift-bears-cover.md
+++ b/.changeset/swift-bears-cover.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/main-nav': patch
 ---
 
-Improved accessibilty
+Improved accessibility

--- a/.changeset/swift-bears-cover.md
+++ b/.changeset/swift-bears-cover.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/main-nav': patch
+---
+
+Improved accessibilty

--- a/packages/core/src/boxPalette.ts
+++ b/packages/core/src/boxPalette.ts
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
+import { RefObject, useEffect, useState } from 'react';
 import { themeVars } from './theme';
 
 // Box Palette
 
 const boxPaletteVars = {
+	palette: '--agds-palette',
 	foregroundText: '--agds-foreground-text',
 	foregroundAction: '--agds-foreground-action',
 	foregroundFocus: '--agds-foreground-focus',
@@ -27,6 +29,7 @@ const boxPaletteVars = {
 
 export const boxPalettes = {
 	light: css({
+		[boxPaletteVars.palette]: 'light',
 		[boxPaletteVars.foregroundText]: `var(${themeVars.lightForegroundText})`,
 		[boxPaletteVars.foregroundAction]: `var(${themeVars.lightForegroundAction})`,
 		[boxPaletteVars.foregroundFocus]: `var(${themeVars.lightForegroundFocus})`,
@@ -48,6 +51,7 @@ export const boxPalettes = {
 		[boxPaletteVars.systemInfoMuted]: `var(${themeVars.lightSystemInfoMuted})`,
 	}),
 	dark: css({
+		[boxPaletteVars.palette]: 'dark',
 		[boxPaletteVars.foregroundText]: `var(${themeVars.darkForegroundText})`,
 		[boxPaletteVars.foregroundAction]: `var(${themeVars.darkForegroundAction})`,
 		[boxPaletteVars.foregroundFocus]: `var(${themeVars.darkForegroundFocus})`,
@@ -93,3 +97,27 @@ export const boxPalette = {
 	systemInfo: `var(${boxPaletteVars.systemInfo})`,
 	systemInfoMuted: `var(${boxPaletteVars.systemInfoMuted})`,
 };
+
+/**
+ * Returns the current palette for a specifc DOM element
+ * Note: As this function relies on CSS vars, the value returned will not be available on the server
+ */
+export function useBoxPalette(element: RefObject<HTMLElement>) {
+	const [value, setValue] = useState<BoxPalette>();
+
+	useEffect(() => {
+		if (!element.current) return;
+		setValue(getInheritedProperty(element.current));
+	}, [element]);
+
+	return value;
+}
+
+function getInheritedProperty(el: HTMLElement): BoxPalette | undefined {
+	const value = getComputedStyle(el).getPropertyValue(boxPaletteVars.palette);
+	if (value === 'light') return 'light';
+	if (value === 'dark') return 'dark';
+	// Walk up the DOM tree until we find the closest value
+	if (el.parentElement) return getInheritedProperty(el.parentElement);
+	return undefined;
+}

--- a/packages/main-nav/package.json
+++ b/packages/main-nav/package.json
@@ -14,7 +14,8 @@
 		"@ag.ds-next/core": "4.0.0",
 		"@ag.ds-next/icon": "11.0.0",
 		"@emotion/react": "^11.7.0",
-		"react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+		"react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+		"react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0"
 	},
 	"devDependencies": {
 		"@ag.ds-next/box": "*",
@@ -22,6 +23,7 @@
 		"@ag.ds-next/core": "*",
 		"@ag.ds-next/icon": "*",
 		"@emotion/react": "^11.7.0",
-		"react": "18.1.0"
+		"react": "18.1.0",
+		"react-dom": "18.1.0"
 	}
 }

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -3,7 +3,9 @@ import {
 	ReactNode,
 	MouseEventHandler,
 	useEffect,
+	useRef,
 } from 'react';
+import { createPortal } from 'react-dom';
 import FocusLock from 'react-focus-lock';
 import { Global } from '@emotion/react';
 import { Box, Flex, backgroundColorMap } from '@ag.ds-next/box';
@@ -14,6 +16,8 @@ import {
 	tokens,
 	useWindowSize,
 	packs,
+	useBoxPalette,
+	BoxPalette,
 } from '@ag.ds-next/core';
 import {
 	hoverMap,
@@ -38,29 +42,22 @@ export function NavContainer({
 	background = 'body',
 	hasItems,
 }: NavContainerProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
 	const hover = hoverMap[background];
 
 	const { windowWidth } = useWindowSize();
 	const [menuOpen, open, close] = useTernaryState(false);
+
 	const menuVisiblyOpen =
 		menuOpen && (windowWidth || 0) <= tokens.breakpoint.lg - 1;
 
-	// Close the component when the user presses the escape key
-	useEffect(() => {
-		const handleKeyDown = (e: KeyboardEvent) => {
-			if (menuVisiblyOpen && e.code === 'Escape') {
-				e.preventDefault();
-				e.stopPropagation();
-				close();
-			}
-		};
-		window.addEventListener('keydown', handleKeyDown);
-		return () => window.removeEventListener('keydown', handleKeyDown);
-	}, [menuVisiblyOpen, close]);
+	// As the main nav element sometimes renders in a portal for a11y reasons, we need to know about the current box palette
+	const palette = useBoxPalette(containerRef);
 
 	return (
 		<Box
 			id={id}
+			ref={containerRef}
 			background={background}
 			color="text"
 			css={{
@@ -82,43 +79,121 @@ export function NavContainer({
 					paddingX={{ xs: 0.75, lg: 2 }}
 				>
 					{hasItems ? <OpenButton onClick={open} /> : null}
-					<FocusLock returnFocus disabled={!menuVisiblyOpen}>
-						<div
-							{...(menuVisiblyOpen
-								? {
-										role: 'dialog',
-										'aria-label': 'Main navigation',
-										'aria-modal': 'true',
-								  }
-								: null)}
-							id="main-nav-dialog"
-							css={{
-								[tokens.mediaQuery.max.md]: {
-									zIndex: 200,
-									position: 'fixed',
-									display: menuOpen ? 'block' : 'none',
-									background: boxPalette.backgroundBody,
-									top: 0,
-									left: 0,
-									bottom: 0,
-									width: '100%',
-									maxWidth: tokens.maxWidth.mobileMenu,
-									padding: mapSpacing(1),
-									boxSizing: 'border-box',
-									overflowY: 'auto',
-								},
-							}}
-						>
-							<CloseButton onClick={close} />
-							{children}
-						</div>
-					</FocusLock>
+					<NavContainerDialog
+						palette={palette}
+						menuVisiblyOpen={menuVisiblyOpen}
+						close={close}
+					>
+						{children}
+					</NavContainerDialog>
 					{rightContent}
 				</Flex>
 			</Flex>
 			{menuVisiblyOpen ? <Overlay onClick={close} /> : null}
 		</Box>
 	);
+}
+
+type NavContainerDialogProps = PropsWithChildren<{
+	close: () => void;
+	menuVisiblyOpen: boolean;
+	palette?: BoxPalette;
+}>;
+
+function NavContainerDialog({
+	children,
+	close,
+	menuVisiblyOpen,
+	palette,
+}: NavContainerDialogProps) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+
+	// Close the component when the user presses the escape key
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (e.code === 'Escape') {
+				e.preventDefault();
+				e.stopPropagation();
+				close();
+			}
+		};
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [close]);
+
+	// The following `useEffect` will add `aria-hidden="true"` to every direct child of the `body` element when the modal is opened.
+	// This is because `aria-modal` is not yet supported by all browsers (https://a11ysupport.io/tech/aria/aria-modal_attribute).
+	// This fixes a bug in certain devices where focus is not trapped correctly such as VoiceOver on iOS.
+	// This has been inspired by Reach UI (https://github.com/reach/reach-ui/blob/main/packages/dialog/src/index.tsx)
+	useEffect(() => {
+		if (!menuVisiblyOpen || !dialogRef.current) return;
+
+		const rootNodes: Element[] = [];
+		const originalAttrs: (string | null)[] = [];
+
+		document.querySelectorAll('body > *').forEach(function (node) {
+			if (node === dialogRef.current) return;
+			const attr = node.getAttribute('aria-hidden');
+			const alreadyHidden = attr !== null && attr !== 'false';
+			if (alreadyHidden) return;
+			rootNodes.push(node);
+			originalAttrs.push(attr);
+			node.setAttribute('aria-hidden', 'true');
+		});
+
+		return () => {
+			rootNodes.forEach((node, index) => {
+				const originalValue = originalAttrs[index];
+				if (originalValue === null) {
+					node.removeAttribute('aria-hidden');
+				} else {
+					node.setAttribute('aria-hidden', originalValue);
+				}
+			});
+		};
+	}, [menuVisiblyOpen]);
+
+	const element = (
+		<Box
+			palette={palette}
+			ref={dialogRef}
+			{...(menuVisiblyOpen
+				? {
+						role: 'dialog',
+						'aria-label': 'Main navigation',
+						'aria-modal': 'true',
+				  }
+				: null)}
+			id="main-nav-dialog"
+			css={{
+				[tokens.mediaQuery.max.md]: {
+					zIndex: 200,
+					position: 'fixed',
+					display: menuVisiblyOpen ? 'block' : 'none',
+					background: boxPalette.backgroundBody,
+					top: 0,
+					left: 0,
+					bottom: 0,
+					width: '100%',
+					maxWidth: tokens.maxWidth.mobileMenu,
+					padding: mapSpacing(1),
+					boxSizing: 'border-box',
+					overflowY: 'auto',
+				},
+			}}
+		>
+			<FocusLock returnFocus disabled={!menuVisiblyOpen}>
+				<CloseButton onClick={close} />
+				{children}
+			</FocusLock>
+		</Box>
+	);
+
+	if (menuVisiblyOpen) {
+		return createPortal(element, document.body);
+	}
+
+	return element;
 }
 
 function LockScroll() {

--- a/packages/main-nav/src/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/main-nav/src/__snapshots__/MainNav.test.tsx.snap
@@ -56,16 +56,16 @@ exports[`MainNav renders correctly 1`] = `
           </button>
         </div>
         <div
-          data-focus-guard="true"
-          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-          tabindex="-1"
-        />
-        <div
-          data-focus-lock-disabled="disabled"
+          class="css-4p6mno-boxStyles-element"
+          id="main-nav-dialog"
         >
           <div
-            class="css-1h8fjlz-NavContainer"
-            id="main-nav-dialog"
+            data-focus-guard="true"
+            style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+            tabindex="-1"
+          />
+          <div
+            data-focus-lock-disabled="disabled"
           >
             <div
               class="css-1ff37wg-boxStyles"
@@ -159,12 +159,12 @@ exports[`MainNav renders correctly 1`] = `
               </ul>
             </nav>
           </div>
+          <div
+            data-focus-guard="true"
+            style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+            tabindex="-1"
+          />
         </div>
-        <div
-          data-focus-guard="true"
-          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-          tabindex="-1"
-        />
         <nav
           aria-label="secondary"
           class="css-1ltfh56-boxStyles"


### PR DESCRIPTION
## Describe your changes

- Added new hook `useBoxPalette` which returns the current palette for a specific DOM element
- Improved accessibility of `main-nav` component

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook