### PR TITLE
docs: Retheme code block

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -133,6 +133,7 @@ const LiveCode = withLive(function LiveCode(props: unknown) {
 				id={codeId}
 				display={isCodeVisible ? 'block' : 'none'}
 				css={packs.print.visible}
+				palette="dark"
 			>
 				<LiveEditor
 					theme={prismTheme}

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -193,12 +193,14 @@ const StaticCode = ({
 				},
 			}}
 		>
-			<StaticEditor
-				code={code}
-				theme={prismTheme}
-				language={language}
-				disabled
-			/>
+			<Box dark>
+				<StaticEditor
+					code={code}
+					theme={prismTheme}
+					language={language}
+					disabled
+				/>
+			</Box>
 			<Flex padding={0.5}>
 				<Button
 					size="sm"

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -1,44 +1,83 @@
 import { PrismTheme } from 'prism-react-renderer';
 import { boxPalette, globalPalette, tokens, fontGrid } from '@ag.ds-next/core';
 
+const blue = '#79c0ff';
+const purple = '#d2a8ff';
+
+// Original: https://github.com/dracula/visual-studio-code
+// Converted automatically using ./tools/themeFromVsCode
 export const prismTheme: PrismTheme = {
 	plain: {
 		fontFamily: tokens.font.monospace,
 		...fontGrid('xs', 'default'),
-		color: globalPalette.lightForegroundText,
-		backgroundColor: globalPalette.lightBackgroundShade,
+		color: boxPalette.foregroundMuted,
+		backgroundColor: boxPalette.backgroundShade,
 	},
 	styles: [
 		{
-			types: ['comment', 'prolog', 'cdata'],
+			types: ['prolog', 'constant', 'builtin'],
 			style: {
-				color: globalPalette.lightForegroundMuted,
-				opacity: 0.5,
+				// color: blue,
+			},
+		},
+		// {
+		// 	types: ['inserted', 'function'],
+		// 	style: {
+		// 		color: 'rgb(80, 250, 123)',
+		// 	},
+		// },
+		// {
+		// 	types: ['deleted'],
+		// 	style: {
+		// 		color: 'rgb(255, 85, 85)',
+		// 	},
+		// },
+		// {
+		// 	types: ['changed'],
+		// 	style: {
+		// 		color: 'rgb(255, 184, 108)',
+		// 	},
+		// },
+		{
+			types: ['punctuation', 'symbol'],
+			style: {
+				color: blue,
 			},
 		},
 		{
-			types: ['punctuation', 'entity'],
+			types: ['tag'],
 			style: {
-				color: globalPalette.lightForegroundMuted,
+				// color: blue,
 			},
 		},
 		{
-			types: ['operator', 'doctype'],
+			types: ['string', 'char', 'selector'],
 			style: {
-				color: globalPalette.lightForegroundMuted,
-				opacity: 0.7,
+				color: globalPalette.accent,
+			},
+		},
+
+		// {
+		// 	types: ['keyword', 'variable'],
+		// 	style: {
+		// 		color: 'rgb(189, 147, 249)',
+		// 		fontStyle: 'italic',
+		// 	},
+		// },
+		// {
+		// 	types: ['comment'],
+		// 	style: {
+		// 		color: boxPalette.foregroundText,
+		// 	},
+		// },
+		{
+			types: ['attr-value'],
+			style: {
+				color: blue,
 			},
 		},
 		{
-			types: [
-				'selector',
-				'string',
-				'char',
-				'builtin',
-				'inserted',
-				'regex',
-				'attr-value',
-			],
+			types: ['attr-name'],
 			style: {
 				color: boxPalette.systemSuccess,
 			},

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -1,4 +1,5 @@
 import { PrismTheme } from 'prism-react-renderer';
+import dracula from 'prism-react-renderer/themes/dracula';
 import { boxPalette, globalPalette, tokens, fontGrid } from '@ag.ds-next/core';
 
 const blue = '#79c0ff';
@@ -10,120 +11,93 @@ export const prismTheme: PrismTheme = {
 	plain: {
 		fontFamily: tokens.font.monospace,
 		...fontGrid('xs', 'default'),
-		color: boxPalette.foregroundMuted,
-		backgroundColor: boxPalette.backgroundShade,
+		color: boxPalette.foregroundText,
+		backgroundColor: boxPalette.backgroundBodyAlt,
 	},
 	styles: [
-		{
-			types: ['prolog', 'constant', 'builtin'],
-			style: {
-				// color: blue,
-			},
-		},
-		// {
-		// 	types: ['inserted', 'function'],
-		// 	style: {
-		// 		color: 'rgb(80, 250, 123)',
-		// 	},
-		// },
-		// {
-		// 	types: ['deleted'],
-		// 	style: {
-		// 		color: 'rgb(255, 85, 85)',
-		// 	},
-		// },
-		// {
-		// 	types: ['changed'],
-		// 	style: {
-		// 		color: 'rgb(255, 184, 108)',
-		// 	},
-		// },
-		{
-			types: ['punctuation', 'symbol'],
-			style: {
-				color: blue,
-			},
-		},
-		{
-			types: ['tag'],
-			style: {
-				// color: blue,
-			},
-		},
-		{
-			types: ['string', 'char', 'selector'],
-			style: {
-				color: globalPalette.accent,
-			},
-		},
-
-		// {
-		// 	types: ['keyword', 'variable'],
-		// 	style: {
-		// 		color: 'rgb(189, 147, 249)',
-		// 		fontStyle: 'italic',
-		// 	},
-		// },
-		// {
-		// 	types: ['comment'],
-		// 	style: {
-		// 		color: boxPalette.foregroundText,
-		// 	},
-		// },
-		{
-			types: ['attr-value'],
-			style: {
-				color: blue,
-			},
-		},
-		{
-			types: ['attr-name'],
-			style: {
-				color: boxPalette.systemSuccess,
-			},
-		},
+		// ...dracula.styles,
 		{
 			types: [
+				'string',
+				'attr-value',
+				'entity',
 				'url',
 				'symbol',
 				'number',
 				'boolean',
 				'variable',
+				'tag',
+
+				'builtin',
+				'char',
+				'class-name',
+			],
+			style: {
+				color: blue,
+			},
+		},
+		{
+			types: ['inserted'],
+			style: {
+				color: 'rgb(80, 250, 123)',
+			},
+		},
+		{
+			types: [
+				'selector',
 				'constant',
 				'property',
 				'regex',
-				'inserted',
+				'.language-autohotkey',
+				'keyword',
+				'deleted',
 			],
 			style: {
-				color: boxPalette.systemWarning,
+				color: '#f55d70',
 			},
 		},
 		{
-			types: ['keyword'],
+			types: ['comment', 'prolog', 'doctype', 'cdata'],
 			style: {
-				color: globalPalette.lightForegroundFocus,
+				color: boxPalette.foregroundMuted,
+				font: 'italic',
 			},
 		},
 		{
-			types: ['function'],
+			types: ['operator', 'punctuation'],
 			style: {
-				color: globalPalette.lightForegroundAction,
-				fontWeight: 'bold',
-				opacity: 0.8,
+				color: boxPalette.foregroundText,
 			},
 		},
 		{
-			types: ['deleted', 'tag', 'atrule', 'attr-name'],
+			types: ['atrule', 'attr-name', 'function'],
 			style: {
-				color: globalPalette.lightForegroundAction,
-				opacity: 0.8,
+				color: purple,
 			},
 		},
 		{
-			types: ['class-name'],
+			types: ['changed'],
 			style: {
-				color: boxPalette.systemWarning,
+				color: '#fd9a5e',
 			},
 		},
 	],
 };
+
+/**
+
+
+namespace {
+	opacity: .7;
+}
+
+
+
+
+important,
+function,
+bold {
+	font-weight: bold;
+}
+
+ */

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -1,12 +1,6 @@
 import { PrismTheme } from 'prism-react-renderer';
-import dracula from 'prism-react-renderer/themes/dracula';
-import { boxPalette, globalPalette, tokens, fontGrid } from '@ag.ds-next/core';
+import { boxPalette, tokens, fontGrid } from '@ag.ds-next/core';
 
-const blue = '#79c0ff';
-const purple = '#d2a8ff';
-
-// Original: https://github.com/dracula/visual-studio-code
-// Converted automatically using ./tools/themeFromVsCode
 export const prismTheme: PrismTheme = {
 	plain: {
 		fontFamily: tokens.font.monospace,
@@ -15,7 +9,6 @@ export const prismTheme: PrismTheme = {
 		backgroundColor: boxPalette.backgroundBodyAlt,
 	},
 	styles: [
-		// ...dracula.styles,
 		{
 			types: [
 				'string',
@@ -33,7 +26,7 @@ export const prismTheme: PrismTheme = {
 				'class-name',
 			],
 			style: {
-				color: blue,
+				color: '#79c0ff',
 			},
 		},
 		{
@@ -72,7 +65,7 @@ export const prismTheme: PrismTheme = {
 		{
 			types: ['atrule', 'attr-name', 'function'],
 			style: {
-				color: purple,
+				color: '#d2a8ff',
 			},
 		},
 		{
@@ -83,21 +76,3 @@ export const prismTheme: PrismTheme = {
 		},
 	],
 };
-
-/**
-
-
-namespace {
-	opacity: .7;
-}
-
-
-
-
-important,
-function,
-bold {
-	font-weight: bold;
-}
-
- */


### PR DESCRIPTION
Retheme the website code block to increase accessibility, use more of our tokens, and generally improve its appearance.

The theme was inspired by the Github VSCode theme.
<img width="827" alt="image" src="https://user-images.githubusercontent.com/12689383/192946772-f6f31060-84b5-4042-8ca9-cae6a9e38c32.png">
<img width="836" alt="image" src="https://user-images.githubusercontent.com/12689383/192946838-83bba953-4a8b-4856-9079-769183948c16.png">
