### PR TITLE
date-picker: add ability to pass refs to the input element

### DIFF
--- a/.changeset/lucky-balloons-hang.md
+++ b/.changeset/lucky-balloons-hang.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/date-picker': patch
+---
+
+- DatePicker: Added new prop `inputRef`
+- DateRangePicker: Added new props `fromInputRef` and `toInputRef`

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep2.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep2.tsx
@@ -37,10 +37,11 @@ export const FormExampleMultiStep2 = () => {
 					control={control}
 					name="date"
 					render={({
-						field: { onChange, onBlur, value, name },
+						field: { onChange, onBlur, value, name, ref },
 						fieldState: { invalid, error },
 					}) => (
 						<DatePicker
+							inputRef={ref}
 							label="Select a date"
 							value={value}
 							onChange={onChange}

--- a/packages/date-picker/src/DatePicker.test.tsx
+++ b/packages/date-picker/src/DatePicker.test.tsx
@@ -1,0 +1,28 @@
+import '@testing-library/jest-dom';
+import 'html-validate/jest';
+import { cleanup, render } from '@testing-library/react';
+import { DatePicker, DatePickerProps } from './DatePicker';
+
+afterEach(cleanup);
+
+function renderDetail(props: DatePickerProps) {
+	return render(<DatePicker {...props} />);
+}
+
+describe('DatePicker', () => {
+	const { container } = renderDetail({
+		label: 'Example',
+		value: new Date('2000-01-01'),
+		onChange: console.log,
+	});
+
+	it('renders correctly', () => {
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders a valid HTML structure', () => {
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
+		});
+	});
+});

--- a/packages/date-picker/src/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker.tsx
@@ -1,7 +1,6 @@
 import {
 	ChangeEvent,
-	forwardRef,
-	RefObject,
+	Ref,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -35,7 +34,7 @@ type DatePickerBaseProps = {
 	/** Function to be fired following a change event. */
 	onChange: (day: Date | undefined) => void;
 	/** Ref to the input element. */
-	inputRef?: RefObject<HTMLInputElement>;
+	inputRef?: Ref<HTMLInputElement>;
 };
 
 export type DatePickerProps = DatePickerInputProps &

--- a/packages/date-picker/src/DatePicker.tsx
+++ b/packages/date-picker/src/DatePicker.tsx
@@ -1,5 +1,7 @@
 import {
 	ChangeEvent,
+	forwardRef,
+	RefObject,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -32,6 +34,8 @@ type DatePickerBaseProps = {
 	value: Date | undefined;
 	/** Function to be fired following a change event. */
 	onChange: (day: Date | undefined) => void;
+	/** Ref to the input element. */
+	inputRef?: RefObject<HTMLInputElement>;
 };
 
 export type DatePickerProps = DatePickerInputProps &
@@ -44,6 +48,7 @@ export const DatePicker = ({
 	minDate,
 	maxDate,
 	initialMonth,
+	inputRef,
 	...props
 }: DatePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
@@ -125,6 +130,7 @@ export const DatePicker = ({
 		<div ref={setRefEl}>
 			<DateInput
 				{...props}
+				ref={inputRef}
 				value={inputValue}
 				onChange={onInputChange}
 				buttonRef={triggerRef}

--- a/packages/date-picker/src/DateRangePicker.test.tsx
+++ b/packages/date-picker/src/DateRangePicker.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom';
+import 'html-validate/jest';
+import { cleanup, render } from '@testing-library/react';
+import { DateRangePicker, DateRangePickerProps } from './DateRangePicker';
+
+afterEach(cleanup);
+
+function renderDetail(props: DateRangePickerProps) {
+	return render(<DateRangePicker {...props} />);
+}
+
+describe('DateRangePicker', () => {
+	const { container } = renderDetail({
+		value: { from: new Date('2000-01-01'), to: new Date('2000-01-02') },
+		onChange: console.log,
+	});
+
+	it('renders correctly', () => {
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders a valid HTML structure', () => {
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
+		});
+	});
+});

--- a/packages/date-picker/src/DateRangePicker.tsx
+++ b/packages/date-picker/src/DateRangePicker.tsx
@@ -5,6 +5,7 @@ import {
 	useState,
 	useEffect,
 	useMemo,
+	RefObject,
 } from 'react';
 import { usePopper } from 'react-popper';
 import { SelectRangeEventHandler } from 'react-day-picker';
@@ -47,6 +48,10 @@ export type DateRangePickerProps = DateRangePickerCalendarProps & {
 	fromLabel?: string;
 	/** The label above the end date text input. */
 	toLabel?: string;
+	/** Ref to the from input element. */
+	fromInputRef?: RefObject<HTMLInputElement>;
+	/** Ref to the start input element. */
+	toInputRef?: RefObject<HTMLInputElement>;
 };
 
 export const DateRangePicker = ({
@@ -58,6 +63,8 @@ export const DateRangePicker = ({
 	required,
 	minDate,
 	maxDate,
+	fromInputRef,
+	endInputRef,
 }: DateRangePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
 	const [inputMode, setInputMode] = useState<'from' | 'to'>();
@@ -193,6 +200,7 @@ export const DateRangePicker = ({
 				gap={1}
 			>
 				<DateInput
+					ref={fromInputRef}
 					label={fromLabel}
 					value={fromInputValue}
 					onChange={onFromInputChange}
@@ -202,6 +210,7 @@ export const DateRangePicker = ({
 					required={required}
 				/>
 				<DateInput
+					ref={endInputRef}
 					label={toLabel}
 					value={toInputValue}
 					onChange={onToInputChange}

--- a/packages/date-picker/src/DateRangePicker.tsx
+++ b/packages/date-picker/src/DateRangePicker.tsx
@@ -48,9 +48,9 @@ export type DateRangePickerProps = DateRangePickerCalendarProps & {
 	fromLabel?: string;
 	/** The label above the end date text input. */
 	toLabel?: string;
-	/** Ref to the from input element. */
-	fromInputRef?: Ref<HTMLInputElement>;
 	/** Ref to the start input element. */
+	fromInputRef?: Ref<HTMLInputElement>;
+	/** Ref to the end input element. */
 	toInputRef?: Ref<HTMLInputElement>;
 };
 

--- a/packages/date-picker/src/DateRangePicker.tsx
+++ b/packages/date-picker/src/DateRangePicker.tsx
@@ -1,11 +1,11 @@
 import {
 	ChangeEvent,
 	useCallback,
+	Ref,
 	useRef,
 	useState,
 	useEffect,
 	useMemo,
-	RefObject,
 } from 'react';
 import { usePopper } from 'react-popper';
 import { SelectRangeEventHandler } from 'react-day-picker';
@@ -49,9 +49,9 @@ export type DateRangePickerProps = DateRangePickerCalendarProps & {
 	/** The label above the end date text input. */
 	toLabel?: string;
 	/** Ref to the from input element. */
-	fromInputRef?: RefObject<HTMLInputElement>;
+	fromInputRef?: Ref<HTMLInputElement>;
 	/** Ref to the start input element. */
-	toInputRef?: RefObject<HTMLInputElement>;
+	toInputRef?: Ref<HTMLInputElement>;
 };
 
 export const DateRangePicker = ({
@@ -64,7 +64,7 @@ export const DateRangePicker = ({
 	minDate,
 	maxDate,
 	fromInputRef,
-	endInputRef,
+	toInputRef,
 }: DateRangePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
 	const [inputMode, setInputMode] = useState<'from' | 'to'>();
@@ -210,7 +210,7 @@ export const DateRangePicker = ({
 					required={required}
 				/>
 				<DateInput
-					ref={endInputRef}
+					ref={toInputRef}
 					label={toLabel}
 					value={toInputValue}
 					onChange={onToInputChange}

--- a/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DatePicker renders correctly 1`] = `
+<div>
+  <div>
+    <div
+      class="css-1904cz9-boxStyles-FieldContainer"
+    >
+      <label
+        class="css-n7rdvo-boxStyles"
+        for="field-1"
+      >
+        <span
+          class="css-433uqb-boxStyles-Text"
+        >
+          Example
+        </span>
+        <span
+          class="css-1rpt3h8-boxStyles-Text"
+        >
+          (dd/mm/yyyy)
+        </span>
+      </label>
+      <div
+        class="css-1az95r4-boxStyles-DateInput"
+      >
+        <input
+          aria-invalid="false"
+          aria-required="false"
+          class="css-qcwla-DateInput"
+          id="field-1"
+          value="01/01/2000"
+        />
+        <button
+          aria-label="Change Date, Saturday January 1st, 2000"
+          class="css-iya2bc-BaseButton-DateInput"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            class="css-4ah0i8-Icon"
+            clip-rule="evenodd"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M8 3C8 4.5621 8 5.4379 8 7"
+            />
+            <path
+              d="M16 3C16 4.5621 16 5.4379 16 7"
+            />
+            <path
+              d="M21 20V6C21 5.44772 20.5523 5 20 5H4C3.44772 5 3 5.44772 3 6V20C3 20.5523 3.44772 21 4 21H20C20.5523 21 21 20.5523 21 20Z"
+            />
+            <line
+              x1="3"
+              x2="21"
+              y1="12"
+              y2="12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
@@ -1,0 +1,138 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateRangePicker renders correctly 1`] = `
+<div>
+  <div>
+    <div
+      class="css-ns3arw-boxStyles"
+    >
+      <div
+        class="css-1904cz9-boxStyles-FieldContainer"
+      >
+        <label
+          class="css-n7rdvo-boxStyles"
+          for="field-1"
+        >
+          <span
+            class="css-433uqb-boxStyles-Text"
+          >
+            Start date
+          </span>
+          <span
+            class="css-1rpt3h8-boxStyles-Text"
+          >
+            (dd/mm/yyyy)
+          </span>
+        </label>
+        <div
+          class="css-1az95r4-boxStyles-DateInput"
+        >
+          <input
+            aria-invalid="false"
+            aria-required="false"
+            class="css-qcwla-DateInput"
+            id="field-1"
+            value="01/01/2000"
+          />
+          <button
+            aria-label="Change Date, Saturday January 1st, 2000"
+            class="css-iya2bc-BaseButton-DateInput"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-4ah0i8-Icon"
+              clip-rule="evenodd"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 3C8 4.5621 8 5.4379 8 7"
+              />
+              <path
+                d="M16 3C16 4.5621 16 5.4379 16 7"
+              />
+              <path
+                d="M21 20V6C21 5.44772 20.5523 5 20 5H4C3.44772 5 3 5.44772 3 6V20C3 20.5523 3.44772 21 4 21H20C20.5523 21 21 20.5523 21 20Z"
+              />
+              <line
+                x1="3"
+                x2="21"
+                y1="12"
+                y2="12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        class="css-1904cz9-boxStyles-FieldContainer"
+      >
+        <label
+          class="css-n7rdvo-boxStyles"
+          for="field-2"
+        >
+          <span
+            class="css-433uqb-boxStyles-Text"
+          >
+            End date
+          </span>
+          <span
+            class="css-1rpt3h8-boxStyles-Text"
+          >
+            (dd/mm/yyyy)
+          </span>
+        </label>
+        <div
+          class="css-1az95r4-boxStyles-DateInput"
+        >
+          <input
+            aria-invalid="false"
+            aria-required="false"
+            class="css-qcwla-DateInput"
+            id="field-2"
+            value="02/01/2000"
+          />
+          <button
+            aria-label="Change Date, Sunday January 2nd, 2000"
+            class="css-iya2bc-BaseButton-DateInput"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="css-4ah0i8-Icon"
+              clip-rule="evenodd"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 3C8 4.5621 8 5.4379 8 7"
+              />
+              <path
+                d="M16 3C16 4.5621 16 5.4379 16 7"
+              />
+              <path
+                d="M21 20V6C21 5.44772 20.5523 5 20 5H4C3.44772 5 3 5.44772 3 6V20C3 20.5523 3.44772 21 4 21H20C20.5523 21 21 20.5523 21 20Z"
+              />
+              <line
+                x1="3"
+                x2="21"
+                y1="12"
+                y2="12"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
## Describe your changes

Added ability to pass ref to the input elements which makes it possible to automatically focus the field when an error occurs.  This fixes DAGR-124. 

 More specifically: 

- DatePicker: Added new prop `inputRef`
- DateRangePicker: Added new props `fromInputRef` and `toInputRef`
- Added tests

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook