### PR TITLE
Docs: Code block does not use pre-tag (DAGR-115)

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -1,14 +1,8 @@
 import React, { ReactNode, useState, useCallback, Fragment } from 'react';
 import { useRouter } from 'next/router';
-import {
-	LiveProvider,
-	LiveEditor,
-	LivePreview,
-	Editor as StaticEditor,
-	withLive,
-} from 'react-live';
+import { LiveProvider, LiveEditor, LivePreview, withLive } from 'react-live';
 import { createUrl } from 'playroom/utils';
-import { Language } from 'prism-react-renderer';
+import Highlight, { defaultProps, Language } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
 import { useId } from '@reach/auto-id';
 import { ExternalLinkCallout } from '@ag.ds-next/a11y';
@@ -194,12 +188,30 @@ const StaticCode = ({
 			}}
 		>
 			<Box dark>
-				<StaticEditor
+				<Highlight
+					{...defaultProps}
 					code={code}
 					theme={prismTheme}
 					language={language}
-					disabled
-				/>
+				>
+					{({ className, style, tokens, getLineProps, getTokenProps }) => (
+						<pre
+							className={className}
+							style={{
+								...style,
+								overflowX: 'auto',
+							}}
+						>
+							{tokens.map((line, i) => (
+								<div key={i} {...getLineProps({ line, key: i })}>
+									{line.map((token, key) => (
+										<span key={key} {...getTokenProps({ token, key })} />
+									))}
+								</div>
+							))}
+						</pre>
+					)}
+				</Highlight>
 			</Box>
 			<Flex padding={0.5}>
 				<Button

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -177,8 +177,9 @@ const StaticCode = ({
 				overflow: 'hidden',
 				marginTop: mapSpacing(1.5),
 
-				'textarea, pre': {
+				pre: {
 					padding: `${mapSpacing(1.5)} !important`,
+					overflowX: 'auto',
 				},
 
 				'& ::selection': {
@@ -196,19 +197,21 @@ const StaticCode = ({
 				>
 					{({ className, style, tokens, getLineProps, getTokenProps }) => (
 						<pre
-							className={className}
-							style={{
-								...style,
-								overflowX: 'auto',
-							}}
+							className={[className, unsetProseStylesClassname].join(' ')}
+							style={style}
 						>
-							{tokens.map((line, i) => (
-								<div key={i} {...getLineProps({ line, key: i })}>
-									{line.map((token, key) => (
-										<span key={key} {...getTokenProps({ token, key })} />
-									))}
-								</div>
-							))}
+							<code>
+								{tokens.map((line, lineKey) => (
+									<div key={lineKey} {...getLineProps({ line, key: lineKey })}>
+										{line.map((token, tokenKey) => (
+											<span
+												key={tokenKey}
+												{...getTokenProps({ token, key: tokenKey })}
+											/>
+										))}
+									</div>
+								))}
+							</code>
 						</pre>
 					)}
 				</Highlight>


### PR DESCRIPTION
## Describe your changes

The component used for our 'non-live' static code blocks was rendering a disabled TextArea. This was captured by the accessibility review as the text area did not have a label.

We've fixed the issue by replacing it with a component that renders a `<pre>` tag instead.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
