### PR TITLE
Improve focus management of multi-step form

### DIFF
--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
@@ -224,7 +224,7 @@ export const FormRegisterPetDetails = () => {
 	);
 };
 
-export const useFormExampleMultiStep = () => {
+export const useFormRegisterPetDetails = () => {
 	const value = useContext(context);
 
 	if (!value) {

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsActions.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsActions.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@ag.ds-next/box';
 import { Text } from '@ag.ds-next/text';
 import { useTernaryState } from '@ag.ds-next/core';
 import { FormDivider } from '../FormDivider';
-import { useFormExampleMultiStep } from './FormRegisterPetDetails';
+import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
 export const FormRegisterPetDetailsActions = () => {
 	const [isModalOpen, openModal, closeModal] = useTernaryState(false);
@@ -16,7 +16,7 @@ export const FormRegisterPetDetailsActions = () => {
 		saveAndExit,
 		isSavingBeforeExiting,
 		cancel,
-	} = useFormExampleMultiStep();
+	} = useFormRegisterPetDetails();
 
 	return (
 		<Fragment>

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsContainer.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsContainer.tsx
@@ -1,11 +1,12 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { Stack } from '@ag.ds-next/box';
 import { PageAlert } from '@ag.ds-next/page-alert';
-import { Prose } from '@ag.ds-next/prose';
+import { H1 } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
 import { PageTitle } from '../PageTitle';
-import { useFormExampleMultiStep } from './FormRegisterPetDetails';
+import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
-export const FormRegisterPetDetailsContainer = ({
+export const FormRegisterPetPersonalDetailsContainer = ({
 	children,
 	title,
 	introduction,
@@ -16,12 +17,24 @@ export const FormRegisterPetDetailsContainer = ({
 	introduction: string;
 	callToAction?: ReactNode;
 }) => {
-	const { hasCompletedPreviousSteps } = useFormExampleMultiStep();
+	const titleRef = useRef<HTMLHeadingElement>(null);
+	const { hasCompletedPreviousSteps, currentStep } =
+		useFormRegisterPetDetails();
+
+	// Focus the title of the current step as the user navigates between form steps
+	useEffect(() => {
+		titleRef.current?.focus();
+	}, [currentStep]);
+
 	return (
 		<Stack gap={3} width="100%">
 			<PageTitle
 				pretext="Your pet’s details"
-				title={title}
+				title={
+					<H1 ref={titleRef} tabIndex={-1} focus>
+						{title}
+					</H1>
+				}
 				introduction={introduction}
 				callToAction={hasCompletedPreviousSteps ? callToAction : undefined}
 			/>
@@ -32,12 +45,10 @@ export const FormRegisterPetDetailsContainer = ({
 					tone="warning"
 					title="This section of the form is not ready to be completed"
 				>
-					<Prose>
-						<p>
-							Before starting this part of the form, you will need to go back
-							and complete all of the previous sections.
-						</p>
-					</Prose>
+					<Text as="p">
+						Before starting this part of the form, you will need to go back and
+						complete all of the previous sections.
+					</Text>
 				</PageAlert>
 			)}
 		</Stack>

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsContainer.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsContainer.tsx
@@ -6,7 +6,7 @@ import { Text } from '@ag.ds-next/text';
 import { PageTitle } from '../PageTitle';
 import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
-export const FormRegisterPetPersonalDetailsContainer = ({
+export const FormRegisterPetDetailsContainer = ({
 	children,
 	title,
 	introduction,

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep0.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep0.tsx
@@ -7,7 +7,7 @@ import { FormStack } from '@ag.ds-next/form-stack';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
 import { FormRegisterPetDetailsContainer } from './FormRegisterPetDetailsContainer';
 import { FormRegisterPetDetailsActions } from './FormRegisterPetDetailsActions';
-import { useFormExampleMultiStep } from './FormRegisterPetDetails';
+import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
 const formSchema = yup
 	.object({
@@ -22,7 +22,7 @@ const formSchema = yup
 export type FormSchema = yup.InferType<typeof formSchema>;
 
 export const FormRegisterPetDetailsStep0 = () => {
-	const { next, stepFormState } = useFormExampleMultiStep();
+	const { next, stepFormState } = useFormRegisterPetDetails();
 
 	const {
 		register,

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep1.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep1.tsx
@@ -19,7 +19,7 @@ import { Prose } from '@ag.ds-next/prose';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
 import { FormRegisterPetDetailsContainer } from './FormRegisterPetDetailsContainer';
 import { FormRegisterPetDetailsActions } from './FormRegisterPetDetailsActions';
-import { useFormExampleMultiStep } from './FormRegisterPetDetails';
+import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
 const formSchema = yup
 	.object({
@@ -36,7 +36,7 @@ const formSchema = yup
 export type FormSchema = yup.InferType<typeof formSchema>;
 
 export const FormRegisterPetDetailsStep1 = () => {
-	const { next, stepFormState } = useFormExampleMultiStep();
+	const { next, stepFormState } = useFormRegisterPetDetails();
 	const scrollToField = useScrollToField();
 	const errorRef = useRef<HTMLDivElement>(null);
 	const [focusedError, setFocusedError] = useState(false);
@@ -129,19 +129,13 @@ export const FormRegisterPetDetailsStep1 = () => {
 					<Controller
 						control={control}
 						name="dob"
-						render={({
-							field: { onChange, onBlur, value, name, ref },
-							fieldState: { invalid, error },
-						}) => (
+						render={({ field: { ref, ...field } }) => (
 							<DatePicker
 								inputRef={ref}
 								label="Date of birth"
-								value={value}
-								onChange={onChange}
-								onBlur={onBlur}
-								name={name}
-								invalid={invalid}
-								message={error?.message}
+								{...field}
+								invalid={Boolean(errors.dob?.message)}
+								message={errors.dob?.message}
 								maxWidth="xl"
 								required
 							/>

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep2.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep2.tsx
@@ -17,7 +17,7 @@ import { useScrollToField } from '@ag.ds-next/field';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
 import { FormRegisterPetDetailsContainer } from './FormRegisterPetDetailsContainer';
 import { FormRegisterPetDetailsActions } from './FormRegisterPetDetailsActions';
-import { useFormExampleMultiStep } from './FormRegisterPetDetails';
+import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
 const formSchema = yup
 	.object({
@@ -28,7 +28,7 @@ const formSchema = yup
 export type FormSchema = yup.InferType<typeof formSchema>;
 
 export const FormRegisterPetDetailsStep2 = () => {
-	const { next, stepFormState, isSubmittingStep } = useFormExampleMultiStep();
+	const { next, stepFormState, isSubmittingStep } = useFormRegisterPetDetails();
 	const scrollToField = useScrollToField();
 	const errorRef = useRef<HTMLDivElement>(null);
 	const [focusedError, setFocusedError] = useState(false);

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep3.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep3.tsx
@@ -4,7 +4,7 @@ import * as yup from 'yup';
 import { Stack } from '@ag.ds-next/box';
 import { DatePicker } from '@ag.ds-next/date-picker';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
-import { useFormExampleMultiStep } from './FormRegisterPetDetails';
+import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 import { FormRegisterPetDetailsActions } from './FormRegisterPetDetailsActions';
 import { FormRegisterPetDetailsContainer } from './FormRegisterPetDetailsContainer';
 
@@ -17,7 +17,7 @@ const formSchema = yup
 export type FormSchema = yup.InferType<typeof formSchema>;
 
 export const FormRegisterPetDetailsStep3 = () => {
-	const { next, stepFormState } = useFormExampleMultiStep();
+	const { next, stepFormState } = useFormRegisterPetDetails();
 
 	const { control, handleSubmit } = useForm<FormSchema>({
 		defaultValues: stepFormState,

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep3.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep3.tsx
@@ -19,7 +19,11 @@ export type FormSchema = yup.InferType<typeof formSchema>;
 export const FormRegisterPetDetailsStep3 = () => {
 	const { next, stepFormState } = useFormRegisterPetDetails();
 
-	const { control, handleSubmit } = useForm<FormSchema>({
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<FormSchema>({
 		defaultValues: stepFormState,
 		resolver: yupResolver(formSchema),
 	});
@@ -38,19 +42,13 @@ export const FormRegisterPetDetailsStep3 = () => {
 				<Controller
 					control={control}
 					name="date"
-					render={({
-						field: { onChange, onBlur, value, name, ref },
-						fieldState: { invalid, error },
-					}) => (
+					render={({ field: { ref, ...field } }) => (
 						<DatePicker
 							inputRef={ref}
 							label="Select a date"
-							value={value}
-							onChange={onChange}
-							onBlur={onBlur}
-							name={name}
-							invalid={invalid}
-							message={error?.message}
+							{...field}
+							invalid={Boolean(errors.date?.message)}
+							message={errors.date?.message}
 							maxWidth="xl"
 							required
 						/>

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep4.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep4.tsx
@@ -3,12 +3,15 @@ import { Stack } from '@ag.ds-next/box';
 import { H2 } from '@ag.ds-next/heading';
 import { Button } from '@ag.ds-next/button';
 import { FormDefinitionList } from '../FormDefinitionList';
-import { FORM_STEPS, useFormExampleMultiStep } from './FormRegisterPetDetails';
+import {
+	FORM_STEPS,
+	useFormRegisterPetDetails,
+} from './FormRegisterPetDetails';
 import { FormRegisterPetDetailsContainer } from './FormRegisterPetDetailsContainer';
 import { FormRegisterPetDetailsActions } from './FormRegisterPetDetailsActions';
 
 export const FormRegisterPetDetailsStep4 = () => {
-	const { formState, goToStep, next } = useFormExampleMultiStep();
+	const { formState, goToStep, next } = useFormRegisterPetDetails();
 
 	const onSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault();

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsContainer.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsContainer.tsx
@@ -1,7 +1,8 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
 import { Stack } from '@ag.ds-next/box';
 import { PageAlert } from '@ag.ds-next/page-alert';
-import { Prose } from '@ag.ds-next/prose';
+import { H1 } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
 import { PageTitle } from '../PageTitle';
 import { useFormRegisterPetPersonalDetails } from './FormRegisterPetPersonalDetails';
 
@@ -16,12 +17,24 @@ export const FormRegisterPetPersonalDetailsContainer = ({
 	introduction: string;
 	callToAction?: ReactNode;
 }) => {
-	const { hasCompletedPreviousSteps } = useFormRegisterPetPersonalDetails();
+	const titleRef = useRef<HTMLHeadingElement>(null);
+	const { hasCompletedPreviousSteps, currentStep } =
+		useFormRegisterPetPersonalDetails();
+
+	// Focus the title of the current step as the user navigates between form steps
+	useEffect(() => {
+		titleRef.current?.focus();
+	}, [currentStep]);
+
 	return (
 		<Stack gap={3} width="100%">
 			<PageTitle
 				pretext="Your personal details"
-				title={title}
+				title={
+					<H1 ref={titleRef} tabIndex={-1} focus>
+						{title}
+					</H1>
+				}
 				introduction={introduction}
 				callToAction={callToAction}
 			/>
@@ -32,12 +45,10 @@ export const FormRegisterPetPersonalDetailsContainer = ({
 					tone="warning"
 					title="This section of the form is not ready to be completed"
 				>
-					<Prose>
-						<p>
-							Before starting this part of the form, you will need to go back
-							and complete all of the previous sections.
-						</p>
-					</Prose>
+					<Text as="p">
+						Before starting this part of the form, you will need to go back and
+						complete all of the previous sections.
+					</Text>
 				</PageAlert>
 			)}
 		</Stack>

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
@@ -176,19 +176,13 @@ export const FormRegisterPetPersonalDetailsStep0 = () => {
 								<Controller
 									control={control}
 									name="dob"
-									render={({
-										field: { onChange, onBlur, value, name, ref },
-										fieldState: { invalid, error },
-									}) => (
+									render={({ field: { ref, ...field } }) => (
 										<DatePicker
 											inputRef={ref}
 											label="Date of birth"
-											value={value}
-											onChange={onChange}
-											onBlur={onBlur}
-											name={name}
-											invalid={invalid}
-											message={error?.message}
+											{...field}
+											invalid={Boolean(errors.dob?.message)}
+											message={errors.dob?.message}
 											maxWidth="xl"
 											required
 										/>

--- a/example-form/components/PageTitle.tsx
+++ b/example-form/components/PageTitle.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { isValidElement, ReactNode } from 'react';
 import { Stack } from '@ag.ds-next/box';
 import { H1 } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
@@ -28,7 +28,7 @@ export const PageTitle = ({
 					{pretext}
 				</Text>
 			) : null}
-			<H1>{title}</H1>
+			{isValidElement(title) ? title : <H1>{title}</H1>}
 		</Stack>
 		{introduction ? (
 			<Text as="p" fontSize="md" color="muted">

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep2.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep2.tsx
@@ -18,7 +18,11 @@ export type FormSchema = yup.InferType<typeof formSchema>;
 export const FormExampleMultiStep2 = () => {
 	const { next, stepFormState } = useFormExampleMultiStep();
 
-	const { control, handleSubmit } = useForm<FormSchema>({
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<FormSchema>({
 		defaultValues: stepFormState,
 		resolver: yupResolver(formSchema),
 	});
@@ -32,23 +36,22 @@ export const FormExampleMultiStep2 = () => {
 			title="Select date (H1)"
 			introduction="The introductory paragraph provides context about this page of the form. Use a short paragraph to reduce cognitive load."
 		>
-			<Stack as="form" gap={3} onSubmit={handleSubmit(onSubmit)} noValidate>
+			<Stack
+				as="form"
+				gap={3}
+				onSubmit={handleSubmit(onSubmit, console.log)}
+				noValidate
+			>
 				<Controller
 					control={control}
 					name="date"
-					render={({
-						field: { onChange, onBlur, value, name, ref },
-						fieldState: { invalid, error },
-					}) => (
+					render={({ field: { ref, ...field } }) => (
 						<DatePicker
 							inputRef={ref}
 							label="Select a date"
-							value={value}
-							onChange={onChange}
-							onBlur={onBlur}
-							name={name}
-							invalid={invalid}
-							message={error?.message}
+							{...field}
+							invalid={Boolean(errors.date?.message)}
+							message={errors.date?.message}
 							maxWidth="xl"
 							required
 						/>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStepContainer.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStepContainer.tsx
@@ -2,7 +2,6 @@ import { ReactNode, useEffect, useRef } from 'react';
 import { H1 } from '@ag.ds-next/heading';
 import { Stack } from '@ag.ds-next/box';
 import { PageAlert } from '@ag.ds-next/page-alert';
-import { Prose } from '@ag.ds-next/prose';
 import { Text } from '@ag.ds-next/text';
 import { PageTitle } from '../PageTitle';
 import { useFormExampleMultiStep } from './FormExampleMultiStep';
@@ -49,12 +48,10 @@ export const FormExampleMultiStepContainer = ({
 					tone="warning"
 					title="This section of the form is not ready to be completed"
 				>
-					<Prose>
-						<p>
-							Before starting this part of the form, you will need to go back
-							and complete all of the previous sections.
-						</p>
-					</Prose>
+					<Text as="p">
+						Before starting this part of the form, you will need to go back and
+						complete all of the previous sections.
+					</Text>
 				</PageAlert>
 			)}
 		</Stack>

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStepContainer.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStepContainer.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useRef } from 'react';
+import { H1 } from '@ag.ds-next/heading';
 import { Stack } from '@ag.ds-next/box';
 import { PageAlert } from '@ag.ds-next/page-alert';
 import { Prose } from '@ag.ds-next/prose';
@@ -15,12 +16,23 @@ export const FormExampleMultiStepContainer = ({
 	title: string;
 	introduction: string;
 }) => {
-	const { hasCompletedPreviousSteps } = useFormExampleMultiStep();
+	const titleRef = useRef<HTMLHeadingElement>(null);
+	const { hasCompletedPreviousSteps, currentStep } = useFormExampleMultiStep();
+
+	// Focus the title of the current step as the user navigates between form steps
+	useEffect(() => {
+		titleRef.current?.focus();
+	}, [currentStep]);
+
 	return (
 		<Stack gap={3}>
 			<PageTitle
 				pretext="Title of multi-page form"
-				title={title}
+				title={
+					<H1 ref={titleRef} tabIndex={-1} focus>
+						{title}
+					</H1>
+				}
 				introduction={introduction}
 				callToAction={
 					hasCompletedPreviousSteps ? (

--- a/example-site/components/PageTitle.tsx
+++ b/example-site/components/PageTitle.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { isValidElement, ReactNode } from 'react';
 import { Stack } from '@ag.ds-next/box';
 import { H1 } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
@@ -28,7 +28,7 @@ export const PageTitle = ({
 					{pretext}
 				</Text>
 			) : null}
-			<H1>{title}</H1>
+			{isValidElement(title) ? title : <H1>{title}</H1>}
 		</Stack>
 		{introduction ? (
 			<Text as="p" fontSize="md" color="muted">


### PR DESCRIPTION
## Describe your changes

Improve focus management of multi-step form (both the register your pet form and multi-page form in our examples). This has included

- Focus the title of the current step as the user navigates between form steps
- Fixed a bug where the invalid state for the date picker is sometimes not shown

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [] Write documentation (README.md)
- [ ] Create stories for Storybook