### PR TITLE
docs: Rewrite links to be more unique in Getting Started

### DIFF
--- a/guides/getting-started.mdx
+++ b/guides/getting-started.mdx
@@ -86,7 +86,7 @@ yarn add @ag.ds-next/core @ag.ds-next/ag-branding @ag.ds-next/box @ag.ds-next/te
 
 ### 3. Wrap your application in our `Core` component
 
-The `Core` component needs to wrap your entire application and it is where you can configure the theme and routing/links. For an example of configuring routing/links in AgDS for a Next.js application, please see [our example site](https://github.com/steelthreads/agds-next/tree/main/example-site/components/LinkComponent.tsx).
+The `Core` component needs to wrap your entire application and it is where you can configure the theme and routing/links. For an example of configuring routing/links in AgDS for a Next.js application, please see [the code for our example site](https://github.com/steelthreads/agds-next/tree/main/example-site/components/LinkComponent.tsx).
 
 ```tsx
 // This example assumes you are using NextJS
@@ -111,11 +111,11 @@ export default function MyApp({ Component, pageProps }) {
 
 You can now start using our components!
 
-> We recommend using TypeScript to get the most out of these components. Our [example site](https://github.com/steelthreads/agds-next/tree/main/example-site) already uses TypeScript so you can use that as reference.
+> We recommend using TypeScript to get the most out of these components. Our example site already uses TypeScript so you can use that as reference. [See code](https://github.com/steelthreads/agds-next/tree/main/example-site).
 
 ## What's next?
 
-Take a look at our [example site](https://steelthreads.github.io/agds-next/example-site/index.html), to see our list of interface examples, as well as the [related code on GitHub](https://github.com/steelthreads/agds-next/tree/main/example-site).
+[Explore our example site](https://steelthreads.github.io/agds-next/example-site/index.html) to see our list of interface examples, as well as the [related code on GitHub](https://github.com/steelthreads/agds-next/tree/main/example-site).
 
 You should also explore our wide range of [components](https://steelthreads.github.io/agds-next/packages), and install the ones you need in your application.
 


### PR DESCRIPTION
Fix issue from a11y audit:
[Product Backlog Item 319337](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/319337?McasTsid=26110): DAGR-116: Link text is not descriptive