### PR TITLE
side-nav: Remove `aria-label`

### DIFF
--- a/.changeset/tasty-sheep-smoke.md
+++ b/.changeset/tasty-sheep-smoke.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/side-nav': patch
 ---
 
-Rename aria-label from 'side navigation' to 'section navigation', to be applicable for narrow viewports
+Rename `aria-label` prop

--- a/.changeset/tasty-sheep-smoke.md
+++ b/.changeset/tasty-sheep-smoke.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/side-nav': patch
+---
+
+Rename aria-label from 'side navigation' to 'section navigation', to be applicable for narrow viewports

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -101,7 +101,7 @@ OptionalTitleLink.args = {
 };
 
 export const Modular = () => (
-	<SideNavContainer background="body" aria-label="section navigation">
+	<SideNavContainer background="body">
 		<SideNavTitle id="side-nav-modular-title" href="#" isCurrentPage={false}>
 			SideNav Title
 		</SideNavTitle>

--- a/packages/side-nav/src/SideNav.stories.tsx
+++ b/packages/side-nav/src/SideNav.stories.tsx
@@ -101,7 +101,7 @@ OptionalTitleLink.args = {
 };
 
 export const Modular = () => (
-	<SideNavContainer background="body" aria-label="side navigation">
+	<SideNavContainer background="body" aria-label="section navigation">
 		<SideNavTitle id="side-nav-modular-title" href="#" isCurrentPage={false}>
 			SideNav Title
 		</SideNavTitle>

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -15,8 +15,6 @@ import { SideNavCollapseButton } from './SideNavCollapseButton';
 import { SideNavBackground, findBestMatch, useSideNavIds } from './utils';
 
 export type SideNavProps = {
-	/** Describes the navigation element to assistive technologies. */
-	'aria-label'?: string;
 	/** Used for highlighting the active element. */
 	activePath: string;
 	/** Used as the title of the expand/collapse trigger on smaller screen sizes. */
@@ -32,7 +30,6 @@ export type SideNavProps = {
 };
 
 export function SideNav({
-	'aria-label': ariaLabel = 'section navigation',
 	activePath,
 	collapseTitle,
 	items,
@@ -66,7 +63,7 @@ export function SideNav({
 	});
 
 	return (
-		<SideNavContainer aria-label={ariaLabel} background={background}>
+		<SideNavContainer background={background}>
 			<SideNavCollapseButton
 				isOpen={isOpen}
 				onClick={onToggle}

--- a/packages/side-nav/src/SideNav.tsx
+++ b/packages/side-nav/src/SideNav.tsx
@@ -32,7 +32,7 @@ export type SideNavProps = {
 };
 
 export function SideNav({
-	'aria-label': ariaLabel = 'side navigation',
+	'aria-label': ariaLabel = 'section navigation',
 	activePath,
 	collapseTitle,
 	items,

--- a/packages/side-nav/src/SideNavContainer.tsx
+++ b/packages/side-nav/src/SideNavContainer.tsx
@@ -4,12 +4,10 @@ import { mapResponsiveProp, mq, packs } from '@ag.ds-next/core';
 import { hoverColorMap, SideNavBackground, localPaletteVars } from './utils';
 
 export type SideNavContainerProps = PropsWithChildren<{
-	'aria-label': string;
 	background: SideNavBackground;
 }>;
 
 export const SideNavContainer = ({
-	'aria-label': ariaLabel,
 	children,
 	background,
 }: SideNavContainerProps) => {
@@ -17,7 +15,6 @@ export const SideNavContainer = ({
 	return (
 		<Box
 			as="aside"
-			aria-label={ariaLabel}
 			background={background}
 			css={mq({
 				...packs.print.hidden,

--- a/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SideNav renders correctly 1`] = `
 <div>
   <aside
-    aria-label="side navigation"
+    aria-label="section navigation"
     class="css-d977xg-boxStyles-SideNavContainer"
   >
     <button

--- a/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`SideNav renders correctly 1`] = `
 <div>
   <aside
-    aria-label="section navigation"
     class="css-d977xg-boxStyles-SideNavContainer"
   >
     <button


### PR DESCRIPTION
## Describe your changes
From [DAGR-112: Section element name could be improved (319203)](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/319203?McasTsid=26110): 
The SideNav has an aria-label of "side navigation". This name is not applicable when the sectioning element owns 100% of the viewport's width.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
