### PR TITLE
core: Add tests for responsive style generation

### DIFF
--- a/packages/core/src/boxPalette.ts
+++ b/packages/core/src/boxPalette.ts
@@ -99,7 +99,7 @@ export const boxPalette = {
 };
 
 /**
- * Returns the current palette for a specifc DOM element
+ * Returns the current palette for a specific DOM element
  * Note: As this function relies on CSS vars, the value returned will not be available on the server
  */
 export function useBoxPalette(element: RefObject<HTMLElement>) {

--- a/packages/core/src/responsive.test.ts
+++ b/packages/core/src/responsive.test.ts
@@ -1,15 +1,12 @@
 import { mapSpacing, Spacing, tokens } from './tokens';
-import { mapResponsiveProp, mq, ResponsiveProp } from './responsive';
+import { mapResponsiveProp, mq } from './responsive';
 
 describe('responsive prop style generation', () => {
 	test('array syntax', () => {
 		expect(
 			mq({
 				display: mapResponsiveProp(['none', 'block', null, 'flex']),
-				gap: mapResponsiveProp(
-					[0, 1, null, 2] as ResponsiveProp<Spacing>,
-					mapSpacing
-				),
+				gap: mapResponsiveProp<Spacing>([0, 1, null, 2], mapSpacing),
 			})
 		).toEqual([
 			{
@@ -24,10 +21,7 @@ describe('responsive prop style generation', () => {
 		expect(
 			mq({
 				display: mapResponsiveProp({ xs: 'none', sm: 'block', lg: 'flex' }),
-				gap: mapResponsiveProp(
-					{ xs: 0, sm: 1, lg: 2 } as ResponsiveProp<Spacing>,
-					mapSpacing
-				),
+				gap: mapResponsiveProp<Spacing>({ xs: 0, sm: 1, lg: 2 }, mapSpacing),
 			})
 		).toEqual([
 			{

--- a/packages/core/src/responsive.test.ts
+++ b/packages/core/src/responsive.test.ts
@@ -1,0 +1,41 @@
+import { mapSpacing, Spacing, tokens } from './tokens';
+import { mapResponsiveProp, mq, ResponsiveProp } from './responsive';
+
+describe('responsive prop style generation', () => {
+	test('array syntax', () => {
+		expect(
+			mq({
+				display: mapResponsiveProp(['none', 'block', null, 'flex']),
+				gap: mapResponsiveProp(
+					[0, 1, null, 2] as ResponsiveProp<Spacing>,
+					mapSpacing
+				),
+			})
+		).toEqual([
+			{
+				[tokens.mediaQuery.min.lg]: { display: 'flex', gap: '2rem' },
+				[tokens.mediaQuery.min.sm]: { display: 'block', gap: '1rem' },
+				display: 'none',
+				gap: '0rem',
+			},
+		]);
+	});
+	test('object syntax', () => {
+		expect(
+			mq({
+				display: mapResponsiveProp({ xs: 'none', sm: 'block', lg: 'flex' }),
+				gap: mapResponsiveProp(
+					{ xs: 0, sm: 1, lg: 2 } as ResponsiveProp<Spacing>,
+					mapSpacing
+				),
+			})
+		).toEqual([
+			{
+				[tokens.mediaQuery.min.lg]: { display: 'flex', gap: '2rem' },
+				[tokens.mediaQuery.min.sm]: { display: 'block', gap: '1rem' },
+				display: 'none',
+				gap: '0rem',
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Describe your changes

Added tests for  the`mq` and `mapResponsiveProp` functions in `core`, which are responsible for responsive style generation.