### PR TITLE
Fix broken Playroom links

### DIFF
--- a/docs/components/Highlight.tsx
+++ b/docs/components/Highlight.tsx
@@ -1,0 +1,81 @@
+import { css } from '@emotion/react';
+import rangeParser from 'parse-numeric-range';
+import type { Language } from 'prism-react-renderer';
+import PrismHighlight, { Prism } from 'prism-react-renderer';
+import { Box } from '@ag.ds-next/box';
+import { prismTheme } from './prism-theme';
+
+type HighlightProps = {
+	code: string;
+	language: string;
+	metastring?: string;
+};
+
+['js', 'jsx', 'ts', 'tsx'].forEach((lang) => {
+	// @ts-expect-error: Property 'insertBefore' does not exist on type 'LanguageDict'.
+	Prism.languages.insertBefore(lang, 'template-string', {
+		'gql-template-string': {
+			pattern: /gql`[^`]*`/,
+			inside: Prism.languages.graphql,
+		},
+	});
+});
+
+const getShouldHighlightLine = (meta = '') => {
+	const pattern = /{([\d,-]+)}/;
+	const result = pattern.exec(meta);
+	if (result) {
+		const lineNumbers = rangeParser(result[1]);
+		return (index: number) => lineNumbers.includes(index + 1);
+	} else {
+		return () => false;
+	}
+};
+
+export function Highlight({ code, language, metastring }: HighlightProps) {
+	const shouldHighlightLine = getShouldHighlightLine(metastring);
+	return (
+		<PrismHighlight
+			Prism={Prism}
+			theme={prismTheme}
+			code={code}
+			language={language as Language}
+		>
+			{({ tokens, getLineProps, getTokenProps }) => (
+				<Box
+					as="code"
+					css={css({
+						/**
+						 * we don't want ligatures because they look strange in lots of
+						 * cases and mess up the editor.
+						 */
+						fontFeatureSettings: 'initial',
+						MozFontFeatureSettings: 'initial',
+						minWidth: '100%',
+					})}
+				>
+					{tokens.map((line, i) => {
+						return (
+							<Box
+								key={i}
+								{...getLineProps({
+									line,
+									key: i,
+								})}
+								css={css({
+									backgroundColor: shouldHighlightLine(i)
+										? 'rgba(0,0,0,0.05)'
+										: undefined,
+								})}
+							>
+								{line.map((token, key) => (
+									<Box as="span" key={key} {...getTokenProps({ token, key })} />
+								))}
+							</Box>
+						);
+					})}
+				</Box>
+			)}
+		</PrismHighlight>
+	);
+}

--- a/docs/components/designSystemComponents.tsx
+++ b/docs/components/designSystemComponents.tsx
@@ -151,3 +151,7 @@ export {
 export { Autocomplete } from '@ag.ds-next/autocomplete';
 export { Combobox } from '@ag.ds-next/combobox';
 export { Details } from '@ag.ds-next/details';
+
+export function Render({ children }: { children: () => JSX.Element }) {
+	return children();
+}

--- a/packages/autocomplete/docs/overview.mdx
+++ b/packages/autocomplete/docs/overview.mdx
@@ -10,31 +10,29 @@ storybookPath: /story/forms-autocomplete--basic
 By default, the `Autocomplete` component does not expand to fill the available space.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Autocomplete
-			label="Find your state"
-			hint="Start typing to see results"
-			value={value}
-			onChange={(value) => setValue(value)}
-			loadOptions={async function loadOptions(inputValue) {
-				// Simulate a slow network call
-				await new Promise((resolve) => setTimeout(resolve, 3000));
-				return [
-					{ label: 'Australian Capital Territory', value: 'act' },
-					{ label: 'New South Wales', value: 'nsw' },
-					{ label: 'Northern Territory', value: 'nt' },
-					{ label: 'Queensland', value: 'qld' },
-					{ label: 'South Australia', value: 'sa' },
-					{ label: 'Tasmania', value: 'tas' },
-					{ label: 'Victoria', value: 'vic' },
-					{ label: 'Western Australia', value: 'wa' },
-				];
-			}}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Autocomplete
+		label="Find your state"
+		hint="Start typing to see results"
+		value={value}
+		onChange={(value) => setValue(value)}
+		loadOptions={async function loadOptions(inputValue) {
+			// Simulate a slow network call
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			return [
+				{ label: 'Australian Capital Territory', value: 'act' },
+				{ label: 'New South Wales', value: 'nsw' },
+				{ label: 'Northern Territory', value: 'nt' },
+				{ label: 'Queensland', value: 'qld' },
+				{ label: 'South Australia', value: 'sa' },
+				{ label: 'Tasmania', value: 'tas' },
+				{ label: 'Victoria', value: 'vic' },
+				{ label: 'Western Australia', value: 'wa' },
+			];
+		}}
+	/>
+);
 ```
 
 ### Required
@@ -42,32 +40,30 @@ By default, the `Autocomplete` component does not expand to fill the available s
 The `Autocomplete` component will always append `(optional)` to the label based on the `required` prop.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Autocomplete
-			label="Find your state"
-			hint="Start typing to see results"
-			required
-			value={value}
-			onChange={(value) => setValue(value)}
-			loadOptions={async function loadOptions(inputValue) {
-				// Simulate a slow network call
-				await new Promise((resolve) => setTimeout(resolve, 3000));
-				return [
-					{ label: 'Australian Capital Territory', value: 'act' },
-					{ label: 'New South Wales', value: 'nsw' },
-					{ label: 'Northern Territory', value: 'nt' },
-					{ label: 'Queensland', value: 'qld' },
-					{ label: 'South Australia', value: 'sa' },
-					{ label: 'Tasmania', value: 'tas' },
-					{ label: 'Victoria', value: 'vic' },
-					{ label: 'Western Australia', value: 'wa' },
-				];
-			}}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Autocomplete
+		label="Find your state"
+		hint="Start typing to see results"
+		required
+		value={value}
+		onChange={(value) => setValue(value)}
+		loadOptions={async function loadOptions(inputValue) {
+			// Simulate a slow network call
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			return [
+				{ label: 'Australian Capital Territory', value: 'act' },
+				{ label: 'New South Wales', value: 'nsw' },
+				{ label: 'Northern Territory', value: 'nt' },
+				{ label: 'Queensland', value: 'qld' },
+				{ label: 'South Australia', value: 'sa' },
+				{ label: 'Tasmania', value: 'tas' },
+				{ label: 'Victoria', value: 'vic' },
+				{ label: 'Western Australia', value: 'wa' },
+			];
+		}}
+	/>
+);
 ```
 
 ## Block
@@ -75,63 +71,59 @@ The `Autocomplete` component will always append `(optional)` to the label based 
 Use the `block` prop to expand the component to fill the available space.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Autocomplete
-			label="Find your state"
-			hint="Start typing to see results"
-			block
-			value={value}
-			onChange={(value) => setValue(value)}
-			loadOptions={async function loadOptions(inputValue) {
-				// Simulate a slow network call
-				await new Promise((resolve) => setTimeout(resolve, 3000));
-				return [
-					{ label: 'Australian Capital Territory', value: 'act' },
-					{ label: 'New South Wales', value: 'nsw' },
-					{ label: 'Northern Territory', value: 'nt' },
-					{ label: 'Queensland', value: 'qld' },
-					{ label: 'South Australia', value: 'sa' },
-					{ label: 'Tasmania', value: 'tas' },
-					{ label: 'Victoria', value: 'vic' },
-					{ label: 'Western Australia', value: 'wa' },
-				];
-			}}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Autocomplete
+		label="Find your state"
+		hint="Start typing to see results"
+		block
+		value={value}
+		onChange={(value) => setValue(value)}
+		loadOptions={async function loadOptions(inputValue) {
+			// Simulate a slow network call
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			return [
+				{ label: 'Australian Capital Territory', value: 'act' },
+				{ label: 'New South Wales', value: 'nsw' },
+				{ label: 'Northern Territory', value: 'nt' },
+				{ label: 'Queensland', value: 'qld' },
+				{ label: 'South Australia', value: 'sa' },
+				{ label: 'Tasmania', value: 'tas' },
+				{ label: 'Victoria', value: 'vic' },
+				{ label: 'Western Australia', value: 'wa' },
+			];
+		}}
+	/>
+);
 ```
 
 ## Invalid
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	const invalid = !value;
-	return (
-		<Autocomplete
-			label="Find your state"
-			hint="Start typing to see results"
-			invalid={invalid}
-			message={invalid ? 'State is required' : undefined}
-			value={value}
-			onChange={(value) => setValue(value)}
-			loadOptions={async function loadOptions(inputValue) {
-				// Simulate a slow network call
-				await new Promise((resolve) => setTimeout(resolve, 3000));
-				return [
-					{ label: 'Australian Capital Territory', value: 'act' },
-					{ label: 'New South Wales', value: 'nsw' },
-					{ label: 'Northern Territory', value: 'nt' },
-					{ label: 'Queensland', value: 'qld' },
-					{ label: 'South Australia', value: 'sa' },
-					{ label: 'Tasmania', value: 'tas' },
-					{ label: 'Victoria', value: 'vic' },
-					{ label: 'Western Australia', value: 'wa' },
-				];
-			}}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+const invalid = !value;
+return (
+	<Autocomplete
+		label="Find your state"
+		hint="Start typing to see results"
+		invalid={invalid}
+		message={invalid ? 'State is required' : undefined}
+		value={value}
+		onChange={(value) => setValue(value)}
+		loadOptions={async function loadOptions(inputValue) {
+			// Simulate a slow network call
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			return [
+				{ label: 'Australian Capital Territory', value: 'act' },
+				{ label: 'New South Wales', value: 'nsw' },
+				{ label: 'Northern Territory', value: 'nt' },
+				{ label: 'Queensland', value: 'qld' },
+				{ label: 'South Australia', value: 'sa' },
+				{ label: 'Tasmania', value: 'tas' },
+				{ label: 'Victoria', value: 'vic' },
+				{ label: 'Western Australia', value: 'wa' },
+			];
+		}}
+	/>
+);
 ```

--- a/packages/combobox/docs/overview.mdx
+++ b/packages/combobox/docs/overview.mdx
@@ -10,26 +10,24 @@ storybookPath: /story/forms-combobox--basic
 By default, the `Combobox` component does not expand to fill the available space.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Combobox
-			label="Select state"
-			value={value}
-			onChange={(value) => setValue(value)}
-			options={[
-				{ label: 'Australian Capital Territory', value: 'act' },
-				{ label: 'New South Wales', value: 'nsw' },
-				{ label: 'Northern Territory', value: 'nt' },
-				{ label: 'Queensland', value: 'qld' },
-				{ label: 'South Australia', value: 'sa' },
-				{ label: 'Tasmania', value: 'tas' },
-				{ label: 'Victoria', value: 'vic' },
-				{ label: 'Western Australia', value: 'wa' },
-			]}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Combobox
+		label="Select state"
+		value={value}
+		onChange={(value) => setValue(value)}
+		options={[
+			{ label: 'Australian Capital Territory', value: 'act' },
+			{ label: 'New South Wales', value: 'nsw' },
+			{ label: 'Northern Territory', value: 'nt' },
+			{ label: 'Queensland', value: 'qld' },
+			{ label: 'South Australia', value: 'sa' },
+			{ label: 'Tasmania', value: 'tas' },
+			{ label: 'Victoria', value: 'vic' },
+			{ label: 'Western Australia', value: 'wa' },
+		]}
+	/>
+);
 ```
 
 ## Block
@@ -37,27 +35,25 @@ By default, the `Combobox` component does not expand to fill the available space
 Use the `block` prop to expand the component to fill the available space.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Combobox
-			label="Select state"
-			block
-			value={value}
-			onChange={(value) => setValue(value)}
-			options={[
-				{ label: 'Australian Capital Territory', value: 'act' },
-				{ label: 'New South Wales', value: 'nsw' },
-				{ label: 'Northern Territory', value: 'nt' },
-				{ label: 'Queensland', value: 'qld' },
-				{ label: 'South Australia', value: 'sa' },
-				{ label: 'Tasmania', value: 'tas' },
-				{ label: 'Victoria', value: 'vic' },
-				{ label: 'Western Australia', value: 'wa' },
-			]}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Combobox
+		label="Select state"
+		block
+		value={value}
+		onChange={(value) => setValue(value)}
+		options={[
+			{ label: 'Australian Capital Territory', value: 'act' },
+			{ label: 'New South Wales', value: 'nsw' },
+			{ label: 'Northern Territory', value: 'nt' },
+			{ label: 'Queensland', value: 'qld' },
+			{ label: 'South Australia', value: 'sa' },
+			{ label: 'Tasmania', value: 'tas' },
+			{ label: 'Victoria', value: 'vic' },
+			{ label: 'Western Australia', value: 'wa' },
+		]}
+	/>
+);
 ```
 
 ## Async
@@ -65,31 +61,29 @@ Use the `block` prop to expand the component to fill the available space.
 Use the `loadOptions` prop when you need to populate options from a network request.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Combobox
-			label="Select state"
-			hint="Start typing to see results"
-			value={value}
-			onChange={(value) => setValue(value)}
-			loadOptions={async function loadOptions(inputValue) {
-				// Simulate a slow network call
-				await new Promise((resolve) => setTimeout(resolve, 3000));
-				return [
-					{ label: 'Australian Capital Territory', value: 'act' },
-					{ label: 'New South Wales', value: 'nsw' },
-					{ label: 'Northern Territory', value: 'nt' },
-					{ label: 'Queensland', value: 'qld' },
-					{ label: 'South Australia', value: 'sa' },
-					{ label: 'Tasmania', value: 'tas' },
-					{ label: 'Victoria', value: 'vic' },
-					{ label: 'Western Australia', value: 'wa' },
-				];
-			}}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Combobox
+		label="Select state"
+		hint="Start typing to see results"
+		value={value}
+		onChange={(value) => setValue(value)}
+		loadOptions={async function loadOptions(inputValue) {
+			// Simulate a slow network call
+			await new Promise((resolve) => setTimeout(resolve, 3000));
+			return [
+				{ label: 'Australian Capital Territory', value: 'act' },
+				{ label: 'New South Wales', value: 'nsw' },
+				{ label: 'Northern Territory', value: 'nt' },
+				{ label: 'Queensland', value: 'qld' },
+				{ label: 'South Australia', value: 'sa' },
+				{ label: 'Tasmania', value: 'tas' },
+				{ label: 'Victoria', value: 'vic' },
+				{ label: 'Western Australia', value: 'wa' },
+			];
+		}}
+	/>
+);
 ```
 
 ### Required
@@ -97,53 +91,49 @@ Use the `loadOptions` prop when you need to populate options from a network requ
 The `Combobox` component will always append `(optional)` to the label based on the `required` prop.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	return (
-		<Combobox
-			label="Select state"
-			required
-			value={value}
-			onChange={(value) => setValue(value)}
-			options={[
-				{ label: 'Australian Capital Territory', value: 'act' },
-				{ label: 'New South Wales', value: 'nsw' },
-				{ label: 'Northern Territory', value: 'nt' },
-				{ label: 'Queensland', value: 'qld' },
-				{ label: 'South Australia', value: 'sa' },
-				{ label: 'Tasmania', value: 'tas' },
-				{ label: 'Victoria', value: 'vic' },
-				{ label: 'Western Australia', value: 'wa' },
-			]}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+return (
+	<Combobox
+		label="Select state"
+		required
+		value={value}
+		onChange={(value) => setValue(value)}
+		options={[
+			{ label: 'Australian Capital Territory', value: 'act' },
+			{ label: 'New South Wales', value: 'nsw' },
+			{ label: 'Northern Territory', value: 'nt' },
+			{ label: 'Queensland', value: 'qld' },
+			{ label: 'South Australia', value: 'sa' },
+			{ label: 'Tasmania', value: 'tas' },
+			{ label: 'Victoria', value: 'vic' },
+			{ label: 'Western Australia', value: 'wa' },
+		]}
+	/>
+);
 ```
 
 ## Invalid
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState(null);
-	const invalid = !value;
-	return (
-		<Combobox
-			label="Select state"
-			invalid={invalid}
-			message={invalid ? 'City is required' : undefined}
-			value={value}
-			onChange={(value) => setValue(value)}
-			options={[
-				{ label: 'Australian Capital Territory', value: 'act' },
-				{ label: 'New South Wales', value: 'nsw' },
-				{ label: 'Northern Territory', value: 'nt' },
-				{ label: 'Queensland', value: 'qld' },
-				{ label: 'South Australia', value: 'sa' },
-				{ label: 'Tasmania', value: 'tas' },
-				{ label: 'Victoria', value: 'vic' },
-				{ label: 'Western Australia', value: 'wa' },
-			]}
-		/>
-	);
-};
+const [value, setValue] = React.useState(null);
+const invalid = !value;
+return (
+	<Combobox
+		label="Select state"
+		invalid={invalid}
+		message={invalid ? 'City is required' : undefined}
+		value={value}
+		onChange={(value) => setValue(value)}
+		options={[
+			{ label: 'Australian Capital Territory', value: 'act' },
+			{ label: 'New South Wales', value: 'nsw' },
+			{ label: 'Northern Territory', value: 'nt' },
+			{ label: 'Queensland', value: 'qld' },
+			{ label: 'South Australia', value: 'sa' },
+			{ label: 'Tasmania', value: 'tas' },
+			{ label: 'Victoria', value: 'vic' },
+			{ label: 'Western Australia', value: 'wa' },
+		]}
+	/>
+);
 ```

--- a/packages/control-input/docs/overview.mdx
+++ b/packages/control-input/docs/overview.mdx
@@ -21,25 +21,23 @@ Check boxes allow users to select one or more items.
 Radio inputs allow users to select one item at a time.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
-	const isChecked = (key) => key === value;
+const [value, setValue] = React.useState();
+const handlerForKey = React.useCallback((key) => () => setValue(key), []);
+const isChecked = (key) => key === value;
 
-	return (
-		<ControlGroup label="Example">
-			<Radio checked={isChecked('phone')} onChange={handlerForKey('phone')}>
-				Phone
-			</Radio>
-			<Radio checked={isChecked('tablet')} onChange={handlerForKey('tablet')}>
-				Tablet
-			</Radio>
-			<Radio checked={isChecked('laptop')} onChange={handlerForKey('laptop')}>
-				Laptop
-			</Radio>
-		</ControlGroup>
-	);
-};
+return (
+	<ControlGroup label="Example">
+		<Radio checked={isChecked('phone')} onChange={handlerForKey('phone')}>
+			Phone
+		</Radio>
+		<Radio checked={isChecked('tablet')} onChange={handlerForKey('tablet')}>
+			Tablet
+		</Radio>
+		<Radio checked={isChecked('laptop')} onChange={handlerForKey('laptop')}>
+			Laptop
+		</Radio>
+	</ControlGroup>
+);
 ```
 
 ### Checkbox block
@@ -59,25 +57,23 @@ Inline checkbox options can sometimes be difficult to scan. Users may find it ch
 Vertically stacked radio buttons.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
-	const isChecked = (key) => key === value;
+const [value, setValue] = React.useState();
+const handlerForKey = React.useCallback((key) => () => setValue(key), []);
+const isChecked = (key) => key === value;
 
-	return (
-		<ControlGroup label="Block example" block>
-			<Radio checked={isChecked('phone')} onChange={handlerForKey('phone')}>
-				Phone
-			</Radio>
-			<Radio checked={isChecked('tablet')} onChange={handlerForKey('tablet')}>
-				Tablet
-			</Radio>
-			<Radio checked={isChecked('laptop')} onChange={handlerForKey('laptop')}>
-				Laptop
-			</Radio>
-		</ControlGroup>
-	);
-};
+return (
+	<ControlGroup label="Block example" block>
+		<Radio checked={isChecked('phone')} onChange={handlerForKey('phone')}>
+			Phone
+		</Radio>
+		<Radio checked={isChecked('tablet')} onChange={handlerForKey('tablet')}>
+			Tablet
+		</Radio>
+		<Radio checked={isChecked('laptop')} onChange={handlerForKey('laptop')}>
+			Laptop
+		</Radio>
+	</ControlGroup>
+);
 ```
 
 ### Valid and invalid states
@@ -85,71 +81,63 @@ Vertically stacked radio buttons.
 Add a border around the control inputs to indicate valid or invalid selections.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
-	const isChecked = (key) => key === value;
+const [value, setValue] = React.useState();
+const handlerForKey = React.useCallback((key) => () => setValue(key), []);
+const isChecked = (key) => key === value;
 
-	return (
-		<ControlGroup label="Invalid example" message="Select an option" invalid>
-			<Radio
-				checked={isChecked('phone')}
-				onChange={handlerForKey('phone')}
-				invalid
-			>
-				Phone
-			</Radio>
-			<Radio
-				checked={isChecked('tablet')}
-				onChange={handlerForKey('tablet')}
-				invalid
-			>
-				Tablet
-			</Radio>
-			<Radio
-				checked={isChecked('laptop')}
-				onChange={handlerForKey('laptop')}
-				invalid
-			>
-				Laptop
-			</Radio>
-		</ControlGroup>
-	);
-};
+return (
+	<ControlGroup label="Invalid example" message="Select an option" invalid>
+		<Radio
+			checked={isChecked('phone')}
+			onChange={handlerForKey('phone')}
+			invalid
+		>
+			Phone
+		</Radio>
+		<Radio
+			checked={isChecked('tablet')}
+			onChange={handlerForKey('tablet')}
+			invalid
+		>
+			Tablet
+		</Radio>
+		<Radio
+			checked={isChecked('laptop')}
+			onChange={handlerForKey('laptop')}
+			invalid
+		>
+			Laptop
+		</Radio>
+	</ControlGroup>
+);
 ```
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
-	const isChecked = (key) => key === value;
+const [value, setValue] = React.useState();
+const handlerForKey = React.useCallback((key) => () => setValue(key), []);
+const isChecked = (key) => key === value;
 
-	return (
-		<ControlGroup label="Valid example" valid>
-			<Radio
-				checked={isChecked('phone')}
-				onChange={handlerForKey('phone')}
-				valid
-			>
-				Phone
-			</Radio>
-			<Radio
-				checked={isChecked('tablet')}
-				onChange={handlerForKey('tablet')}
-				valid
-			>
-				Tablet
-			</Radio>
-			<Radio
-				checked={isChecked('laptop')}
-				onChange={handlerForKey('laptop')}
-				valid
-			>
-				Laptop
-			</Radio>
-		</ControlGroup>
-	);
-};
+return (
+	<ControlGroup label="Valid example" valid>
+		<Radio checked={isChecked('phone')} onChange={handlerForKey('phone')} valid>
+			Phone
+		</Radio>
+		<Radio
+			checked={isChecked('tablet')}
+			onChange={handlerForKey('tablet')}
+			valid
+		>
+			Tablet
+		</Radio>
+		<Radio
+			checked={isChecked('laptop')}
+			onChange={handlerForKey('laptop')}
+			valid
+		>
+			Laptop
+		</Radio>
+	</ControlGroup>
+);
 ```
 
 ### Disabled control inputs

--- a/packages/date-picker/docs/overview.mdx
+++ b/packages/date-picker/docs/overview.mdx
@@ -12,10 +12,8 @@ storybookPath: /story/forms-datepicker-datepicker--basic
 ### Basic
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return <DatePicker label="Select date" value={value} onChange={setValue} />;
-};
+const [value, setValue] = React.useState();
+return <DatePicker label="Select date" value={value} onChange={setValue} />;
 ```
 
 ### Block
@@ -23,12 +21,10 @@ storybookPath: /story/forms-datepicker-datepicker--basic
 Use the `block` prop to expand the component to fill the available space.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker label="Select date" value={value} onChange={setValue} block />
-	);
-};
+const [value, setValue] = React.useState();
+return (
+	<DatePicker label="Select date" value={value} onChange={setValue} block />
+);
 ```
 
 ### Valid and invalid inputs
@@ -36,21 +32,19 @@ Use the `block` prop to expand the component to fill the available space.
 Use the `invalid` and `valid` props to indicate whether user input is valid (validates according to the elements settings) or invalid (does not validate according to the elements settings).
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<Stack gap={1}>
-			<DatePicker
-				label="Invalid"
-				invalid
-				message="This input is invalid"
-				value={value}
-				onChange={setValue}
-			/>
-			<DatePicker label="Valid" valid value={value} onChange={setValue} />
-		</Stack>
-	);
-};
+const [value, setValue] = React.useState();
+return (
+	<Stack gap={1}>
+		<DatePicker
+			label="Invalid"
+			invalid
+			message="This input is invalid"
+			value={value}
+			onChange={setValue}
+		/>
+		<DatePicker label="Valid" valid value={value} onChange={setValue} />
+	</Stack>
+);
 ```
 
 ### Disabled
@@ -58,17 +52,10 @@ Use the `invalid` and `valid` props to indicate whether user input is valid (val
 Disabled input elements are unusable and can not be clicked. This prevents a user from interacting with the input element until another action is complete.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	return (
-		<DatePicker
-			label="Select date"
-			value={value}
-			onChange={setValue}
-			disabled
-		/>
-	);
-};
+const [value, setValue] = React.useState();
+return (
+	<DatePicker label="Select date" value={value} onChange={setValue} disabled />
+);
 ```
 
 ### Minimum and maximum dates
@@ -80,23 +67,21 @@ The `maxDate` property can be used to disable any days after a specific date.
 If a valid date is entered using the text input but it falls outside the constrained range, the closest valid date will be used.
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState();
+const [value, setValue] = React.useState();
 
-	const today = new Date();
-	const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
-	const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+const today = new Date();
+const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
 
-	return (
-		<DatePicker
-			label="Select date"
-			minDate={lastWeek}
-			maxDate={nextWeek}
-			value={value}
-			onChange={setValue}
-		/>
-	);
-};
+return (
+	<DatePicker
+		label="Select date"
+		minDate={lastWeek}
+		maxDate={nextWeek}
+		value={value}
+		onChange={setValue}
+	/>
+);
 ```
 
 ## Date Range Picker
@@ -106,54 +91,46 @@ If a valid date is entered using the text input but it falls outside the constra
 ### Basic
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState({ from: undefined, to: undefined });
-	return <DateRangePicker value={value} onChange={setValue} />;
-};
+const [value, setValue] = React.useState({ from: undefined, to: undefined });
+return <DateRangePicker value={value} onChange={setValue} />;
 ```
 
 ### Labels
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState({ from: undefined, to: undefined });
-	return (
-		<DateRangePicker
-			value={value}
-			onChange={setValue}
-			fromLabel="From"
-			toLabel="To"
-		/>
-	);
-};
+const [value, setValue] = React.useState({ from: undefined, to: undefined });
+return (
+	<DateRangePicker
+		value={value}
+		onChange={setValue}
+		fromLabel="From"
+		toLabel="To"
+	/>
+);
 ```
 
 ### Disabled
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState({ from: undefined, to: undefined });
-	return <DateRangePicker value={value} onChange={setValue} disabled />;
-};
+const [value, setValue] = React.useState({ from: undefined, to: undefined });
+return <DateRangePicker value={value} onChange={setValue} disabled />;
 ```
 
 ### Minimum and maximum dates
 
 ```jsx live
-() => {
-	const [value, setValue] = React.useState({ from: undefined, to: undefined });
+const [value, setValue] = React.useState({ from: undefined, to: undefined });
 
-	const today = new Date();
-	const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
-	const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
+const today = new Date();
+const lastWeek = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+const nextWeek = new Date(today.getTime() + 7 * 24 * 60 * 60 * 1000);
 
-	return (
-		<DateRangePicker
-			value={value}
-			onChange={setValue}
-			minDate={lastWeek}
-			maxDate={nextWeek}
-		/>
-	);
-};
+return (
+	<DateRangePicker
+		value={value}
+		onChange={setValue}
+		minDate={lastWeek}
+		maxDate={nextWeek}
+	/>
+);
 ```

--- a/packages/file-upload/docs/overview.mdx
+++ b/packages/file-upload/docs/overview.mdx
@@ -52,30 +52,28 @@ In this example, the file is instantly uploaded to a file hosting service, and t
 `FileUpload` component allows you to indicate the status of an upload via a `file.status` property.
 
 ```jsx live
-() => {
-	const uploadingFile = new File(['this is an example file'], 'example.jpg', {
+const uploadingFile = new File(['this is an example file'], 'example.jpg', {
+	type: 'image/jpg',
+});
+uploadingFile.status = 'uploading';
+const uploadedFile = new File(
+	['this is another example file that has uploaded'],
+	'example.jpg',
+	{
 		type: 'image/jpg',
-	});
-	uploadingFile.status = 'uploading';
-	const uploadedFile = new File(
-		['this is another example file that has uploaded'],
-		'example.jpg',
-		{
-			type: 'image/jpg',
-		}
-	);
-	uploadedFile.status = 'success';
-	return (
-		<FileUpload
-			label="Avatar image"
-			hint="Formats accepted: .png, .jpg."
-			multiple={false}
-			accept={['image/jpeg', 'image/jpg', 'image/png']}
-			value={[uploadedFile, uploadingFile]}
-			onChange={console.log}
-		/>
-	);
-};
+	}
+);
+uploadedFile.status = 'success';
+return (
+	<FileUpload
+		label="Avatar image"
+		hint="Formats accepted: .png, .jpg."
+		multiple={false}
+		accept={['image/jpeg', 'image/jpg', 'image/png']}
+		value={[uploadedFile, uploadingFile]}
+		onChange={console.log}
+	/>
+);
 ```
 
 ---

--- a/packages/modal/docs/overview.mdx
+++ b/packages/modal/docs/overview.mdx
@@ -10,34 +10,32 @@ Modals are ideal for prompting a user to confirm a destructive action.
 For other uses, other patterns are preferred.
 
 ```jsx live
-() => {
-	const [isModalOpen, openModal, closeModal] = useTernaryState(false);
-	return (
-		<React.Fragment>
-			<Button onClick={openModal}>Open modal</Button>
-			<Modal
-				isOpen={isModalOpen}
-				onDismiss={closeModal}
-				title="This is the title of the modal dialogue, it can span lines but should not be too long."
-				actions={
-					<ButtonGroup>
-						<Button onClick={closeModal}>Primary button</Button>
-						<Button variant="secondary" onClick={closeModal}>
-							Secondary button
-						</Button>
-						<Button variant="tertiary" onClick={closeModal}>
-							Tertiary button
-						</Button>
-					</ButtonGroup>
-				}
-			>
-				<Text as="p">
-					This is the Modal Body paragraph, it provides detailed instruction and
-					context for the the modal action. It can also span lines but long form
-					content should be avoided.
-				</Text>
-			</Modal>
-		</React.Fragment>
-	);
-};
+const [isModalOpen, openModal, closeModal] = useTernaryState(false);
+return (
+	<React.Fragment>
+		<Button onClick={openModal}>Open modal</Button>
+		<Modal
+			isOpen={isModalOpen}
+			onDismiss={closeModal}
+			title="This is the title of the modal dialogue, it can span lines but should not be too long."
+			actions={
+				<ButtonGroup>
+					<Button onClick={closeModal}>Primary button</Button>
+					<Button variant="secondary" onClick={closeModal}>
+						Secondary button
+					</Button>
+					<Button variant="tertiary" onClick={closeModal}>
+						Tertiary button
+					</Button>
+				</ButtonGroup>
+			}
+		>
+			<Text as="p">
+				This is the Modal Body paragraph, it provides detailed instruction and
+				context for the the modal action. It can also span lines but long form
+				content should be avoided.
+			</Text>
+		</Modal>
+	</React.Fragment>
+);
 ```

--- a/packages/pagination/docs/overview.mdx
+++ b/packages/pagination/docs/overview.mdx
@@ -28,14 +28,12 @@ This requires you to manage the state of the current page in the URL, which usua
 `PaginationButtons` renders a button element for each list item which makes it possible to manage the state outside of the URL, e.g. `React.useState`.
 
 ```jsx live
-() => {
-	const [currentPage, setCurrentPage] = React.useState(5);
-	return (
-		<PaginationButtons
-			currentPage={currentPage}
-			onChange={setCurrentPage}
-			totalPages={10}
-		/>
-	);
-};
+const [currentPage, setCurrentPage] = React.useState(5);
+return (
+	<PaginationButtons
+		currentPage={currentPage}
+		onChange={setCurrentPage}
+		totalPages={10}
+	/>
+);
 ```

--- a/packages/switch/docs/overview.mdx
+++ b/packages/switch/docs/overview.mdx
@@ -12,16 +12,14 @@ A Switch should not be used in Forms, or where a submit button is needed. Instea
 `Switch` is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components).
 
 ```jsx live
-() => {
-	const [isChecked, setChecked] = React.useState(false);
-	return (
-		<Switch
-			label="Show establishments"
-			checked={isChecked}
-			onChange={setChecked}
-		/>
-	);
-};
+const [isChecked, setChecked] = React.useState(false);
+return (
+	<Switch
+		label="Show establishments"
+		checked={isChecked}
+		onChange={setChecked}
+	/>
+);
 ```
 
 ## Size
@@ -29,15 +27,13 @@ A Switch should not be used in Forms, or where a submit button is needed. Instea
 Control size can be changed using the `size` prop.
 
 ```jsx live
-() => {
-	const [isChecked, setChecked] = React.useState(false);
-	return (
-		<Switch
-			label="Small Switch"
-			checked={isChecked}
-			onChange={setChecked}
-			size="sm"
-		/>
-	);
-};
+const [isChecked, setChecked] = React.useState(false);
+return (
+	<Switch
+		label="Small Switch"
+		checked={isChecked}
+		onChange={setChecked}
+		size="sm"
+	/>
+);
 ```


### PR DESCRIPTION
## Describe your changes

**WIP**

The Playroom links for examples that weren't just a simple component (e.g. with state) didn't work.

This PR fixes that by wrapping code with a component called `Render` that looks like this:
```tsx
export function Render({ children }: { children: () => JSX.Element }) {
	return children();
}
```

When the code examples are wrapped, it looks like this:

```tsx
<Render>
  {() => {
    // example code goes here
  }}
</Render>
```

---

The current state of the code _mostly_ works, but to get the errors to work properly, it looks like we might have to hand-roll some of the code instead of using the components that come from the `react-live` package.
