### PR TITLE
DatePicker: Update accessible text for opening calendar

### DIFF
--- a/.changeset/nasty-wombats-guess.md
+++ b/.changeset/nasty-wombats-guess.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/date-picker': patch
+---
+
+Update accessible text for opening calendar

--- a/packages/date-picker/src/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput.tsx
@@ -44,10 +44,10 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 		};
 
 		const ariaLabel = useMemo(() => {
-			if (typeof value !== 'string') return 'Choose date';
+			if (typeof value !== 'string') return 'Open calendar picker';
 			const parsed = parseDate(value);
-			if (!parsed) return 'Choose date';
-			return `Change Date, ${formatHumanReadableDate(parsed)}`;
+			if (!parsed) return 'Open calendar picker';
+			return `Open calendar picker, ${formatHumanReadableDate(parsed)}`;
 		}, [value]);
 
 		return (

--- a/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`DatePicker renders correctly 1`] = `
           value="01/01/2000"
         />
         <button
-          aria-label="Change Date, Saturday January 1st, 2000"
+          aria-label="Open calendar picker, Saturday January 1st, 2000"
           class="css-iya2bc-BaseButton-DateInput"
           type="button"
         >

--- a/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             value="01/01/2000"
           />
           <button
-            aria-label="Change Date, Saturday January 1st, 2000"
+            aria-label="Open calendar picker, Saturday January 1st, 2000"
             class="css-iya2bc-BaseButton-DateInput"
             type="button"
           >
@@ -107,7 +107,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             value="02/01/2000"
           />
           <button
-            aria-label="Change Date, Sunday January 2nd, 2000"
+            aria-label="Open calendar picker, Sunday January 2nd, 2000"
             class="css-iya2bc-BaseButton-DateInput"
             type="button"
           >


### PR DESCRIPTION
## Describe your changes

On the button that opens the calendar in DatePicker, we are changing the accessible label from "Choose date" to "Open calendar picker"

## Checklist

- [x] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
