### PR TITLE
PR checklist: Add run test and update snapshots as a checklist item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@ Include screenshots, photos or links if necessary.
 - [ ] Read and check your code before tagging someone for review.
 - [ ] Run `yarn format`
 - [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
+- [ ] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
 - [ ] Add necessary tests
 - [ ] Run `yarn changeset` to create a changeset file
 - [ ] Write documentation (README.md)


### PR DESCRIPTION
## Describe your changes

Now that our tests are getting more useful, we should be running `yarn test` to ensure snapshots are still passing.