### PR TITLE
Add more tests for form fields

### DIFF
--- a/.changeset/nine-spies-design.md
+++ b/.changeset/nine-spies-design.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/date-picker': patch
+---
+
+Add default `type` to input field

--- a/.changeset/ninety-pumas-cry.md
+++ b/.changeset/ninety-pumas-cry.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text-input': patch
+---
+
+Set a default value of the `type` prop to `text`

--- a/packages/date-picker/src/DatePicker.test.tsx
+++ b/packages/date-picker/src/DatePicker.test.tsx
@@ -5,13 +5,13 @@ import { DatePicker, DatePickerProps } from './DatePicker';
 
 afterEach(cleanup);
 
-function renderDetail(props: DatePickerProps) {
+function renderDatePicker(props: DatePickerProps) {
 	return render(<DatePicker {...props} />);
 }
 
 describe('DatePicker', () => {
 	it('renders correctly', () => {
-		const { container } = renderDetail({
+		const { container } = renderDatePicker({
 			label: 'Example',
 			value: new Date('2000-01-01'),
 			onChange: console.log,
@@ -20,7 +20,7 @@ describe('DatePicker', () => {
 	});
 
 	it('renders a valid HTML structure', () => {
-		const { container } = renderDetail({
+		const { container } = renderDatePicker({
 			label: 'Example',
 			value: new Date('2000-01-01'),
 			onChange: console.log,

--- a/packages/date-picker/src/DatePicker.test.tsx
+++ b/packages/date-picker/src/DatePicker.test.tsx
@@ -10,17 +10,21 @@ function renderDetail(props: DatePickerProps) {
 }
 
 describe('DatePicker', () => {
-	const { container } = renderDetail({
-		label: 'Example',
-		value: new Date('2000-01-01'),
-		onChange: console.log,
-	});
-
 	it('renders correctly', () => {
+		const { container } = renderDetail({
+			label: 'Example',
+			value: new Date('2000-01-01'),
+			onChange: console.log,
+		});
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
+		const { container } = renderDetail({
+			label: 'Example',
+			value: new Date('2000-01-01'),
+			onChange: console.log,
+		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 		});

--- a/packages/date-picker/src/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput.tsx
@@ -65,6 +65,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 					<Flex alignItems="flex-end" css={{ maxWidth }}>
 						<input
 							ref={ref}
+							type="text"
 							css={{ ...styles, maxWidth: 'unset' }}
 							{...a11yProps}
 							{...props}

--- a/packages/date-picker/src/DateRangePicker.test.tsx
+++ b/packages/date-picker/src/DateRangePicker.test.tsx
@@ -10,18 +10,23 @@ function renderDetail(props: DateRangePickerProps) {
 }
 
 describe('DateRangePicker', () => {
-	const { container } = renderDetail({
-		value: { from: new Date('2000-01-01'), to: new Date('2000-01-02') },
-		onChange: console.log,
-	});
-
 	it('renders correctly', () => {
+		const { container } = renderDetail({
+			value: { from: new Date('2000-01-01'), to: new Date('2000-01-02') },
+			onChange: console.log,
+		});
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
+		const { container } = renderDetail({
+			value: { from: new Date('2000-01-01'), to: new Date('2000-01-02') },
+			onChange: console.log,
+		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+			// We use a deterministic mock ID in tests
+			rules: { 'no-dup-id': 'off' },
 		});
 	});
 });

--- a/packages/date-picker/src/DateRangePicker.test.tsx
+++ b/packages/date-picker/src/DateRangePicker.test.tsx
@@ -5,13 +5,13 @@ import { DateRangePicker, DateRangePickerProps } from './DateRangePicker';
 
 afterEach(cleanup);
 
-function renderDetail(props: DateRangePickerProps) {
+function renderDateRangePicker(props: DateRangePickerProps) {
 	return render(<DateRangePicker {...props} />);
 }
 
 describe('DateRangePicker', () => {
 	it('renders correctly', () => {
-		const { container } = renderDetail({
+		const { container } = renderDateRangePicker({
 			value: { from: new Date('2000-01-01'), to: new Date('2000-01-02') },
 			onChange: console.log,
 		});
@@ -19,7 +19,7 @@ describe('DateRangePicker', () => {
 	});
 
 	it('renders a valid HTML structure', () => {
-		const { container } = renderDetail({
+		const { container } = renderDateRangePicker({
 			value: { from: new Date('2000-01-01'), to: new Date('2000-01-02') },
 			onChange: console.log,
 		});

--- a/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`DatePicker renders correctly 1`] = `
           aria-required="false"
           class="css-qcwla-DateInput"
           id="field-mockId"
+          type="text"
           value="01/01/2000"
         />
         <button

--- a/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             aria-required="false"
             class="css-qcwla-DateInput"
             id="field-mockId"
+            type="text"
             value="01/01/2000"
           />
           <button
@@ -104,6 +105,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             aria-required="false"
             class="css-qcwla-DateInput"
             id="field-mockId"
+            type="text"
             value="02/01/2000"
           />
           <button

--- a/packages/details/src/Details.test.tsx
+++ b/packages/details/src/Details.test.tsx
@@ -12,21 +12,29 @@ function renderDetail(props: DetailsProps) {
 }
 
 describe('Details', () => {
-	const { container } = renderDetail({
-		label: 'Details',
-		children: (
-			<Text as="p">
-				This is a small paragraph of text that is supplementary to the main page
-				content.
-			</Text>
-		),
-	});
-
 	it('renders correctly', () => {
+		const { container } = renderDetail({
+			label: 'Details',
+			children: (
+				<Text as="p">
+					This is a small paragraph of text that is supplementary to the main
+					page content.
+				</Text>
+			),
+		});
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
+		const { container } = renderDetail({
+			label: 'Details',
+			children: (
+				<Text as="p">
+					This is a small paragraph of text that is supplementary to the main
+					page content.
+				</Text>
+			),
+		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 		});

--- a/packages/field/src/Field.test.tsx
+++ b/packages/field/src/Field.test.tsx
@@ -89,7 +89,7 @@ describe('Field', () => {
 	});
 
 	describe('FieldLabel', () => {
-		it.only('renders correctly when optional', () => {
+		it('renders correctly when optional', () => {
 			renderField({ required: false });
 			const labelEl = screen.getByText('Name')
 				.parentElement as HTMLLabelElement;

--- a/packages/field/src/Field.test.tsx
+++ b/packages/field/src/Field.test.tsx
@@ -1,32 +1,131 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { cleanup, render } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { Field, FieldProps } from './Field';
 
-function renderField(props: FieldProps) {
-	return render(<Field {...props} />);
+function renderField({
+	label = 'Name',
+	hint = undefined,
+	message = undefined,
+	required = true,
+	invalid = true,
+	valid = undefined,
+	children = (a11yProps) => (
+		<input data-testid="example-input" type="text" {...a11yProps} />
+	),
+	...props
+}: Partial<FieldProps>) {
+	return render(
+		<Field
+			label={label}
+			hint={hint}
+			message={message}
+			required={required}
+			invalid={invalid}
+			valid={valid}
+			{...props}
+		>
+			{children}
+		</Field>
+	);
 }
 
 afterEach(cleanup);
 
 describe('Field', () => {
-	const { container } = renderField({
-		label: 'Name',
-		hint: 'Hint text',
-		message: 'This field is required',
-		required: true,
-		invalid: true,
-		valid: undefined,
-		children: (a11yProps) => <input type="text" {...a11yProps} />,
-	});
-
 	it('renders correctly', () => {
+		const { container } = renderField({
+			label: 'Name',
+			hint: 'Hint text',
+			message: 'This field is required',
+			invalid: true,
+		});
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
+		const { container } = renderField({
+			label: 'Name',
+			hint: 'Hint text',
+			message: 'This field is required',
+			invalid: true,
+		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+		});
+	});
+
+	it('automatically generates an ID if no ID is provided', () => {
+		renderField({});
+		const id = screen.getByTestId('example-input').id;
+		const labelEl = screen.getByText('Name').parentElement as HTMLLabelElement;
+		const inputEl = screen.getByTestId('example-input');
+		expect(labelEl.htmlFor).toBe(id);
+		expect(inputEl.id).toBe(id);
+	});
+
+	it('uses ID prop if provided ', () => {
+		renderField({ id: 'name' });
+		const labelEl = screen.getByText('Name').parentElement as HTMLLabelElement;
+		const inputEl = screen.getByTestId('example-input');
+		expect(labelEl.htmlFor).toBe('name');
+		expect(inputEl.id).toBe('name');
+	});
+
+	it('provides the correct a11y props', () => {
+		const label = 'Name';
+		const hint = 'Hint text';
+		const message = 'This field is required';
+		renderField({ label, hint, message, invalid: true });
+		const labelEl = screen.getByText(label).parentElement as HTMLLabelElement;
+		const hintEl = screen.getByText(hint);
+		const messageEl = screen.getByText(message);
+		const inputEl = screen.getByTestId('example-input');
+		expect(inputEl.getAttribute('aria-required')).toBe('true');
+		expect(inputEl.getAttribute('aria-describedby')).toBe(
+			[messageEl.id, hintEl.id].join(' ')
+		);
+		expect(inputEl.id).toBe(labelEl.htmlFor);
+	});
+
+	describe('FieldLabel', () => {
+		it.only('renders correctly when optional', () => {
+			renderField({ required: false });
+			const labelEl = screen.getByText('Name')
+				.parentElement as HTMLLabelElement;
+			expect(labelEl).toBeInTheDocument();
+			expect(labelEl).toHaveTextContent('Name(optional)');
+		});
+		it('renders correctly when required', () => {
+			renderField({ required: true });
+			const labelEl = screen.getByText('Name')
+				.parentElement as HTMLLabelElement;
+			expect(labelEl).toBeInTheDocument();
+			expect(labelEl).toHaveTextContent('Name');
+		});
+	});
+
+	describe('FieldHint', () => {
+		it('renders correctly', () => {
+			const hint = 'Hint text';
+			renderField({ hint });
+			const hintEl = screen.getByText(hint);
+			const inputEl = screen.getByTestId('example-input');
+			expect(hintEl).toBeInTheDocument();
+			expect(hintEl).toHaveTextContent(hint);
+			expect(inputEl.getAttribute('aria-describedby')).toBe(hintEl.id);
+		});
+	});
+
+	describe('FieldMessage', () => {
+		it('renders correctly', () => {
+			const message = 'This field is required';
+			renderField({ message, invalid: true });
+			const messageEl = screen.getByText(message);
+			const inputEl = screen.getByTestId('example-input');
+			expect(messageEl).toBeInTheDocument();
+			expect(messageEl).toHaveTextContent(message);
+			expect(inputEl.getAttribute('aria-describedby')).toBe(messageEl.id);
 		});
 	});
 });

--- a/packages/field/src/Field.test.tsx
+++ b/packages/field/src/Field.test.tsx
@@ -57,11 +57,10 @@ describe('Field', () => {
 
 	it('automatically generates an ID if no ID is provided', () => {
 		renderField({});
-		const id = screen.getByTestId('example-input').id;
-		const labelEl = screen.getByText('Name').parentElement as HTMLLabelElement;
 		const inputEl = screen.getByTestId('example-input');
+		const labelEl = screen.getByText('Name').parentElement as HTMLLabelElement;
+		const id = inputEl.id;
 		expect(labelEl.htmlFor).toBe(id);
-		expect(inputEl.id).toBe(id);
 	});
 
 	it('uses ID prop if provided ', () => {

--- a/packages/field/src/__snapshots__/Field.test.tsx.snap
+++ b/packages/field/src/__snapshots__/Field.test.tsx.snap
@@ -59,6 +59,7 @@ exports[`Field renders correctly 1`] = `
       aria-describedby="field-mockId-message field-mockId-hint"
       aria-invalid="true"
       aria-required="true"
+      data-testid="example-input"
       id="field-mockId"
       type="text"
     />

--- a/packages/search-box/src/Search.test.tsx
+++ b/packages/search-box/src/Search.test.tsx
@@ -17,13 +17,14 @@ function renderSearch() {
 }
 
 describe('SearchBox', () => {
-	const { container } = renderSearch();
-
 	it('renders correctly', () => {
+		const { container } = renderSearch();
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
+		const { container } = renderSearch();
+
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 		});

--- a/packages/text-input/src/TextInput.test.tsx
+++ b/packages/text-input/src/TextInput.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import 'html-validate/jest';
+import { cleanup, render } from '@testing-library/react';
+import { TextInput, TextInputProps } from './TextInput';
+
+afterEach(cleanup);
+
+function renderTextInput(props: TextInputProps) {
+	return render(<TextInput {...props} />);
+}
+
+describe('TextInput', () => {
+	it('renders correctly', () => {
+		const { container } = renderTextInput({
+			label: 'Name',
+			hint: 'Hint text',
+			message: 'This field is required',
+			invalid: true,
+		});
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders a valid HTML structure', () => {
+		const { container } = renderTextInput({
+			label: 'Name',
+			hint: 'Hint text',
+			message: 'This field is required',
+			invalid: true,
+		});
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
+		});
+	});
+});

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -51,6 +51,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			block,
 			maxWidth,
 			id,
+			type = 'text',
 			...props
 		},
 		ref
@@ -67,7 +68,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 				id={id}
 			>
 				{(a11yProps) => (
-					<input ref={ref} css={styles} {...a11yProps} {...props} />
+					<input ref={ref} css={styles} {...a11yProps} type={type} {...props} />
 				)}
 			</Field>
 		);

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextInput renders correctly 1`] = `
+<div>
+  <div
+    class="css-1n67ua0-boxStyles-FieldContainer"
+  >
+    <label
+      class="css-n7rdvo-boxStyles"
+      for="field-mockId"
+    >
+      <span
+        class="css-433uqb-boxStyles-Text"
+      >
+        Name
+      </span>
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
+      >
+        (optional)
+      </span>
+    </label>
+    <span
+      class="css-lw0v8u-boxStyles-Text"
+      id="field-mockId-hint"
+    >
+      Hint text
+    </span>
+    <div
+      class="css-1xkbxzi-boxStyles"
+    >
+      <div
+        class="css-1ldvxqr-boxStyles"
+      >
+        <svg
+          aria-hidden="false"
+          aria-label="Error"
+          class="css-vnv4i8-Icon-FieldMessage"
+          clip-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M16.4661 0.5C16.7332 0.5 16.9893 0.6069 17.1771 0.796862L23.2111 6.89871C23.3962 7.08591 23.5 7.33857 23.5 7.60185V16.3935C23.5 16.6595 23.394 16.9146 23.2055 17.1023L17.0712 23.2087C16.8838 23.3953 16.6301 23.5 16.3657 23.5H7.63889C7.37177 23.5 7.11576 23.3931 6.92792 23.2032L0.789033 16.9968C0.60386 16.8095 0.5 16.5569 0.5 16.2935V7.60646C0.5 7.34045 0.605983 7.08541 0.794505 6.89774L6.92885 0.791284C7.11625 0.604732 7.36991 0.5 7.63434 0.5H16.4661ZM16.7071 7.29289C17.0976 7.68342 17.0976 8.31658 16.7071 8.70711L13.4142 12L16.7071 15.2929C17.0976 15.6834 17.0976 16.3166 16.7071 16.7071C16.3166 17.0976 15.6834 17.0976 15.2929 16.7071L12 13.4142L8.70711 16.7071C8.31658 17.0976 7.68342 17.0976 7.29289 16.7071C6.90237 16.3166 6.90237 15.6834 7.29289 15.2929L10.5858 12L7.29289 8.70711C6.90237 8.31658 6.90237 7.68342 7.29289 7.29289C7.68342 6.90237 8.31658 6.90237 8.70711 7.29289L12 10.5858L15.2929 7.29289C15.6834 6.90237 16.3166 6.90237 16.7071 7.29289Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+            stroke="none"
+          />
+        </svg>
+      </div>
+      <span
+        class="css-tfsyf8-boxStyles-Text"
+        id="field-mockId-message"
+      >
+        This field is required
+      </span>
+    </div>
+    <input
+      aria-describedby="field-mockId-message field-mockId-hint"
+      aria-invalid="true"
+      aria-required="false"
+      class="css-b9h5aa-Field"
+      id="field-mockId"
+    />
+  </div>
+</div>
+`;

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -66,6 +66,7 @@ exports[`TextInput renders correctly 1`] = `
       aria-required="false"
       class="css-b9h5aa-Field"
       id="field-mockId"
+      type="text"
     />
   </div>
 </div>

--- a/packages/textarea/src/Textarea.test.tsx
+++ b/packages/textarea/src/Textarea.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom';
+import 'html-validate/jest';
+import { cleanup, render } from '@testing-library/react';
+import { Textarea, TextareaProps } from './Textarea';
+
+afterEach(cleanup);
+
+function renderTextarea(props: TextareaProps) {
+	return render(<Textarea {...props} />);
+}
+
+describe('Textarea', () => {
+	it('renders correctly', () => {
+		const { container } = renderTextarea({
+			label: 'Name',
+			hint: 'Hint text',
+			message: 'This field is required',
+			invalid: true,
+		});
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders a valid HTML structure', () => {
+		const { container } = renderTextarea({
+			label: 'Name',
+			hint: 'Hint text',
+			message: 'This field is required',
+			invalid: true,
+		});
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
+		});
+	});
+});

--- a/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Textarea renders correctly 1`] = `
+<div>
+  <div
+    class="css-1n67ua0-boxStyles-FieldContainer"
+  >
+    <label
+      class="css-n7rdvo-boxStyles"
+      for="field-mockId"
+    >
+      <span
+        class="css-433uqb-boxStyles-Text"
+      >
+        Name
+      </span>
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
+      >
+        (optional)
+      </span>
+    </label>
+    <span
+      class="css-lw0v8u-boxStyles-Text"
+      id="field-mockId-hint"
+    >
+      Hint text
+    </span>
+    <div
+      class="css-1xkbxzi-boxStyles"
+    >
+      <div
+        class="css-1ldvxqr-boxStyles"
+      >
+        <svg
+          aria-hidden="false"
+          aria-label="Error"
+          class="css-vnv4i8-Icon-FieldMessage"
+          clip-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M16.4661 0.5C16.7332 0.5 16.9893 0.6069 17.1771 0.796862L23.2111 6.89871C23.3962 7.08591 23.5 7.33857 23.5 7.60185V16.3935C23.5 16.6595 23.394 16.9146 23.2055 17.1023L17.0712 23.2087C16.8838 23.3953 16.6301 23.5 16.3657 23.5H7.63889C7.37177 23.5 7.11576 23.3931 6.92792 23.2032L0.789033 16.9968C0.60386 16.8095 0.5 16.5569 0.5 16.2935V7.60646C0.5 7.34045 0.605983 7.08541 0.794505 6.89774L6.92885 0.791284C7.11625 0.604732 7.36991 0.5 7.63434 0.5H16.4661ZM16.7071 7.29289C17.0976 7.68342 17.0976 8.31658 16.7071 8.70711L13.4142 12L16.7071 15.2929C17.0976 15.6834 17.0976 16.3166 16.7071 16.7071C16.3166 17.0976 15.6834 17.0976 15.2929 16.7071L12 13.4142L8.70711 16.7071C8.31658 17.0976 7.68342 17.0976 7.29289 16.7071C6.90237 16.3166 6.90237 15.6834 7.29289 15.2929L10.5858 12L7.29289 8.70711C6.90237 8.31658 6.90237 7.68342 7.29289 7.29289C7.68342 6.90237 8.31658 6.90237 8.70711 7.29289L12 10.5858L15.2929 7.29289C15.6834 6.90237 16.3166 6.90237 16.7071 7.29289Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+            stroke="none"
+          />
+        </svg>
+      </div>
+      <span
+        class="css-tfsyf8-boxStyles-Text"
+        id="field-mockId-message"
+      >
+        This field is required
+      </span>
+    </div>
+    <textarea
+      aria-describedby="field-mockId-message field-mockId-hint"
+      aria-invalid="true"
+      aria-required="false"
+      class="css-xktc3q-Field"
+      id="field-mockId"
+    />
+  </div>
+</div>
+`;

--- a/plop-templates/component/src/{{componentName}}.test.tsx.hbs
+++ b/plop-templates/component/src/{{componentName}}.test.tsx.hbs
@@ -12,7 +12,11 @@ function render{{componentName}}(props?: Partial<{{componentName}}Props>) {
 }
 
 describe('{{componentName}}', () => {
-  it('renders a valid HTML structure', () => {
+	it('renders correctly', () => {
+		const { container } = render{{componentName}}();
+		expect(container).toMatchSnapshot();
+	});
+	it('renders a valid HTML structure', () => {
 		const { container } = render{{componentName}}();
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],


### PR DESCRIPTION
## Describe your changes

- Add tests to `field`, `textinput` and `textarea`
- Restructure some tests to get accurate HTML validation tests
- DatePicker: Set a default value of the `type` prop to `text`
- TextInput: Set a default value of the `type` prop to `text`

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook