### PR TITLE
Rollback "Replace useId from @reach/auto-id with @react-aria/utils"

### DIFF
--- a/.changeset/rude-poems-confess.md
+++ b/.changeset/rude-poems-confess.md
@@ -12,4 +12,4 @@
 '@ag.ds-next/side-nav': patch
 ---
 
-Replace useId from `@reach/auto-id` with `@react-aria/utils` to ensure that HTML is valid before hydration.
+Upgraded `@reach/auto-id` 

--- a/packages/accordion/src/Accordion.test.tsx
+++ b/packages/accordion/src/Accordion.test.tsx
@@ -39,8 +39,8 @@ describe('Accordion', () => {
 				'no-inline-style': 'off',
 				// Our HTML is based off ARIA APG https://www.w3.org/WAI/ARIA/apg/example-index/accordion/accordion.html
 				'prefer-native-element': 'off',
-				// We use a deterministic mock ID in tests
-				'no-dup-id': 'off',
+				// react 18s `useId` break this rule
+				'valid-id': 'off',
 			},
 		});
 	});

--- a/packages/accordion/src/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/accordion/src/__snapshots__/Accordion.test.tsx.snap
@@ -12,10 +12,10 @@ exports[`Accordion renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <button
-          aria-controls="accordion-mockId-body"
+          aria-controls="accordion-:r0:-body"
           aria-expanded="false"
           class="css-1c9c7xg-BaseButton-boxStyles-AccordionTitle"
-          id="accordion-mockId-title"
+          id="accordion-:r0:-title"
           type="button"
         >
           Accordion 1
@@ -38,9 +38,9 @@ exports[`Accordion renders correctly 1`] = `
         </button>
       </h3>
       <div
-        aria-labelledby="accordion-mockId-title"
+        aria-labelledby="accordion-:r0:-title"
         class="css-1g0zzsa-AccordionBody"
-        id="accordion-mockId-body"
+        id="accordion-:r0:-body"
         role="region"
         style="display: none; height: 0px;"
       >
@@ -64,10 +64,10 @@ exports[`Accordion renders correctly 1`] = `
         class="css-79i25n-boxStyles"
       >
         <button
-          aria-controls="accordion-mockId-body"
+          aria-controls="accordion-:r1:-body"
           aria-expanded="false"
           class="css-1c9c7xg-BaseButton-boxStyles-AccordionTitle"
-          id="accordion-mockId-title"
+          id="accordion-:r1:-title"
           type="button"
         >
           Accordion 2
@@ -90,9 +90,9 @@ exports[`Accordion renders correctly 1`] = `
         </button>
       </h3>
       <div
-        aria-labelledby="accordion-mockId-title"
+        aria-labelledby="accordion-:r1:-title"
         class="css-1g0zzsa-AccordionBody"
-        id="accordion-mockId-body"
+        id="accordion-:r1:-body"
         role="region"
         style="display: none; height: 0px;"
       >

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,8 +6,7 @@
 	"module": "dist/ag.ds-next-core.esm.js",
 	"dependencies": {
 		"@babel/runtime": "^7.4.5",
-		"@react-aria/ssr": "^3.3.0",
-		"@react-aria/utils": "^3.14.0"
+		"@reach/auto-id": "^0.18.0"
 	},
 	"devDependencies": {
 		"@emotion/react": "^11.7.0",

--- a/packages/core/src/CoreProvider.tsx
+++ b/packages/core/src/CoreProvider.tsx
@@ -5,8 +5,6 @@ import {
 	PropsWithChildren,
 	AnchorHTMLAttributes,
 } from 'react';
-import { SSRProvider, useIsSSR } from '@react-aria/ssr';
-export { useId } from '@react-aria/utils';
 
 const DefaultLinkComponent = forwardRef<
 	HTMLAnchorElement,
@@ -51,15 +49,13 @@ export type CoreProviderProps = PropsWithChildren<{
 
 export function CoreProvider({ linkComponent, children }: CoreProviderProps) {
 	return (
-		<SSRProvider>
-			<coreContext.Provider
-				value={{
-					linkComponent: linkComponent ?? DefaultLinkComponent,
-				}}
-			>
-				{children}
-			</coreContext.Provider>
-		</SSRProvider>
+		<coreContext.Provider
+			value={{
+				linkComponent: linkComponent ?? DefaultLinkComponent,
+			}}
+		>
+			{children}
+		</coreContext.Provider>
 	);
 }
 
@@ -67,5 +63,3 @@ export function useLinkComponent() {
 	const { linkComponent } = useContext(coreContext);
 	return linkComponent;
 }
-
-export { useIsSSR };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,4 @@
+export { useId } from './useId';
 export { useTernaryState } from './useTernaryState';
 export { useToggleState } from './useToggleState';
 export { useElementSize } from './useElementSize';

--- a/packages/core/src/utils/useId.ts
+++ b/packages/core/src/utils/useId.ts
@@ -1,0 +1,1 @@
+export { useId } from '@reach/auto-id';

--- a/packages/date-picker/src/DatePicker.test.tsx
+++ b/packages/date-picker/src/DatePicker.test.tsx
@@ -27,6 +27,8 @@ describe('DatePicker', () => {
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+			// react 18s `useId` break this rule
+			rules: { 'valid-id': 'off' },
 		});
 	});
 });

--- a/packages/date-picker/src/DateRangePicker.test.tsx
+++ b/packages/date-picker/src/DateRangePicker.test.tsx
@@ -25,8 +25,10 @@ describe('DateRangePicker', () => {
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
-			// We use a deterministic mock ID in tests
-			rules: { 'no-dup-id': 'off' },
+			rules: {
+				// react 18s `useId` break this rule
+				'valid-id': 'off',
+			},
 		});
 	});
 });

--- a/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`DatePicker renders correctly 1`] = `
     >
       <label
         class="css-n7rdvo-boxStyles"
-        for="field-mockId"
+        for="field-:r0:"
       >
         <span
           class="css-433uqb-boxStyles-Text"
@@ -28,7 +28,7 @@ exports[`DatePicker renders correctly 1`] = `
           aria-invalid="false"
           aria-required="false"
           class="css-qcwla-DateInput"
-          id="field-mockId"
+          id="field-:r0:"
           type="text"
           value="01/01/2000"
         />

--- a/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`DateRangePicker renders correctly 1`] = `
       >
         <label
           class="css-n7rdvo-boxStyles"
-          for="field-mockId"
+          for="field-:r0:"
         >
           <span
             class="css-433uqb-boxStyles-Text"
@@ -31,7 +31,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             aria-invalid="false"
             aria-required="false"
             class="css-qcwla-DateInput"
-            id="field-mockId"
+            id="field-:r0:"
             type="text"
             value="01/01/2000"
           />
@@ -84,7 +84,7 @@ exports[`DateRangePicker renders correctly 1`] = `
       >
         <label
           class="css-n7rdvo-boxStyles"
-          for="field-mockId"
+          for="field-:r1:"
         >
           <span
             class="css-433uqb-boxStyles-Text"
@@ -104,7 +104,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             aria-invalid="false"
             aria-required="false"
             class="css-qcwla-DateInput"
-            id="field-mockId"
+            id="field-:r1:"
             type="text"
             value="02/01/2000"
           />

--- a/packages/field/src/Field.test.tsx
+++ b/packages/field/src/Field.test.tsx
@@ -52,6 +52,8 @@ describe('Field', () => {
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+			// react 18s `useId` break this rule
+			rules: { 'valid-id': 'off' },
 		});
 	});
 

--- a/packages/field/src/__snapshots__/Field.test.tsx.snap
+++ b/packages/field/src/__snapshots__/Field.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Field renders correctly 1`] = `
   >
     <label
       class="css-n7rdvo-boxStyles"
-      for="field-mockId"
+      for="field-:r0:"
     >
       <span
         class="css-433uqb-boxStyles-Text"
@@ -17,7 +17,7 @@ exports[`Field renders correctly 1`] = `
     </label>
     <span
       class="css-lw0v8u-boxStyles-Text"
-      id="field-mockId-hint"
+      id="field-:r0:-hint"
     >
       Hint text
     </span>
@@ -50,17 +50,17 @@ exports[`Field renders correctly 1`] = `
       </div>
       <span
         class="css-tfsyf8-boxStyles-Text"
-        id="field-mockId-message"
+        id="field-:r0:-message"
       >
         This field is required
       </span>
     </div>
     <input
-      aria-describedby="field-mockId-message field-mockId-hint"
+      aria-describedby="field-:r0:-message field-:r0:-hint"
       aria-invalid="true"
       aria-required="true"
       data-testid="example-input"
-      id="field-mockId"
+      id="field-:r0:"
       type="text"
     />
   </div>

--- a/packages/progress-indicator/src/ProgressIndicator.test.tsx
+++ b/packages/progress-indicator/src/ProgressIndicator.test.tsx
@@ -28,7 +28,11 @@ describe('ProgressIndicator', () => {
 			const { container } = renderProgressIndicator(exampleProps);
 			expect(container).toHTMLValidate({
 				extends: ['html-validate:recommended'],
-				rules: { 'no-inline-style': 'off' },
+				rules: {
+					'no-inline-style': 'off',
+					// react 18s `useId` break this rule
+					'valid-id': 'off',
+				},
 			});
 		});
 	});
@@ -60,7 +64,11 @@ describe('ProgressIndicator', () => {
 			const { container } = renderProgressIndicator(exampleProps);
 			expect(container).toHTMLValidate({
 				extends: ['html-validate:recommended'],
-				rules: { 'no-inline-style': 'off' },
+				rules: {
+					'no-inline-style': 'off',
+					// react 18s `useId` break this rule
+					'valid-id': 'off',
+				},
 			});
 		});
 	});

--- a/packages/progress-indicator/src/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/progress-indicator/src/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
     class="css-1slslyo-boxStyles-ProgressIndicatorContainer"
   >
     <button
-      aria-controls="progress-indicator-mockId-body"
+      aria-controls="progress-indicator-:r0:-body"
       aria-expanded="false"
       class="css-1rwe9m2-BaseButton-boxStyles-ProgressIndicatorCollapseButton"
-      id="progress-indicator-mockId-button"
+      id="progress-indicator-:r0:-button"
       type="button"
     >
       Doing step 2 of 3
@@ -32,7 +32,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
     </button>
     <div
       class="css-fmb23f-ProgressIndicator"
-      id="progress-indicator-mockId-body"
+      id="progress-indicator-:r0:-body"
       style="display: none; height: 0px; overflow: hidden;"
     >
       <ul
@@ -176,10 +176,10 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
     class="css-1slslyo-boxStyles-ProgressIndicatorContainer"
   >
     <button
-      aria-controls="progress-indicator-mockId-body"
+      aria-controls="progress-indicator-:r2:-body"
       aria-expanded="false"
       class="css-1rwe9m2-BaseButton-boxStyles-ProgressIndicatorCollapseButton"
-      id="progress-indicator-mockId-button"
+      id="progress-indicator-:r2:-button"
       type="button"
     >
       Doing step 2 of 3
@@ -202,7 +202,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
     </button>
     <div
       class="css-fmb23f-ProgressIndicator"
-      id="progress-indicator-mockId-body"
+      id="progress-indicator-:r2:-body"
       style="display: none; height: 0px; overflow: hidden;"
     >
       <ul

--- a/packages/search-box/src/Search.test.tsx
+++ b/packages/search-box/src/Search.test.tsx
@@ -24,9 +24,12 @@ describe('SearchBox', () => {
 
 	it('renders a valid HTML structure', () => {
 		const { container } = renderSearch();
-
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+			rules: {
+				// react 18s `useId` break this rule
+				'valid-id': 'off',
+			},
 		});
 	});
 });

--- a/packages/search-box/src/__snapshots__/Search.test.tsx.snap
+++ b/packages/search-box/src/__snapshots__/Search.test.tsx.snap
@@ -14,13 +14,13 @@ exports[`SearchBox renders correctly 1`] = `
       >
         <label
           class="css-1dixsb6-boxStyles-Text-SearchBoxLabel"
-          for="search-mockId"
+          for="search-:r0:"
         >
           Search
         </label>
         <input
           class="css-i4ov2d-SearchBoxInput"
-          id="search-mockId"
+          id="search-:r0:"
           type="search"
         />
       </div>

--- a/packages/side-nav/src/SideNav.test.tsx
+++ b/packages/side-nav/src/SideNav.test.tsx
@@ -77,7 +77,11 @@ describe('SideNav', () => {
 		const { container } = renderSideNav(exampleProps);
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
-			rules: { 'no-inline-style': 'off' },
+			rules: {
+				'no-inline-style': 'off',
+				// react 18s `useId` break this rule
+				'valid-id': 'off',
+			},
 		});
 	});
 	describe('renders the title correctly', () => {

--- a/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
@@ -6,10 +6,10 @@ exports[`SideNav renders correctly 1`] = `
     class="css-d977xg-boxStyles-SideNavContainer"
   >
     <button
-      aria-controls="sideNav-mockId-body"
+      aria-controls="sideNav-:r0:-body"
       aria-expanded="false"
       class="css-10gm9gu-BaseButton-boxStyles-SideNavCollapseButton"
-      id="sideNav-mockId-button"
+      id="sideNav-:r0:-button"
       type="button"
     >
       In this section
@@ -32,17 +32,17 @@ exports[`SideNav renders correctly 1`] = `
     </button>
     <div
       class="css-1wh7zb4-SideNav"
-      id="sideNav-mockId-body"
+      id="sideNav-:r0:-body"
       style="display: none; height: 0px; overflow: hidden;"
     >
       <nav
-        aria-labelledby="sideNav-mockId-title"
+        aria-labelledby="sideNav-:r0:-title"
         class="css-zipzg2-boxStyles"
-        id="sideNav-mockId-nav"
+        id="sideNav-:r0:-nav"
       >
         <h2
           class="css-79i25n-boxStyles"
-          id="sideNav-mockId-title"
+          id="sideNav-:r0:-title"
         >
           <a
             class="css-1qbo8fu-boxStyles-SideNavTitle"

--- a/packages/text-input/src/TextInput.test.tsx
+++ b/packages/text-input/src/TextInput.test.tsx
@@ -29,6 +29,10 @@ describe('TextInput', () => {
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+			rules: {
+				// react 18s `useId` break this rule
+				'valid-id': 'off',
+			},
 		});
 	});
 });

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`TextInput renders correctly 1`] = `
   >
     <label
       class="css-n7rdvo-boxStyles"
-      for="field-mockId"
+      for="field-:r0:"
     >
       <span
         class="css-433uqb-boxStyles-Text"
@@ -22,7 +22,7 @@ exports[`TextInput renders correctly 1`] = `
     </label>
     <span
       class="css-lw0v8u-boxStyles-Text"
-      id="field-mockId-hint"
+      id="field-:r0:-hint"
     >
       Hint text
     </span>
@@ -55,17 +55,17 @@ exports[`TextInput renders correctly 1`] = `
       </div>
       <span
         class="css-tfsyf8-boxStyles-Text"
-        id="field-mockId-message"
+        id="field-:r0:-message"
       >
         This field is required
       </span>
     </div>
     <input
-      aria-describedby="field-mockId-message field-mockId-hint"
+      aria-describedby="field-:r0:-message field-:r0:-hint"
       aria-invalid="true"
       aria-required="false"
       class="css-b9h5aa-Field"
-      id="field-mockId"
+      id="field-:r0:"
       type="text"
     />
   </div>

--- a/packages/textarea/src/Textarea.test.tsx
+++ b/packages/textarea/src/Textarea.test.tsx
@@ -29,6 +29,8 @@ describe('Textarea', () => {
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
+			// react 18s `useId` break this rule
+			rules: { 'valid-id': 'off' },
 		});
 	});
 });

--- a/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Textarea renders correctly 1`] = `
   >
     <label
       class="css-n7rdvo-boxStyles"
-      for="field-mockId"
+      for="field-:r0:"
     >
       <span
         class="css-433uqb-boxStyles-Text"
@@ -22,7 +22,7 @@ exports[`Textarea renders correctly 1`] = `
     </label>
     <span
       class="css-lw0v8u-boxStyles-Text"
-      id="field-mockId-hint"
+      id="field-:r0:-hint"
     >
       Hint text
     </span>
@@ -55,17 +55,17 @@ exports[`Textarea renders correctly 1`] = `
       </div>
       <span
         class="css-tfsyf8-boxStyles-Text"
-        id="field-mockId-message"
+        id="field-:r0:-message"
       >
         This field is required
       </span>
     </div>
     <textarea
-      aria-describedby="field-mockId-message field-mockId-hint"
+      aria-describedby="field-:r0:-message field-:r0:-hint"
       aria-invalid="true"
       aria-required="false"
       class="css-xktc3q-Field"
-      id="field-mockId"
+      id="field-:r0:"
     />
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,10 +1104,38 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.8", "@babel/runtime@^7.15.4", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
-  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.15.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.7.7", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4":
+  version "7.17.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
+  integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.13":
+  version "7.17.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.8.tgz#3e56e4aff81befa55ac3ac6a0967349fd1c5bca2"
+  integrity sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.14.8", "@babel/runtime@^7.4.5":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
+  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.17.8":
+  version "7.18.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.0.tgz#6d77142a19cb6088f0af662af1ada37a604d34ae"
+  integrity sha512-YMQvx/6nKEaucl0MY56mwIG483xk8SDNdlUwb2Ts6FUpr7fm85DxEmsY18LXBNhcTz6tO6JwZV8w1W06v8UKeg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.18.9", "@babel/runtime@^7.9.2":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -2103,23 +2131,17 @@
   resolved "https://registry.yarnpkg.com/@preconstruct/next/-/next-4.0.0.tgz#4d9c64ed68bb7cdc72d35d79d1dbe26ba2cae61e"
   integrity sha512-vSrc8wFQgBErU7dKTKSQtr/DLWPHcN9jMoiWOAQodB1+B4Kpqqry6QhGYoRm0DQU5gNL+Rcp+Xb350O1E/gjsg==
 
-"@react-aria/ssr@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.3.0.tgz#25e81daf0c7a270a4a891159d8d984578e4512d8"
-  integrity sha512-yNqUDuOVZIUGP81R87BJVi/ZUZp/nYOBXbPsRe7oltJOfErQZD+UezMpw4vM2KRz18cURffvmC8tJ6JTeyDtaQ==
+"@reach/auto-id@^0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.18.0.tgz#4b97085cd1cf1360a9bedc6e9c78e97824014f0d"
+  integrity sha512-XwY1IwhM7mkHZFghhjiqjQ6dstbOdpbFLdggeke75u8/8icT8uEHLbovFUgzKjy9qPvYwZIB87rLiR8WdtOXCg==
   dependencies:
-    "@babel/runtime" "^7.6.2"
+    "@reach/utils" "0.18.0"
 
-"@react-aria/utils@^3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/utils/-/utils-3.14.0.tgz#87877e89e959c8b6299da953ec3a7167de2192c3"
-  integrity sha512-DHgmwNBNEhnb6DEYYAfbt99wprBqJJOBBeIpQ2g3+pxwlw4BZ+v4Qr+rDD0ZibWV0mYzt8zOhZ9StpId7iTF0Q==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    "@react-aria/ssr" "^3.3.0"
-    "@react-stately/utils" "^3.5.1"
-    "@react-types/shared" "^3.15.0"
-    clsx "^1.1.1"
+"@reach/utils@0.18.0":
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.18.0.tgz#4f3cebe093dd436eeaff633809bf0f68f4f9d2ee"
+  integrity sha512-KdVMdpTgDyK8FzdKO9SCpiibuy/kbv3pwgfXshTI6tEcQT1OOwj7BAksnzGC0rPz0UholwC+AgkqEl3EJX3M1A==
 
 "@react-spring/animated@~9.4.5":
   version "9.4.5"
@@ -2166,18 +2188,6 @@
     "@react-spring/core" "~9.4.5"
     "@react-spring/shared" "~9.4.5"
     "@react-spring/types" "~9.4.5"
-
-"@react-stately/utils@^3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@react-stately/utils/-/utils-3.5.1.tgz#502de762e5d33e892347c5f58053674e06d3bc92"
-  integrity sha512-INeQ5Er2Jm+db8Py4upKBtgfzp3UYgwXYmbU/XJn49Xw27ktuimH9e37qP3bgHaReb5L3g8IrGs38tJUpnGPHA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-
-"@react-types/shared@^3.15.0":
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/@react-types/shared/-/shared-3.15.0.tgz#a4a78f36bc8daaefe6e9a9df1f453271639c2233"
-  integrity sha512-hwuE4BmgswqP+HRDSLMj7DcnYOCCK+ZRuKnc9AVhXS4LBrwRSkdUkNvXhgvqF5tav7IqTpG9pBYMR9wedehuhA==
 
 "@rollup/plugin-alias@^3.1.1":
   version "3.1.9"
@@ -5730,11 +5740,6 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
-
-clsx@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.2.1.tgz#0ddc4a20a549b59c93a4116bb26f5294ca17dc12"
-  integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
 
 co@^4.6.0:
   version "4.6.0"


### PR DESCRIPTION
## Describe your changes

Rollback PR #749 but....

- Export `useId` from Core
- Use the latest version of `@reach/auto-id` which uses reacts internal `useId` function if available.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
