### PR TITLE
Update eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,12 +41,15 @@ module.exports = {
 	},
 	overrides: [
 		{
-			// Both of these sites are hosted using GitHub pages
-			// which is incompatible with @next/image
+			// These sites are hosted using GitHub pages which is incompatible with @next/image
 			files: ['docs/**/*', 'example-site/**/*', 'packages/**/*'],
 			rules: {
 				'@next/next/no-img-element': 'off',
 			},
+		},
+		{
+			files: ['packages/**/*'],
+			rules: { '@next/next/no-html-link-for-pages': 'off' },
 		},
 	],
 };


### PR DESCRIPTION
## Describe your changes

Fixes a console warning when running `yarn lint`

```
Pages directory cannot be found at ../agds-next/pages or .../agds-next/src/pages. If using a custom path, please configure with the `no-html-link-for-pages` rule in your eslint config file.
```