### PR TITLE
Box: Add display: table to Box styles. Add to missing components

### DIFF
--- a/.changeset/blue-suns-live.md
+++ b/.changeset/blue-suns-live.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/table': patch
+---
+
+Update usage of CSS display properties

--- a/.changeset/rich-meals-applaud.md
+++ b/.changeset/rich-meals-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/box': patch
+---
+
+Add 'table', 'grid' and 'inline-grid' display types

--- a/packages/box/src/styles.ts
+++ b/packages/box/src/styles.ts
@@ -121,6 +121,7 @@ type LayoutProps = Partial<{
 		| 'inline-block'
 		| 'inline-flex'
 		| 'none'
+		| 'table'
 		| 'table-row-group'
 		| 'table-header-group'
 		| 'table-footer-group'
@@ -129,6 +130,8 @@ type LayoutProps = Partial<{
 		| 'table-column-group'
 		| 'table-column'
 		| 'table-caption'
+		| 'grid'
+		| 'inline-grid'
 	>;
 	flexDirection: ResponsiveProp<
 		'row' | 'column' | 'row-reverse' | 'column-reverse'

--- a/packages/table/src/Table.tsx
+++ b/packages/table/src/Table.tsx
@@ -21,6 +21,7 @@ export const Table = forwardRef<HTMLTableElement, TableProps>(function Table(
 			fontSize="sm"
 			focus
 			width="100%"
+			display="table"
 			css={{
 				borderCollapse: 'collapse',
 				borderSpacing: 0,

--- a/packages/table/src/TableBody.tsx
+++ b/packages/table/src/TableBody.tsx
@@ -5,7 +5,7 @@ export type TableBodyProps = { children: ReactNode };
 
 export const TableBody = ({ children }: TableBodyProps) => {
 	return (
-		<Box as="tbody" css={{ display: 'table-row-group' }}>
+		<Box as="tbody" display="table-row-group">
 			{children}
 		</Box>
 	);

--- a/packages/table/src/TableCaption.tsx
+++ b/packages/table/src/TableCaption.tsx
@@ -12,8 +12,8 @@ export const TableCaption = ({ children }: TableCaptionProps) => {
 			fontSize="md"
 			fontWeight="bold"
 			paddingBottom={0.5}
+			display="table-caption"
 			css={{
-				display: 'table-caption',
 				textAlign: 'left',
 			}}
 		>

--- a/packages/table/src/TableHead.tsx
+++ b/packages/table/src/TableHead.tsx
@@ -10,9 +10,7 @@ export const TableHead = ({ children }: TableHeadProps) => {
 			borderBottom
 			borderBottomWidth="xl"
 			borderColor="muted"
-			css={{
-				display: 'table-header-group',
-			}}
+			display="table-header-group"
 		>
 			{children}
 		</Box>


### PR DESCRIPTION
## Describe your changes

Recently realised that display='table' was missing as an option in the box styles. I've added it here along with grid and inline grid, and also updated usage of display properties in some of our components

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook