### PR TITLE
button: Removed loading props from `ButtonLink`

### DIFF
--- a/.changeset/violet-worms-itch.md
+++ b/.changeset/violet-worms-itch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/button': minor
+---
+
+Removed `loading` and `loadingLabel` prop from `ButtonLink`. If you are using these props, you should be using `Button` instead.

--- a/packages/button/src/Button.test.tsx
+++ b/packages/button/src/Button.test.tsx
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Button, ButtonLink, ButtonProps } from './Button';
+import { Button, ButtonLink, ButtonLinkProps, ButtonProps } from './Button';
 
-function ButtonExample(props: ButtonProps) {
-	return (
+afterEach(cleanup);
+
+function renderButton(props?: Partial<ButtonProps>) {
+	return render(
 		<Button data-testid="example" {...props}>
 			My button
 		</Button>
@@ -13,65 +15,81 @@ function ButtonExample(props: ButtonProps) {
 }
 
 describe('Button', () => {
-	it('renders correctly with minimal props', () => {
-		render(<ButtonExample />);
+	it('renders correctly', () => {
+		const { container } = renderButton();
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders a valid HTML structure', () => {
+		const { container } = renderButton();
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
+		});
+	});
+
+	it('renders basic attributes correctly', () => {
+		renderButton();
 		const el = screen.getByTestId('example');
-		expect(el).toBeInTheDocument();
 		expect(el.tagName).toBe('BUTTON');
 		expect(el).toHaveAccessibleName('My button');
 	});
-	it('renders a valid HTML structure', () => {
-		const { container } = render(<ButtonExample />);
-		expect(container).toHTMLValidate({
-			extends: ['html-validate:recommended'],
-		});
-	});
+
 	it('responds to an onClick event', async () => {
 		const onClick = jest.fn();
-		render(<ButtonExample onClick={onClick} />);
+		renderButton({ onClick });
 		await userEvent.click(screen.getByTestId('example'));
 		expect(onClick).toHaveBeenCalledTimes(1);
 	});
-});
 
-describe('Button with loading', () => {
-	it('renders correctly with minimal props', () => {
-		render(<ButtonExample loading />);
-		const el = screen.getByTestId('example');
-		expect(el).toBeInTheDocument();
-		expect(el.tagName).toBe('BUTTON');
-		expect(el).toHaveAccessibleName('My button Busy');
-	});
-	it('renders a valid HTML structure', () => {
-		const { container } = render(<ButtonExample loading />);
-		expect(container).toHTMLValidate({
-			extends: ['html-validate:recommended'],
-			rules: {
-				'no-inline-style': 'off',
-			},
+	describe('Loading', () => {
+		it('renders correctly', () => {
+			const { container } = renderButton({ loading: true });
+			expect(container).toMatchSnapshot();
+		});
+
+		it('renders correctly with minimal props', () => {
+			renderButton({ loading: true });
+			const el = screen.getByTestId('example');
+			expect(el).toBeInTheDocument();
+			expect(el.tagName).toBe('BUTTON');
+			expect(el).toHaveAccessibleName('My button Busy');
+		});
+
+		it('renders a valid HTML structure', () => {
+			const { container } = renderButton({ loading: true });
+			expect(container).toHTMLValidate({
+				extends: ['html-validate:recommended'],
+				rules: { 'no-inline-style': 'off' },
+			});
 		});
 	});
 });
 
-function ButtonLinkExample() {
-	return (
-		<ButtonLink href="#" data-testid="example">
+function renderButtonLink(props?: Partial<ButtonLinkProps>) {
+	return render(
+		<ButtonLink href="#" data-testid="example" {...props}>
 			My button link
 		</ButtonLink>
 	);
 }
 
 describe('ButtonLink', () => {
-	it('renders correctly with minimal props', () => {
-		render(<ButtonLinkExample />);
+	it('renders correctly', () => {
+		const { container } = renderButtonLink();
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders basic attributes correctly', () => {
+		renderButtonLink();
 		const el = screen.getByTestId('example');
 		expect(el).toBeInTheDocument();
 		expect(el.tagName).toBe('A');
 		expect(el).toHaveAttribute('href', '#');
 		expect(el).toHaveAccessibleName('My button link');
 	});
+
 	it('renders a valid HTML structure', () => {
-		const { container } = render(<ButtonLinkExample />);
+		const { container } = renderButtonLink();
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 		});

--- a/packages/button/src/Button.test.tsx
+++ b/packages/button/src/Button.test.tsx
@@ -58,6 +58,7 @@ describe('Button', () => {
 			const el = screen.getByTestId('example');
 			expect(el).toBeInTheDocument();
 			expect(el.tagName).toBe('BUTTON');
+			expect(el).toHaveAttribute('type', 'button');
 			expect(el).toHaveAccessibleName('My button Busy');
 		});
 

--- a/packages/button/src/Button.test.tsx
+++ b/packages/button/src/Button.test.tsx
@@ -41,6 +41,12 @@ describe('Button', () => {
 		expect(onClick).toHaveBeenCalledTimes(1);
 	});
 
+	it('renders an empty aria-live container', () => {
+		const { container } = renderButton();
+		const liveRegion = container.querySelector('[aria-live]');
+		expect(liveRegion?.childElementCount).toBe(0);
+	});
+
 	describe('Loading', () => {
 		it('renders correctly', () => {
 			const { container } = renderButton({ loading: true });
@@ -61,6 +67,21 @@ describe('Button', () => {
 				extends: ['html-validate:recommended'],
 				rules: { 'no-inline-style': 'off' },
 			});
+		});
+
+		it('announces loading label correctly', () => {
+			const { container } = renderButton({
+				loading: true,
+				loadingLabel: 'Processing action',
+			});
+			const liveRegion = container.querySelector('[aria-live]');
+			expect(liveRegion).toHaveTextContent('Processing action');
+		});
+
+		it('announces default loadingLabel correctly', () => {
+			const { container } = renderButton({ loading: true });
+			const liveRegion = container.querySelector('[aria-live]');
+			expect(liveRegion).toHaveTextContent('Busy');
 		});
 	});
 });

--- a/packages/button/src/Button.tsx
+++ b/packages/button/src/Button.tsx
@@ -18,17 +18,22 @@ type CommonButtonProps = {
 	iconBefore?: ComponentType<IconProps>;
 	/** The icon to display after the buttons children. */
 	iconAfter?: ComponentType<IconProps>;
-	/** When true, the button will display a loading indicator. */
-	loading?: boolean;
-	/** Text to read out to assistive technologies when button is loading. */
-	loadingLabel?: string;
 	/** The size of the button. */
 	size?: ButtonSize;
 	/** The variant of the button. */
 	variant?: ButtonVariant;
 };
 
-export type ButtonProps = CommonButtonProps & BaseButtonProps;
+type LoadingButtonProps = {
+	/** When true, the button will display a loading indicator. */
+	loading?: boolean;
+	/** Text to read out to assistive technologies when button is loading. */
+	loadingLabel?: string;
+};
+
+export type ButtonProps = CommonButtonProps &
+	LoadingButtonProps &
+	BaseButtonProps;
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 	function Button(
@@ -78,8 +83,6 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 			iconBefore: IconBefore,
 			iconAfter: IconAfter,
 			size = 'md',
-			loading,
-			loadingLabel = 'Busy',
 			variant = 'primary',
 			...props
 		},
@@ -92,14 +95,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
 				{IconBefore ? (
 					<IconBefore size={iconSize[size]} weight="regular" />
 				) : null}
-				<span>
-					<span css={{ opacity: loading ? 0 : 1 }}>{children}</span>
-					<ButtonLoadingDots
-						loading={loading}
-						label={loadingLabel}
-						size={size}
-					/>
-				</span>
+				{children}
 				{IconAfter ? (
 					<IconAfter size={iconSize[size]} weight="regular" />
 				) : null}

--- a/packages/button/src/__snapshots__/Button.test.tsx.snap
+++ b/packages/button/src/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button Loading renders correctly 1`] = `
+<div>
+  <button
+    class="css-3jmmp1-BaseButton-Button"
+    data-testid="example"
+    type="button"
+  >
+    <span>
+      <span
+        class="css-17k4jap-Button"
+      >
+        My button
+      </span>
+      <span
+        aria-live="assertive"
+      >
+        <span
+          aria-atomic="false"
+          class="css-zovuvr-boxStyles-ButtonLoadingDots"
+        >
+          <span
+            class="css-avudkd-VisuallyHidden"
+          >
+            Busy
+          </span>
+          <span
+            aria-hidden="true"
+            class="css-3a1w1j-boxStyles-LoadingDots"
+            style="opacity: 0;"
+          />
+          <span
+            aria-hidden="true"
+            class="css-3a1w1j-boxStyles-LoadingDots"
+            style="opacity: 0;"
+          />
+          <span
+            aria-hidden="true"
+            class="css-3a1w1j-boxStyles-LoadingDots"
+            style="opacity: 0;"
+          />
+        </span>
+      </span>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Button renders correctly 1`] = `
+<div>
+  <button
+    class="css-3jmmp1-BaseButton-Button"
+    data-testid="example"
+    type="button"
+  >
+    <span>
+      <span
+        class="css-oobk4c-Button"
+      >
+        My button
+      </span>
+      <span
+        aria-live="assertive"
+      />
+    </span>
+  </button>
+</div>
+`;
+
+exports[`ButtonLink renders correctly 1`] = `
+<div>
+  <a
+    class="css-1wxekme-ButtonLink"
+    data-testid="example"
+    href="#"
+  >
+    My button link
+  </a>
+</div>
+`;


### PR DESCRIPTION
## Describe your changes

- Removed `loading` and `loadingLabel` prop from `ButtonLink`. If you are using these props, you should be using `Button` instead.
- Added more tests

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file