### PR TITLE
docs: Fix broken figma button

### DIFF
--- a/guides/figma.mdx
+++ b/guides/figma.mdx
@@ -9,7 +9,7 @@ description: How to access the AgDS design files
 	variant="secondary"
 	iconBefore={() => <FigmaLogo />}
 >
-	Go to Figma
+	{'Go to Figma'}
 </ButtonLink>
 
 Our Design System Figma library contains all of the component, colours, icons, and font-styles needed to build applications for the Export Service. The best way to consume this library is to install it into your project file.


### PR DESCRIPTION
## Describe your changes

MDX version 2 (bumped in #812 ) caused this issue. MDX was wrapping "Go to figma" in a `p` tag 🤔.

| Before      | After |
| ----------- | ----------- |
| <img width="349" alt="Screen Shot 2022-10-27 at 2 09 12 pm" src="https://user-images.githubusercontent.com/6265154/198189625-0aac5a51-c20d-42c0-a56c-6cf6bfa6cc42.png">      | <img width="347" alt="Screen Shot 2022-10-27 at 2 09 01 pm" src="https://user-images.githubusercontent.com/6265154/198189638-59d848f3-967b-49ee-b5e6-1b9e348e4cdb.png">       |


