### PR TITLE
docs: Add env vars for Playroom and Storybook links

### DIFF
--- a/docs/.env.development
+++ b/docs/.env.development
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_PLAYROOM_URL=http://localhost:9000/
+NEXT_PUBLIC_STORYBOOK_URL=http://localhost:6006/index.html

--- a/docs/.env.production
+++ b/docs/.env.production
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_PLAYROOM_URL=/playroom/index.html
+NEXT_PUBLIC_STORYBOOK_URL=/storybook/index.html

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -70,7 +70,7 @@ const LiveCode = withLive(function LiveCode(props: unknown) {
 	);
 
 	const playroomUrl = createUrl({
-		baseUrl: 'https://steelthreads.github.io/agds-next/playroom',
+		baseUrl: process.env.NEXT_PUBLIC_PLAYROOM_URL,
 		code: live.code.startsWith('<')
 			? live.code
 			: `<Render>\n    {${live.code

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -44,7 +44,7 @@ export function PkgLayout({
 				callToAction={
 					pkg.storybookPath && (
 						<CallToActionLink
-							href={`https://steelthreads.github.io/agds-next/storybook/index.html?path=${pkg.storybookPath}`}
+							href={`${process.env.NEXT_PUBLIC_STORYBOOK_URL}?path=${pkg.storybookPath}`}
 						>
 							View in Storybook
 						</CallToActionLink>

--- a/docs/components/SiteFooter.tsx
+++ b/docs/components/SiteFooter.tsx
@@ -9,11 +9,11 @@ const footerLinks = [
 	{ label: 'Home', href: '/' },
 	{
 		label: 'Storybook',
-		href: 'https://steelthreads.github.io/agds-next/storybook/index.html',
+		href: process.env.NEXT_PUBLIC_STORYBOOK_URL,
 	},
 	{
 		label: 'Playroom',
-		href: 'https://steelthreads.github.io/agds-next/playroom/index.html',
+		href: process.env.NEXT_PUBLIC_PLAYROOM_URL,
 	},
 	{
 		label: 'Starter kit',


### PR DESCRIPTION
## Describe your changes

Improves the experience of working with Storybook and Playroom locally by using environment variables to link to URLs based on whether the docs site is running in a development or production environment.

### To test dev

In seperate processes run:

```sh
yarn docs:dev
yarn playroom:build
yarn storybook:build
```

### To test prod

```sh
yarn docs:build && yarn playroom:build && yarn storybook:build && cd docs && yarn next start
```