### PR TITLE
[WIP] Docs: Add tabIndex to homepage main content area

### DIFF
--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -1,6 +1,6 @@
 import { Columns } from '@ag.ds-next/columns';
 import { SectionContent } from '@ag.ds-next/content';
-import { Stack } from '@ag.ds-next/box';
+import { Box, Stack } from '@ag.ds-next/box';
 import { CallToActionLink } from '@ag.ds-next/call-to-action';
 import { Prose } from '@ag.ds-next/prose';
 import { TextLink } from '@ag.ds-next/text-link';
@@ -19,7 +19,7 @@ export default function Homepage() {
 		<>
 			<DocumentTitle />
 			<AppLayout>
-				<main id="main-content">
+				<Box as="main" focus id="main-content" tabIndex={-1}>
 					<HeroBanner>
 						<HeroBannerTitleContainer>
 							<HeroBannerTitle>
@@ -85,7 +85,7 @@ export default function Homepage() {
 							</Columns>
 						</Stack>
 					</SectionContent>
-				</main>
+				</Box>
 			</AppLayout>
 		</>
 	);


### PR DESCRIPTION
## Describe your changes

DAGR-111. Follows on from changes in #727 

In the recent test, the issue *DAGR-111: Skip link does not move keyboard focus to target destination* was flagged as not fixed

> "The {{#main-content}} element has not be provided with {{tabindex="-1"}} to allow it to receive focus as noted in the recommendation."

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
