### PR TITLE
IndicatorDot: Retire neutral tone

### DIFF
--- a/.changeset/tiny-pigs-worry.md
+++ b/.changeset/tiny-pigs-worry.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/badge': minor
+---
+
+Remove neutral tone from IndicatorDot

--- a/.changeset/tiny-pigs-worry.md
+++ b/.changeset/tiny-pigs-worry.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/badge': minor
 ---
 
-Remove neutral tone from IndicatorDot
+Removed the neutral tone as well as the `tone` prop from IndicatorDot. It now only uses the blue 'action' colour.

--- a/.changeset/tiny-pigs-worry.md
+++ b/.changeset/tiny-pigs-worry.md
@@ -1,5 +1,5 @@
 ---
-'@ag.ds-next/badge': minor
+'@ag.ds-next/badge': major
 ---
 
 Removed the neutral tone as well as the `tone` prop from IndicatorDot. It now only uses the blue 'action' colour.

--- a/.storybook/stories/kitchenSink.tsx
+++ b/.storybook/stories/kitchenSink.tsx
@@ -397,10 +397,7 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 								<NotificationBadge tone="action" value={8} />
 							</Flex>
 
-							<Flex gap={0.5}>
-								<IndicatorDot tone="neutral" />
-								<IndicatorDot tone="action" />
-							</Flex>
+							<IndicatorDot />
 
 							<Table striped>
 								<TableCaption>

--- a/packages/badge/docs/overview.mdx
+++ b/packages/badge/docs/overview.mdx
@@ -46,13 +46,6 @@ Use the `max` property where the count is expected to exceed a reasonable number
 
 A small decorative indicator used to call attention to an item, such as an unread message.
 
-```jsx live
-<Flex gap={1}>
-	<IndicatorDot tone="neutral" />
-	<IndicatorDot tone="action" />
-</Flex>
-```
-
 An IndicatorDot should not be used on its own, as it gives no context. It should instead be considered as part of a wider composition.
 
 ```jsx live

--- a/packages/badge/src/IndicatorDot.stories.tsx
+++ b/packages/badge/src/IndicatorDot.stories.tsx
@@ -14,9 +14,6 @@ export default {
 export const Basic: ComponentStory<typeof IndicatorDot> = (args) => (
 	<IndicatorDot {...args} />
 );
-Basic.args = {
-	tone: 'neutral',
-};
 
 export const Example = () => {
 	return (

--- a/packages/badge/src/IndicatorDot.stories.tsx
+++ b/packages/badge/src/IndicatorDot.stories.tsx
@@ -42,7 +42,7 @@ export const Example = () => {
 
 					<Flex alignItems="center" gap={0.5}>
 						<Text color="muted">10:15am</Text>
-						<IndicatorDot tone="action" />
+						<IndicatorDot />
 						<VisuallyHidden>Unread message</VisuallyHidden>
 					</Flex>
 				</Flex>

--- a/packages/badge/src/IndicatorDot.test.tsx
+++ b/packages/badge/src/IndicatorDot.test.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { cleanup, render } from '../../../test-utils';
 import { IndicatorDot, IndicatorDotProps } from './IndicatorDot';
-import { badgeToneMap, BadgeTone } from './utils';
 
 afterEach(cleanup);
 
@@ -10,22 +9,24 @@ function renderIndicatorDot(props: IndicatorDotProps) {
 	return render(<IndicatorDot {...props} />);
 }
 
-const tones = Object.keys(badgeToneMap) as BadgeTone[];
-
 describe('IndicatorDot', () => {
-	tones.forEach((tone) => {
-		describe(`tone: ${tone}`, () => {
-			it('renders correctly', () => {
-				const { container } = renderIndicatorDot({ tone });
-				expect(container).toMatchSnapshot();
-			});
+	it('renders correctly', () => {
+		const { container } = renderIndicatorDot({});
+		expect(container).toMatchSnapshot();
+	});
 
-			it('renders a valid HTML structure', () => {
-				const { container } = renderIndicatorDot({ tone });
-				expect(container).toHTMLValidate({
-					extends: ['html-validate:recommended'],
-				});
-			});
+	it('renders a valid HTML structure', () => {
+		const { container } = renderIndicatorDot({});
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
 		});
+	});
+
+	it('supports aria-label', () => {
+		const { container } = renderIndicatorDot({ 'aria-label': 'test' });
+		expect(container.querySelector('div')).toHaveAttribute(
+			'aria-label',
+			'test'
+		);
 	});
 });

--- a/packages/badge/src/IndicatorDot.tsx
+++ b/packages/badge/src/IndicatorDot.tsx
@@ -1,23 +1,24 @@
 import { Box } from '@ag.ds-next/box';
-import { BadgeTone, badgeToneMap } from './utils';
+import { boxPalette } from '@ag.ds-next/core';
 
 export type IndicatorDotProps = {
 	/** The accessible label to read out in screen readers. */
 	'aria-label'?: string;
-	/** The colour tone to apply. */
-	tone: BadgeTone;
 };
 
 export const IndicatorDot = ({
 	'aria-label': ariaLabel,
-	tone,
 }: IndicatorDotProps) => {
-	const backgroundColor = badgeToneMap[tone];
 	return (
 		<Box
 			aria-label={ariaLabel}
 			highContrastOutline
-			css={{ width: 8, height: 8, borderRadius: 4, backgroundColor }}
+			css={{
+				width: 8,
+				height: 8,
+				borderRadius: 4,
+				backgroundColor: boxPalette.foregroundAction,
+			}}
 		/>
 	);
 };

--- a/packages/badge/src/StatusBadge.tsx
+++ b/packages/badge/src/StatusBadge.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { Flex } from '@ag.ds-next/box';
+import { Box, Flex } from '@ag.ds-next/box';
 import { boxPalette, mapSpacing } from '@ag.ds-next/core';
 import {
 	SuccessIcon,
@@ -8,7 +8,6 @@ import {
 	WarningIcon,
 } from '@ag.ds-next/icon';
 import { Text } from '@ag.ds-next/text';
-import { IndicatorDot } from './IndicatorDot';
 
 export type StatusBadgeProps = {
 	/** The status that is printed in the text label. */
@@ -57,10 +56,22 @@ const iconWidth = '1.375rem'; // 22px
 
 export type StatusBadgeTone = keyof typeof toneMap;
 
+const NeutralDot = () => (
+	<Box
+		highContrastOutline
+		css={{
+			width: 8,
+			height: 8,
+			borderRadius: 4,
+			backgroundColor: boxPalette.foregroundMuted,
+		}}
+	/>
+);
+
 const toneMap = {
 	neutral: {
 		borderColor: boxPalette.border,
-		icon: () => <IndicatorDot tone="neutral" />,
+		icon: () => <NeutralDot />,
 	},
 	success: {
 		borderColor: boxPalette.systemSuccess,

--- a/packages/badge/src/__snapshots__/IndicatorDot.test.tsx.snap
+++ b/packages/badge/src/__snapshots__/IndicatorDot.test.tsx.snap
@@ -1,17 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IndicatorDot tone: action renders correctly 1`] = `
+exports[`IndicatorDot renders correctly 1`] = `
 <div>
   <div
     class="css-h9c2dm-boxStyles-IndicatorDot"
-  />
-</div>
-`;
-
-exports[`IndicatorDot tone: neutral renders correctly 1`] = `
-<div>
-  <div
-    class="css-1dq4bau-boxStyles-IndicatorDot"
   />
 </div>
 `;

--- a/packages/badge/src/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/badge/src/__snapshots__/StatusBadge.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`StatusBadge tone: neutral renders correctly 1`] = `
     class="css-13gpbg6-boxStyles-StatusBadge"
   >
     <div
-      class="css-1dq4bau-boxStyles-IndicatorDot"
+      class="css-1ttchuf-boxStyles-NeutralDot"
     />
     <span
       class="css-10dvol5-boxStyles-Text-StatusBadge"


### PR DESCRIPTION
## Describe your changes

Remove the neutral tone from IndicatorDot as suggested in DAGR-69 Round 2.
Also removed tone as a prop as now only the 'action' tone exists

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook
