### PR TITLE
header: Adjust responsive behaviour

### DIFF
--- a/.changeset/eighty-cars-knock.md
+++ b/.changeset/eighty-cars-knock.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/header': patch
+---
+
+Adjust responsive behaviour to better support searchbox

--- a/.changeset/eighty-cars-knock.md
+++ b/.changeset/eighty-cars-knock.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/header': patch
 ---
 
-Adjust responsive behavior to better support searchbox
+Adjust responsive behaviour to better support `SearchBox`

--- a/.changeset/eighty-cars-knock.md
+++ b/.changeset/eighty-cars-knock.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/header': patch
 ---
 
-Adjust responsive behaviour to better support searchbox
+Adjust responsive behavior to better support searchbox

--- a/packages/header/src/Header.stories.tsx
+++ b/packages/header/src/Header.stories.tsx
@@ -103,10 +103,3 @@ CoBranded.args = {
 	heading: 'TODO ...',
 };
 CoBranded.storyName = '🕥 Co-Branded';
-
-export const Hero = Template.bind({});
-Hero.args = {
-	...defaultArgs,
-	heading: 'TODO ...',
-};
-Hero.storyName = '🕥 Header Hero';

--- a/packages/header/src/Header.stories.tsx
+++ b/packages/header/src/Header.stories.tsx
@@ -5,6 +5,8 @@ import {
 	SearchBoxInput,
 	SearchBoxButton,
 } from '@ag.ds-next/search-box';
+import { Box } from '@ag.ds-next/box';
+import { MainNav } from '@ag.ds-next/main-nav';
 import { Header } from './Header';
 import { HeaderContainer } from './HeaderContainer';
 import { HeaderBrand } from './HeaderBrand';

--- a/packages/header/src/Header.stories.tsx
+++ b/packages/header/src/Header.stories.tsx
@@ -94,8 +94,59 @@ Search.args = {
 		</SearchBox>
 	),
 };
+Search.storyName = 'With SearchBox';
 
-// TODO
+const TemplateWithMainNav: ComponentStory<typeof Header> = (args) => {
+	return (
+		<Box>
+			<Header {...args} />
+			<MainNav
+				items={[
+					{
+						href: '#account',
+						label: 'Home',
+					},
+					{
+						href: '#establishments',
+						label: 'Establishments',
+					},
+					{
+						href: '#intelligence',
+						label: 'Data and insights',
+					},
+					{
+						href: '#compliance',
+						label: 'Compliance',
+					},
+				]}
+				activePath="#account"
+				background="body"
+			/>
+		</Box>
+	);
+};
+
+export const WithMainNav = TemplateWithMainNav.bind({});
+WithMainNav.storyName = 'With MainNav';
+WithMainNav.args = {
+	...defaultArgs,
+	background: 'bodyAlt',
+};
+
+export const WithMainNavAndSearch = TemplateWithMainNav.bind({});
+WithMainNavAndSearch.storyName = 'With MainNav and SearchBox';
+WithMainNavAndSearch.args = {
+	...defaultArgs,
+	rightContent: (
+		<SearchBox onSubmit={console.log}>
+			<SearchBoxInput label="Search this website" />
+			<SearchBoxButton iconOnly={{ xs: true, md: false }}>
+				Search
+			</SearchBoxButton>
+		</SearchBox>
+	),
+	background: 'bodyAlt',
+};
 
 export const CoBranded = Template.bind({});
 CoBranded.args = {

--- a/packages/header/src/Header.tsx
+++ b/packages/header/src/Header.tsx
@@ -28,7 +28,7 @@ export function Header({
 	const hasRightContent = !!rightContent;
 	return (
 		<HeaderContainer background={background} size={size}>
-			<Column columnSpan={{ xs: 12, md: hasRightContent ? 8 : 12 }}>
+			<Column columnSpan={{ xs: 12, lg: hasRightContent ? 8 : 12 }}>
 				<HeaderBrand
 					badgeLabel={badgeLabel}
 					logo={logo}
@@ -39,7 +39,7 @@ export function Header({
 				/>
 			</Column>
 			{hasRightContent && (
-				<Column columnSpan={{ xs: 12, md: 4 }} css={packs.print.hidden}>
+				<Column columnSpan={{ xs: 12, lg: 4 }} css={packs.print.hidden}>
 					{rightContent}
 				</Column>
 			)}

--- a/packages/header/src/__snapshots__/Header.test.tsx.snap
+++ b/packages/header/src/__snapshots__/Header.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Header renders correctly 1`] = `
         class="css-og54d0-boxStyles-Columns"
       >
         <div
-          class="css-11cnnkq-boxStyles-Column"
+          class="css-bmsj3y-boxStyles-Column"
         >
           <a
             class="css-nhpu2w-boxStyles-HeaderBrand"


### PR DESCRIPTION
## Describe your changes

We recently found a visual bug in Header when composed with SearchBox, which is visible in 'tablet' viewports. In this view, the space isn't used as effectively as it could be. [View in Playroom](https://steelthreads.github.io/agds-next/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPABFAhgJwGsA%2BAHQDtNMkAJGHWPcyygZwEsAvGAXhJAFsofJswBGOMAQDmeCAFcyUXiFHQAngEEANgBdhFZlohSI3YEgAyxiJgD0RAL4jKACzpQ2ZKcoCi6AA4QeDqYAMoweABubGAw%2BsyYLHKiWp48fAAqLmwsmDmYOAWJyan8MMUpafFi9FIwFjiiMFrKTTo41ZR4bFIuOgDCEGQ6MMNmzsxI4fhgLmhYQ6HJ-Gw6ZpBkLBBaMAB0RlIOpAYJlFN0eLPzAJJk-nIhWo3NytOXLpg62bkA7jCi7BGfDsx1OkzeVwwKAeOiGeQ2AHkyFo1GZgJh0Cx4J88HIYAAaTCCbEAMxwWhY5QcRwmYIhLlpk1s9Pm0J0sLIoNOSGZF0h6C5lCcBns5BESAAsjhPAA5HCRPIjfgsMwAbXRTyaWmxfFoWiMfEJLjwMBJOpAAGJgQ4ALoOEHkHnzY5IAAKODqg2GoxCOBVfH40rIfC5btklMFVBcAEYiO66pg3PRPFIeTHI0h-JHKFYTfw8v4kvmoNsgolVgUyjpCRtKWARjo5HgCh5-DkwCnMM1VrtMK7mjtvSwAI54gp6E7MGZyLs7Ngk0ZQQmRfBsOS5UZsfNkIaE5oweeLzBkNiiFy9gCKchyo-KEkwTw7J8K3Z0u0ZCMubEwK%2B66%2BPOCwremD%2BKMgGnv%2BMAhIGUgnrkHi5P4%2BCNt0PpEkMIwsISZB%2BrEKGMt0HhgHIWj-vw669rcIx1M2LCxDs3QjmOgEPj0JGFEqgTNvuh6KL2ABqMAsDoEGkfwjKRNsDxIdW2CltxM64jouL5rWMCjoBhKpE0siYAAVuusIPhInhsBxQSwnghJsEIk6UL%2Ba65JZlkFN65a%2BlWx45FovYaKMdAUCxUDXtgZn8L2-R4H6RSpFI7EFIyOBueSbAafmj6mTgvYAKohCWRjNmlhIyPKNkvjOwXfqOOSEvw2xCSJcR2cZT5mXJBW9gAYuusQtWRbCEv4Lj4FBUXoTswlsOUzlljAciEiSpmiOujIZc%2BrE6RA76TjyWYTJm2ZhOuoGKDklKYAuchSGZIR4C4QzEbkME4bOB4LooBSpGlvYSkEojfnNOR1VAXboIyGwrvq%2BTRJEERjTx71QL2MokU8%2Baw1oF1Lf%2B2kRFtmBSjAsQ4bkOw2JS-D4uDQx1g2TbuZWUEFkWP7NDWED8MDNhceyqxlt9mAo-qODpaeeOMmQqM4DWTZJLkHFNm2G6yVL-CQHgoHNkYqjBPkVYUZg2ipXIIufcbIuMlsuATUS5JCSbuC9q6w2Uvq-6Aozjxi7pDzHlLIEWYUQQ4SalHBs1r4PkTjZYXkEgkfkTOSaROgyV2dSyZxZbByNXbhmHIx4MF%2BZQYygYTQ7hRkmU8tgK5IzM3I%2Bb%2BN0Ky5J4F04HIHbLSwvZLCwJ0IedVt2ywZdQf%2B1W5JEJH3O0DcQ%2BSqR9wTf3fhscXlDs9aQRntssCwVfY%2BPzWkbvq-9vqPpCcBnH-pVrOY139Zlqr6ua9tCS7aGtiuuGMAXR-w9DAL0IxhjHBAPiEAPwbJfBYAgVUABmAA7AAVnxGglBAA2fEOCAAc%2BIACcRCABM%2BJowAAZSEABY7RAA)

<img width="1488" alt="image" src="https://user-images.githubusercontent.com/12689383/200715387-7b7c9f2a-00d5-4b75-80b6-79ec3c1310c9.png">

We've fixed this by adjusting the responsive layout logic within Header component, to delay the change from vertical to horizontal layout from the `md` breakpoint (768px) to `lg` (992px).
<img width="1493" alt="image" src="https://user-images.githubusercontent.com/12689383/200715487-b7c41540-fe18-450f-a416-a8fd28ee8a3d.png">

In this PR, I also created some stories that show Header placed with MainNav. It allows us to test changes with these two components together.

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook

