### PR TITLE
Example form: Adjust heading levels for form step pages

### DIFF
--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsContainer.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsContainer.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@ag.ds-next/box';
 import { PageAlert } from '@ag.ds-next/page-alert';
 import { H1 } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
-import { PageTitle } from '../PageTitle';
+import { FormStepTitle } from '../FormStepTitle';
 import { useFormRegisterPetDetails } from './FormRegisterPetDetails';
 
 export const FormRegisterPetDetailsContainer = ({
@@ -27,10 +27,10 @@ export const FormRegisterPetDetailsContainer = ({
 
 	return (
 		<Stack gap={3} width="100%">
-			<PageTitle
-				pretext="Your pet’s details"
-				title={
-					<H1 ref={titleRef} tabIndex={-1} focus>
+			<FormStepTitle
+				sectionTitle="Your pet’s details"
+				pageTitle={
+					<H1 as="h2" ref={titleRef} tabIndex={-1} focus>
 						{title}
 					</H1>
 				}

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep4.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep4.tsx
@@ -25,7 +25,7 @@ export const FormRegisterPetDetailsStep4 = () => {
 		>
 			{/** Summary: Step 0 */}
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[0].label}</H2>
+				<H2 as="h3">{FORM_STEPS[0].label}</H2>
 				<FormDefinitionList
 					items={[
 						{
@@ -40,7 +40,7 @@ export const FormRegisterPetDetailsStep4 = () => {
 			</Stack>
 			{/** Summary: Step 1 */}
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[1].label}</H2>
+				<H2 as="h3">{FORM_STEPS[1].label}</H2>
 				<FormDefinitionList
 					items={[
 						{
@@ -66,7 +66,7 @@ export const FormRegisterPetDetailsStep4 = () => {
 				</Button>
 			</Stack>
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[2].label}</H2>
+				<H2 as="h3">{FORM_STEPS[2].label}</H2>
 				<FormDefinitionList
 					items={[
 						{
@@ -82,7 +82,7 @@ export const FormRegisterPetDetailsStep4 = () => {
 				</Button>
 			</Stack>
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[3].label}</H2>
+				<H2 as="h3">{FORM_STEPS[3].label}</H2>
 				<FormDefinitionList
 					items={[
 						{

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsContainer.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsContainer.tsx
@@ -3,7 +3,7 @@ import { Stack } from '@ag.ds-next/box';
 import { PageAlert } from '@ag.ds-next/page-alert';
 import { H1 } from '@ag.ds-next/heading';
 import { Text } from '@ag.ds-next/text';
-import { PageTitle } from '../PageTitle';
+import { FormStepTitle } from '../FormStepTitle';
 import { useFormRegisterPetPersonalDetails } from './FormRegisterPetPersonalDetails';
 
 export const FormRegisterPetPersonalDetailsContainer = ({
@@ -28,10 +28,10 @@ export const FormRegisterPetPersonalDetailsContainer = ({
 
 	return (
 		<Stack gap={3} width="100%">
-			<PageTitle
-				pretext="Your personal details"
-				title={
-					<H1 ref={titleRef} tabIndex={-1} focus>
+			<FormStepTitle
+				sectionTitle="Your personal details"
+				pageTitle={
+					<H1 as="h2" ref={titleRef} tabIndex={-1} focus>
 						{title}
 					</H1>
 				}

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
@@ -135,7 +135,7 @@ export const FormRegisterPetPersonalDetailsStep0 = () => {
 			<Stack gap={3} alignItems="flex-start" width="100%">
 				{isFormVisibile ? (
 					<Stack gap={1.5} width="100%">
-						<H2>Update personal details</H2>
+						<H2 as="h3">Update personal details</H2>
 						<FormRequiredFieldsMessage />
 						<Stack
 							as="form"
@@ -229,7 +229,7 @@ export const FormRegisterPetPersonalDetailsStep0 = () => {
 				) : (
 					<>
 						<Stack gap={1.5} alignItems="flex-start" width="100%">
-							<H2 ref={headingRef} tabIndex={-1} focus>
+							<H2 as="h3" ref={headingRef} tabIndex={-1} focus>
 								Check personal details
 							</H2>
 							<SummaryList>

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep1.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep1.tsx
@@ -109,7 +109,7 @@ export const FormRegisterPetPersonalDetailsStep1 = () => {
 			<Stack gap={3} alignItems="flex-start">
 				{isFormVisibile ? (
 					<Stack gap={1.5}>
-						<H2>Update address details</H2>
+						<H2 as="h3">Update address details</H2>
 						<FormRequiredFieldsMessage />
 						<Stack
 							as="form"
@@ -208,7 +208,7 @@ export const FormRegisterPetPersonalDetailsStep1 = () => {
 				) : (
 					<>
 						<Stack gap={1.5} alignItems="flex-start" width="100%">
-							<H2 ref={headingRef} tabIndex={-1} focus>
+							<H2 as="h3" ref={headingRef} tabIndex={-1} focus>
 								Check address details
 							</H2>
 							<SummaryList>

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep3.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep3.tsx
@@ -25,7 +25,7 @@ export const FormRegisterPetPersonalDetailsStep3 = () => {
 		>
 			{/** Summary: Step 0 */}
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[0].label}</H2>
+				<H2 as="h3">{FORM_STEPS[0].label}</H2>
 				<FormDefinitionList
 					items={[
 						{
@@ -52,7 +52,7 @@ export const FormRegisterPetPersonalDetailsStep3 = () => {
 			</Stack>
 			{/** Summary: Step 1 */}
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[1].label}</H2>
+				<H2 as="h3">{FORM_STEPS[1].label}</H2>
 				<FormDefinitionList
 					items={[
 						{
@@ -78,7 +78,7 @@ export const FormRegisterPetPersonalDetailsStep3 = () => {
 				</Button>
 			</Stack>
 			<Stack gap={1.5} alignItems="flex-start">
-				<H2>{FORM_STEPS[2].label}</H2>
+				<H2 as="h3">{FORM_STEPS[2].label}</H2>
 				<FormDefinitionList
 					items={[
 						{

--- a/example-form/components/FormStepTitle.tsx
+++ b/example-form/components/FormStepTitle.tsx
@@ -1,0 +1,40 @@
+import { isValidElement, ReactNode } from 'react';
+import { Stack } from '@ag.ds-next/box';
+import { H1 } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
+
+export type FormStepTitleProps = {
+	sectionTitle?: string;
+	pageTitle: ReactNode;
+	introduction?: ReactNode;
+	callToAction?: ReactNode;
+};
+
+// Based on PageTitle, but with a different heading levels
+export const FormStepTitle = ({
+	sectionTitle,
+	pageTitle,
+	introduction,
+	callToAction,
+}: FormStepTitleProps) => (
+	<Stack gap={1.5}>
+		<Stack>
+			<Text
+				as="h1"
+				fontSize="sm"
+				color="muted"
+				fontWeight="bold"
+				lineHeight="heading"
+			>
+				{sectionTitle}
+			</Text>
+			{isValidElement(pageTitle) ? pageTitle : <H1 as="h2">{pageTitle}</H1>}
+		</Stack>
+		{introduction ? (
+			<Text as="p" fontSize="md" color="muted">
+				{introduction}
+			</Text>
+		) : null}
+		{callToAction}
+	</Stack>
+);


### PR DESCRIPTION
Resolves [Intopia UT 1: Text should be a heading - remove span (339996)](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/339996?McasTsid=26110).

> On each new page of the form, the form name/section text is styled and positioned like a heading but is marked up using a `<span>`

As per their suggestion, we've addressed this problem by promoting the form title text from a span to a H1, and demoted the page title to a H2. We've also demoted any sibling `H2` headings to `H3`.

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/12689383/200720271-42797024-379f-4c7f-9e89-293a504aff10.png">

As far as the code is concerned, we've created a FormStepTitle component to replace the PageTitle in Form step pages only. There is no visual difference, but as mentioned above, the HTML elements are different (H1 instead of span, H2 instead of H1).

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [X] Run `yarn format`
- [X] Run `yarn lint` in the root of the repository to ensure tests are passing
- [X] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.

