### PR TITLE
Remove `valid` from form fields

### DIFF
--- a/.changeset/serious-seas-prove.md
+++ b/.changeset/serious-seas-prove.md
@@ -1,0 +1,13 @@
+---
+'@ag.ds-next/autocomplete': minor
+'@ag.ds-next/combobox': minor
+'@ag.ds-next/control-input': minor
+'@ag.ds-next/date-picker': minor
+'@ag.ds-next/field': minor
+'@ag.ds-next/file-upload': minor
+'@ag.ds-next/select': minor
+'@ag.ds-next/text-input': minor
+'@ag.ds-next/textarea': minor
+---
+
+Removed `valid` prop

--- a/.storybook/stories/kitchenSink.tsx
+++ b/.storybook/stories/kitchenSink.tsx
@@ -338,12 +338,6 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 									value={new Date()}
 									onChange={() => {}}
 								/>
-								<TextInput
-									label="Username"
-									value="example"
-									valid
-									message="This username is available"
-								/>
 								<Select
 									label="Example"
 									placeholder="Please select"

--- a/packages/autocomplete/docs/overview.mdx
+++ b/packages/autocomplete/docs/overview.mdx
@@ -108,7 +108,9 @@ Use the `block` prop to expand the component to fill the available space.
 };
 ```
 
-## Invalid
+### Invalid
+
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
 () => {

--- a/packages/autocomplete/src/Autocomplete.stories.tsx
+++ b/packages/autocomplete/src/Autocomplete.stories.tsx
@@ -53,13 +53,6 @@ Invalid.args = {
 	message: 'City is required',
 };
 
-export const Valid = Template.bind({});
-Valid.args = {
-	...defaultArgs,
-	valid: true,
-	message: 'City is valid',
-};
-
 export const Block = Template.bind({});
 Block.args = {
 	...defaultArgs,

--- a/packages/combobox/docs/overview.mdx
+++ b/packages/combobox/docs/overview.mdx
@@ -125,7 +125,9 @@ The `Combobox` component will always append `(optional)` to the label based on t
 };
 ```
 
-## Invalid
+### Invalid
+
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
 () => {

--- a/packages/combobox/src/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox.stories.tsx
@@ -238,13 +238,6 @@ Invalid.args = {
 	message: 'Country is required',
 };
 
-export const Valid = Template.bind({});
-Valid.args = {
-	...defaultArgs,
-	valid: true,
-	message: 'Country is valid',
-};
-
 export const Block = Template.bind({});
 Block.args = {
 	...defaultArgs,

--- a/packages/combobox/src/Combobox.tsx
+++ b/packages/combobox/src/Combobox.tsx
@@ -21,12 +21,10 @@ export type ComboboxProps<Option extends DefaultComboboxOption> = {
 	required?: boolean;
 	/** Provides extra information about the field. */
 	hint?: string;
-	/** Message to show when the field is invalid or valid. */
+	/** Message to show when the field is invalid. */
 	message?: string;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true, the valid state will be rendered. */
-	valid?: boolean;
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	disabled?: boolean;
@@ -38,7 +36,7 @@ export type ComboboxProps<Option extends DefaultComboboxOption> = {
 	showDropdownTrigger?: boolean;
 	/** The list of options to show in the dropdown. */
 	options?: Option[];
-	/** Function to be used when options need to be loaded over the newtwork. */
+	/** Function to be used when options need to be loaded over the network. */
 	loadOptions?: (inputValue: string) => Promise<Option[]>;
 	/** The value of the field. */
 	value?: Option | null;
@@ -56,7 +54,6 @@ export function Combobox<Option extends DefaultComboboxOption>({
 	hint,
 	message,
 	invalid,
-	valid,
 	id: idProp,
 	disabled,
 	block,
@@ -147,7 +144,6 @@ export function Combobox<Option extends DefaultComboboxOption>({
 			block,
 			maxWidth: 'xl',
 			invalid,
-			valid,
 		}),
 	};
 
@@ -159,7 +155,6 @@ export function Combobox<Option extends DefaultComboboxOption>({
 				hint={hint}
 				message={message}
 				invalid={invalid}
-				valid={valid}
 				id={inputId}
 			>
 				{(a11yProps) => (

--- a/packages/control-input/docs/overview.mdx
+++ b/packages/control-input/docs/overview.mdx
@@ -80,9 +80,9 @@ Vertically stacked radio buttons.
 };
 ```
 
-### Valid and invalid states
+### Invalid
 
-Add a border around the control inputs to indicate valid or invalid selections.
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
 () => {
@@ -103,40 +103,6 @@ Add a border around the control inputs to indicate valid or invalid selections.
 				Tablet
 			</Radio>
 			<Radio checked={isChecked('laptop')} onChange={handlerForKey('laptop')}>
-				Laptop
-			</Radio>
-		</ControlGroup>
-	);
-};
-```
-
-```jsx live
-() => {
-	const [value, setValue] = React.useState();
-	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
-	const isChecked = (key) => key === value;
-
-	return (
-		<ControlGroup label="Valid example" valid>
-			<Radio
-				checked={isChecked('phone')}
-				onChange={handlerForKey('phone')}
-				valid
-			>
-				Phone
-			</Radio>
-			<Radio
-				checked={isChecked('tablet')}
-				onChange={handlerForKey('tablet')}
-				valid
-			>
-				Tablet
-			</Radio>
-			<Radio
-				checked={isChecked('laptop')}
-				onChange={handlerForKey('laptop')}
-				valid
-			>
 				Laptop
 			</Radio>
 		</ControlGroup>

--- a/packages/control-input/src/Checkbox.stories.tsx
+++ b/packages/control-input/src/Checkbox.stories.tsx
@@ -35,10 +35,3 @@ Invalid.args = {
 	invalid: true,
 	disabled: false,
 };
-
-export const Valid = Template.bind({});
-Valid.args = {
-	children: 'Valid',
-	valid: true,
-	disabled: false,
-};

--- a/packages/control-input/src/Checkbox.tsx
+++ b/packages/control-input/src/Checkbox.tsx
@@ -28,15 +28,13 @@ type BaseCheckboxProps = PropsWithChildren<{
 export type CheckboxProps = BaseCheckboxProps & {
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true,  the valid state will be rendered. */
-	valid?: boolean;
 	/** The size of the input. */
 	size?: ControlSize;
 };
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 	function Checkbox(
-		{ children, disabled, invalid: invalidProp, valid, size = 'md', ...props },
+		{ children, disabled, invalid: invalidProp, size = 'md', ...props },
 		ref
 	) {
 		const controlGroupContext = useControlGroupContext();
@@ -53,12 +51,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 					}
 					{...props}
 				/>
-				<CheckboxIndicator
-					disabled={disabled}
-					invalid={invalid}
-					size={size}
-					valid={valid}
-				/>
+				<CheckboxIndicator disabled={disabled} invalid={invalid} size={size} />
 				<ControlLabel disabled={disabled} size={size}>
 					{children}
 				</ControlLabel>

--- a/packages/control-input/src/CheckboxIndicator.tsx
+++ b/packages/control-input/src/CheckboxIndicator.tsx
@@ -6,14 +6,12 @@ export type CheckboxIndicatorProps = {
 	disabled?: boolean;
 	invalid?: boolean;
 	size: ControlSize;
-	valid?: boolean;
 };
 
 export const CheckboxIndicator = ({
 	disabled,
 	invalid,
 	size,
-	valid,
 }: CheckboxIndicatorProps) => {
 	const { width, height, borderWidth } = packs.control[size];
 	return (
@@ -29,17 +27,10 @@ export const CheckboxIndicator = ({
 				borderStyle: 'solid',
 				borderColor: boxPalette.border,
 				opacity: disabled ? 0.3 : undefined,
-				...(invalid
-					? {
-							borderColor: boxPalette.systemError,
-							backgroundColor: boxPalette.systemErrorMuted,
-					  }
-					: valid
-					? {
-							borderColor: boxPalette.systemSuccess,
-							backgroundColor: boxPalette.systemSuccessMuted,
-					  }
-					: undefined),
+				...(invalid && {
+					borderColor: boxPalette.systemError,
+					backgroundColor: boxPalette.systemErrorMuted,
+				}),
 			}}
 			background="body"
 			color="text"

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -65,9 +65,7 @@ export const ControlGroup = ({
 					>
 						{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
 						{message && invalid ? (
-							<FieldMessage invalid={invalid} id={messageId}>
-								{message}
-							</FieldMessage>
+							<FieldMessage id={messageId}>{message}</FieldMessage>
 						) : null}
 						<Flex
 							gap={1}

--- a/packages/control-input/src/Radio.stories.tsx
+++ b/packages/control-input/src/Radio.stories.tsx
@@ -34,10 +34,3 @@ Invalid.args = {
 	invalid: true,
 	checked: true,
 };
-
-export const Valid = Template.bind({});
-Valid.args = {
-	children: 'Valid',
-	valid: true,
-	checked: true,
-};

--- a/packages/control-input/src/Radio.tsx
+++ b/packages/control-input/src/Radio.tsx
@@ -29,14 +29,12 @@ type BaseCheckboxProps = PropsWithChildren<{
 export type RadioProps = BaseCheckboxProps & {
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true,  the valid state will be rendered. */
-	valid?: boolean;
 	/** The size of the input. */
 	size?: ControlSize;
 };
 
 export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
-	{ children, disabled, invalid: invalidProp, valid, size = 'md', ...props },
+	{ children, disabled, invalid: invalidProp, size = 'md', ...props },
 	ref
 ) {
 	const controlGroupContext = useControlGroupContext();
@@ -51,12 +49,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 				aria-describedby={invalid ? controlGroupContext?.messageId : undefined}
 				{...props}
 			/>
-			<RadioIndicator
-				disabled={disabled}
-				invalid={invalid}
-				size={size}
-				valid={valid}
-			/>
+			<RadioIndicator disabled={disabled} invalid={invalid} size={size} />
 			<ControlLabel disabled={disabled} size={size}>
 				{children}
 			</ControlLabel>

--- a/packages/control-input/src/RadioIndicator.tsx
+++ b/packages/control-input/src/RadioIndicator.tsx
@@ -6,14 +6,12 @@ export type RadioIndicatorProps = {
 	disabled?: boolean;
 	invalid?: boolean;
 	size: ControlSize;
-	valid?: boolean;
 };
 
 export const RadioIndicator = ({
 	disabled,
 	invalid,
 	size,
-	valid,
 }: RadioIndicatorProps) => {
 	const { width, height, borderWidth } = packs.control[size];
 	return (
@@ -30,17 +28,10 @@ export const RadioIndicator = ({
 				borderStyle: 'solid',
 				borderColor: boxPalette.border,
 				opacity: disabled ? 0.3 : undefined,
-				...(invalid
-					? {
-							borderColor: boxPalette.systemError,
-							backgroundColor: boxPalette.systemErrorMuted,
-					  }
-					: valid
-					? {
-							borderColor: boxPalette.systemSuccess,
-							backgroundColor: boxPalette.systemSuccessMuted,
-					  }
-					: undefined),
+				...(invalid && {
+					borderColor: boxPalette.systemError,
+					backgroundColor: boxPalette.systemErrorMuted,
+				}),
 			}}
 			background="body"
 			color="text"

--- a/packages/date-picker/docs/overview.mdx
+++ b/packages/date-picker/docs/overview.mdx
@@ -31,24 +31,21 @@ Use the `block` prop to expand the component to fill the available space.
 };
 ```
 
-### Valid and invalid inputs
+### Invalid
 
-Use the `invalid` and `valid` props to indicate whether user input is valid (validates according to the elements settings) or invalid (does not validate according to the elements settings).
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
 () => {
 	const [value, setValue] = React.useState();
 	return (
-		<Stack gap={1}>
-			<DatePicker
-				label="Invalid"
-				invalid
-				message="This input is invalid"
-				value={value}
-				onChange={setValue}
-			/>
-			<DatePicker label="Valid" valid value={value} onChange={setValue} />
-		</Stack>
+		<DatePicker
+			label="Invalid"
+			invalid
+			message="This input is invalid"
+			value={value}
+			onChange={setValue}
+		/>
 	);
 };
 ```

--- a/packages/date-picker/src/DatePicker.stories.tsx
+++ b/packages/date-picker/src/DatePicker.stories.tsx
@@ -55,13 +55,6 @@ Invalid.args = {
 	invalid: true,
 };
 
-export const Valid = Template.bind({});
-Valid.args = {
-	label: 'Example',
-	message: 'The date you have entered is valid',
-	valid: true,
-};
-
 export const Hint = Template.bind({});
 Hint.args = {
 	label: 'Example',

--- a/packages/date-picker/src/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput.tsx
@@ -23,7 +23,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			hint,
 			message,
 			invalid,
-			valid,
 			block,
 			id,
 			buttonRef,
@@ -36,7 +35,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 		ref
 	) {
 		const { maxWidth, ...styles } = {
-			...textInputStyles({ block, invalid, maxWidth: maxWidthProp, valid }),
+			...textInputStyles({ block, invalid, maxWidth: maxWidthProp }),
 			width: '100%',
 			borderRight: 'none',
 			borderTopRightRadius: 0,
@@ -58,7 +57,6 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 				hint={hint}
 				message={message}
 				invalid={invalid}
-				valid={valid}
 				id={id}
 			>
 				{(a11yProps) => (

--- a/packages/field/docs/overview.mdx
+++ b/packages/field/docs/overview.mdx
@@ -44,22 +44,13 @@ Hints can be used to provide more context that will help the user successfully c
 Error messages are used to notify the user when a form field has not passed validation. Use clear messages to explain what went wrong and how to fix it.
 
 ```jsx live
-<Stack gap={1}>
-	<Field
-		label="Email"
-		invalid
-		message="Enter an email address in the correct format, like name@example.com"
-	>
-		{(a11yProps) => <input type="email" {...a11yProps} />}
-	</Field>
-	<Field
-		label="Email"
-		valid
-		message="The email address you have entered is valid"
-	>
-		{(a11yProps) => <input type="email" {...a11yProps} />}
-	</Field>
-</Stack>
+<Field
+	label="Email"
+	invalid
+	message="Enter an email address in the correct format, like name@example.com"
+>
+	{(a11yProps) => <input type="email" {...a11yProps} />}
+</Field>
 ```
 
 ### Required

--- a/packages/field/src/Field.stories.tsx
+++ b/packages/field/src/Field.stories.tsx
@@ -34,20 +34,11 @@ Invalid.args = {
 	invalid: true,
 };
 
-export const Valid: ComponentStory<typeof Field> = (args) => (
-	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
-);
-Valid.args = {
-	label: 'Valid',
-	message: 'This field is valid',
-	valid: true,
-};
-
 export const SecondaryLabel: ComponentStory<typeof Field> = (args) => (
 	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
 );
 SecondaryLabel.args = {
-	label: 'Valid',
+	label: 'Label',
 	secondaryLabel: '(dd/mm/yyy)',
 };
 
@@ -78,7 +69,9 @@ export const Modular: ComponentStory<typeof Field> = ({
 				{label}
 			</FieldLabel>
 			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
-			{message ? <FieldMessage id={messageId}>{message}</FieldMessage> : null}
+			{message && invalid ? (
+				<FieldMessage id={messageId}>{message}</FieldMessage>
+			) : null}
 			<input {...a11yProps} />
 		</FieldContainer>
 	);

--- a/packages/field/src/Field.test.tsx
+++ b/packages/field/src/Field.test.tsx
@@ -11,7 +11,6 @@ function renderField({
 	message = undefined,
 	required = true,
 	invalid = true,
-	valid = undefined,
 	children = (a11yProps) => (
 		<input data-testid="example-input" type="text" {...a11yProps} />
 	),
@@ -24,7 +23,6 @@ function renderField({
 			message={message}
 			required={required}
 			invalid={invalid}
-			valid={valid}
 			{...props}
 		>
 			{children}

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -17,12 +17,10 @@ export type FieldProps = {
 	label: string;
 	/** Override the default secondary label. */
 	secondaryLabel?: string;
-	/** Message to show when the field is invalid or valid. */
+	/** Message to show when the field is invalid. */
 	message: string | undefined;
 	/** If false, "(optional)" will be appended to the label. */
 	required: boolean;
-	/** If true, the valid state will be rendered. */
-	valid?: boolean;
 };
 
 export const Field = ({
@@ -34,7 +32,6 @@ export const Field = ({
 	secondaryLabel,
 	message,
 	required,
-	valid,
 }: FieldProps) => {
 	const { fieldId, hintId, messageId } = useFieldIds(id);
 
@@ -58,10 +55,8 @@ export const Field = ({
 				{label}
 			</FieldLabel>
 			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
-			{message && (invalid || valid) ? (
-				<FieldMessage id={messageId} invalid={invalid} valid={valid}>
-					{message}
-				</FieldMessage>
+			{message && invalid ? (
+				<FieldMessage id={messageId}>{message}</FieldMessage>
 			) : null}
 			{typeof children === 'function' ? children(a11yProps) : children}
 		</FieldContainer>

--- a/packages/field/src/FieldMessage.tsx
+++ b/packages/field/src/FieldMessage.tsx
@@ -7,7 +7,7 @@ export const FieldMessage = ({
 	id,
 }: {
 	children: string;
-	id?: string;
+	id: string;
 }) => (
 	<Flex gap={0.5} alignItems="center">
 		<Box flexShrink={0}>

--- a/packages/field/src/FieldMessage.tsx
+++ b/packages/field/src/FieldMessage.tsx
@@ -5,44 +5,22 @@ import { Text } from '@ag.ds-next/text';
 export const FieldMessage = ({
 	children,
 	id,
-	invalid,
-	valid,
 }: {
 	children: string;
 	id?: string;
-	invalid?: boolean;
-	valid?: boolean;
 }) => (
 	<Flex gap={0.5} alignItems="center">
-		{invalid ? (
-			<Box flexShrink={0}>
-				<AlertFilledIcon
-					color="error"
-					size="md"
-					aria-label="Error"
-					aria-hidden="false"
-					css={{ display: 'block' }}
-				/>
-			</Box>
-		) : null}
-		<Text
-			display="block"
-			fontWeight="bold"
-			color={getColor({ invalid, valid })}
-			id={id}
-		>
+		<Box flexShrink={0}>
+			<AlertFilledIcon
+				color="error"
+				size="md"
+				aria-label="Error"
+				aria-hidden="false"
+				css={{ display: 'block' }}
+			/>
+		</Box>
+		<Text display="block" fontWeight="bold" color="error" id={id}>
 			{children}
 		</Text>
 	</Flex>
 );
-
-const getColor = ({
-	invalid,
-	valid,
-}: {
-	invalid?: boolean;
-	valid?: boolean;
-}) => {
-	if (invalid) return 'error';
-	if (valid) return 'success';
-};

--- a/packages/file-upload/src/FileUpload.stories.tsx
+++ b/packages/file-upload/src/FileUpload.stories.tsx
@@ -57,13 +57,6 @@ Invalid.args = {
 	invalid: true,
 };
 
-export const Valid = TemplateWithValue.bind({});
-Valid.args = {
-	label: 'Drivers licence',
-	message: 'The file you have submitted is valid',
-	valid: true,
-};
-
 export const MultipleFiles = Template.bind({});
 MultipleFiles.args = {
 	label: 'Identity documents',

--- a/packages/file-upload/src/FileUpload.tsx
+++ b/packages/file-upload/src/FileUpload.tsx
@@ -36,7 +36,7 @@ type BaseInputProps = {
 };
 
 export type FileUploadProps = BaseInputProps & {
-	/** List of acceptible file types, e.g.`image/jpeg`, `application/pdf` */
+	/** List of acceptable file types, e.g.`image/jpeg`, `application/pdf` */
 	accept?: FileFormats[];
 	/** A label that describes the field*/
 	label: string;
@@ -52,14 +52,12 @@ export type FileUploadProps = BaseInputProps & {
 	required?: boolean;
 	/** Provides extra information about the field. */
 	hint?: string;
-	/** Message to show when the field is invalid or valid. */
+	/** Message to show when the field is invalid. */
 	message?: string;
 	/** Whether multiple files are allowed to be selected. */
 	multiple?: boolean;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true, the valid state will be rendered. */
-	valid?: boolean;
 };
 
 type RejectedFile = {
@@ -85,7 +83,6 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			hint,
 			message,
 			invalid,
-			valid,
 			id,
 			...consumerProps
 		},
@@ -144,7 +141,6 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 		const styles = fileInputStyles({
 			disabled,
 			invalid: invalid || !!errorSummary,
-			valid,
 		});
 
 		useEffect(() => {
@@ -190,7 +186,6 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 				hint={hint}
 				message={message || errorSummary}
 				invalid={invalid || !!errorSummary}
-				valid={valid}
 				id={id}
 			>
 				{(a11yProps) => {
@@ -291,11 +286,9 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 export const fileInputStyles = ({
 	disabled,
 	invalid,
-	valid,
 }: {
 	disabled?: boolean;
 	invalid?: boolean;
-	valid?: boolean;
 	multiline?: boolean;
 }) =>
 	({
@@ -303,23 +296,17 @@ export const fileInputStyles = ({
 		borderStyle: 'dashed',
 		borderColor: boxPalette.border,
 		backgroundColor: boxPalette.backgroundShade,
-		...(invalid
-			? {
-					backgroundColor: boxPalette.systemErrorMuted,
-					borderColor: boxPalette.systemError,
-			  }
-			: valid
-			? {
-					backgroundColor: boxPalette.systemSuccessMuted,
-					borderColor: boxPalette.systemSuccess,
-			  }
-			: disabled
-			? {
-					cursor: 'not-allowed',
-					opacity: 0.3,
-					background: 'none',
-			  }
-			: undefined),
+
+		...(invalid && {
+			backgroundColor: boxPalette.systemErrorMuted,
+			borderColor: boxPalette.systemError,
+		}),
+
+		...(disabled && {
+			cursor: 'not-allowed',
+			opacity: 0.3,
+			background: 'none',
+		}),
 
 		'&:focus': packs.outline,
 	} as const);

--- a/packages/select/docs/overview.mdx
+++ b/packages/select/docs/overview.mdx
@@ -78,34 +78,22 @@ The `Select` component will always append `(optional)` to the label based on the
 </Stack>
 ```
 
-### Valid and invalid selects
+### Invalid
 
-Use the `invalid` and `valid` props to indicate whether user select is valid (validates according to the elements settings) or invalid (does not validate according to the elements settings).
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
-<Stack gap={1}>
-	<Select
-		label="Invalid"
-		placeholder="Please select"
-		invalid
-		message="This select is invalid"
-		options={[
-			{ value: 'a', label: 'Option A' },
-			{ value: 'b', label: 'Option B' },
-			{ value: 'c', label: 'Option C' },
-		]}
-	/>
-	<Select
-		label="Valid"
-		placeholder="Please select"
-		valid
-		options={[
-			{ value: 'a', label: 'Option A' },
-			{ value: 'b', label: 'Option B' },
-			{ value: 'c', label: 'Option C' },
-		]}
-	/>
-</Stack>
+<Select
+	label="Invalid"
+	placeholder="Please select"
+	invalid
+	message="This select is invalid"
+	options={[
+		{ value: 'a', label: 'Option A' },
+		{ value: 'b', label: 'Option B' },
+		{ value: 'c', label: 'Option C' },
+	]}
+/>
 ```
 
 ### Disabled

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -77,19 +77,6 @@ Invalid.args = {
 	options: EXAMPLE_OPTIONS,
 };
 
-export const Valid: ComponentStory<typeof Select> = (args) => (
-	<Select {...args} />
-);
-Valid.args = {
-	label: 'Example',
-	placeholder: 'Please select',
-	message: 'This select is valid',
-	required: true,
-	valid: true,
-	options: EXAMPLE_OPTIONS,
-	value: EXAMPLE_OPTIONS[0].value,
-};
-
 export const Hint: ComponentStory<typeof Select> = (args) => (
 	<Select {...args} />
 );

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -43,12 +43,10 @@ export type SelectProps = BaseSelectProps & {
 	required?: boolean;
 	/** Provides extra information about the field. */
 	hint?: string;
-	/** Message to show when the field is invalid or valid. */
+	/** Message to show when the field is invalid. */
 	message?: string;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true, the valid state will be rendered. */
-	valid?: boolean;
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
@@ -63,7 +61,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 			hint,
 			message,
 			invalid,
-			valid,
 			block,
 			maxWidth,
 			options,
@@ -73,7 +70,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 		},
 		ref
 	) {
-		const styles = selectStyles({ block, invalid, valid });
+		const styles = selectStyles({ block, invalid });
 		return (
 			<Field
 				label={label}
@@ -81,7 +78,6 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 				hint={hint}
 				message={message}
 				invalid={invalid}
-				valid={valid}
 				id={id}
 			>
 				{(a11yProps) => (
@@ -170,11 +166,9 @@ const SelectIcon = ({ disabled }: { disabled?: boolean }) => (
 const selectStyles = ({
 	block,
 	invalid,
-	valid,
 }: {
 	block?: boolean;
 	invalid?: boolean;
-	valid?: boolean;
 }) =>
 	({
 		position: 'relative',
@@ -199,17 +193,10 @@ const selectStyles = ({
 			display: 'block',
 		}),
 
-		...(invalid
-			? {
-					backgroundColor: boxPalette.systemErrorMuted,
-					borderColor: boxPalette.systemError,
-			  }
-			: valid
-			? {
-					backgroundColor: boxPalette.systemSuccessMuted,
-					borderColor: boxPalette.systemSuccess,
-			  }
-			: undefined),
+		...(invalid && {
+			backgroundColor: boxPalette.systemErrorMuted,
+			borderColor: boxPalette.systemError,
+		}),
 
 		'&:disabled': {
 			cursor: 'not-allowed',

--- a/packages/text-input/docs/overview.mdx
+++ b/packages/text-input/docs/overview.mdx
@@ -33,15 +33,12 @@ The `TextInput` component will always append `(optional)` to the label based on 
 </Stack>
 ```
 
-### Valid and invalid inputs
+### Invalid
 
-Use the `invalid` and `valid` props to indicate whether user input is valid (validates according to the elements settings) or invalid (does not validate according to the elements settings).
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
-<Stack gap={1}>
-	<TextInput label="Invalid" invalid message="This input is invalid" />
-	<TextInput label="Valid" valid />
-</Stack>
+<TextInput label="Invalid" invalid message="This input is invalid" />
 ```
 
 ### Disabled

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -41,17 +41,6 @@ Invalid.args = {
 	invalid: true,
 };
 
-export const Valid: ComponentStory<typeof TextInput> = (args) => (
-	<TextInput {...args} />
-);
-Valid.args = {
-	type: 'email',
-	label: 'Email',
-	message: 'The email address you have entered is valid',
-	value: 'hello@example.com',
-	valid: true,
-};
-
 export const Hint: ComponentStory<typeof TextInput> = (args) => (
 	<TextInput {...args} />
 );

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -27,12 +27,10 @@ export type TextInputProps = BaseTextInputProps & {
 	required?: boolean;
 	/** Provides extra information about the field. */
 	hint?: string;
-	/** Message to show when the field is invalid or valid. */
+	/** Message to show when the field is invalid. */
 	message?: string;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true, the valid state will be rendered. */
-	valid?: boolean;
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
@@ -47,7 +45,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			hint,
 			message,
 			invalid,
-			valid,
 			block,
 			maxWidth,
 			id,
@@ -56,7 +53,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 		},
 		ref
 	) {
-		const styles = textInputStyles({ block, maxWidth, invalid, valid });
+		const styles = textInputStyles({ block, maxWidth, invalid });
 		return (
 			<Field
 				label={label}
@@ -64,7 +61,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 				hint={hint}
 				message={message}
 				invalid={invalid}
-				valid={valid}
 				id={id}
 			>
 				{(a11yProps) => (
@@ -79,13 +75,11 @@ export const textInputStyles = ({
 	block,
 	maxWidth,
 	invalid,
-	valid,
 	multiline,
 }: {
 	block?: boolean;
 	maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 	invalid?: boolean;
-	valid?: boolean;
 	multiline?: boolean;
 }) =>
 	({
@@ -110,17 +104,10 @@ export const textInputStyles = ({
 			width: '100%',
 		}),
 
-		...(invalid
-			? {
-					backgroundColor: boxPalette.systemErrorMuted,
-					borderColor: boxPalette.systemError,
-			  }
-			: valid
-			? {
-					backgroundColor: boxPalette.systemSuccessMuted,
-					borderColor: boxPalette.systemSuccess,
-			  }
-			: undefined),
+		...(invalid && {
+			backgroundColor: boxPalette.systemErrorMuted,
+			borderColor: boxPalette.systemError,
+		}),
 
 		...(multiline && {
 			paddingTop: mapSpacing(0.5),

--- a/packages/textarea/docs/overview.mdx
+++ b/packages/textarea/docs/overview.mdx
@@ -33,15 +33,12 @@ The `Textarea` component will always append `(optional)` to the label based on t
 </Stack>
 ```
 
-### Valid and invalid textareas
+### Invalid
 
-Use the `invalid` and `valid` props to indicate whether user input is valid (validates according to the elements settings) or invalid (does not validate according to the elements settings).
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 ```jsx live
-<Stack gap={1}>
-	<Textarea label="Invalid" invalid message="This field is invalid" />
-	<Textarea label="Valid" valid message="This field is valid" />
-</Stack>
+<Textarea label="Invalid" invalid message="This field is invalid" />
 ```
 
 ### Disabled

--- a/packages/textarea/src/Textarea.stories.tsx
+++ b/packages/textarea/src/Textarea.stories.tsx
@@ -40,16 +40,6 @@ Invalid.args = {
 	invalid: true,
 };
 
-export const Valid: ComponentStory<typeof Textarea> = (args) => (
-	<Textarea {...args} />
-);
-Valid.args = {
-	label: 'Message',
-	message: 'The message you have entered is valid',
-	value: 'Lorem ipsum dolar',
-	valid: true,
-};
-
 export const Hint: ComponentStory<typeof Textarea> = (args) => (
 	<Textarea {...args} />
 );

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -25,12 +25,10 @@ export type TextareaProps = BaseTextareaProps & {
 	required?: boolean;
 	/** Provides extra information about the field. */
 	hint?: string;
-	/** Message to show when the field is invalid or valid. */
+	/** Message to show when the field is invalid. */
 	message?: string;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
-	/** If true, the valid state will be rendered. */
-	valid?: boolean;
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
@@ -39,25 +37,13 @@ export type TextareaProps = BaseTextareaProps & {
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 	function Textarea(
-		{
-			label,
-			required,
-			hint,
-			message,
-			invalid,
-			valid,
-			block,
-			maxWidth,
-			id,
-			...props
-		},
+		{ label, required, hint, message, invalid, block, maxWidth, id, ...props },
 		ref
 	) {
 		const styles = textInputStyles({
 			block,
 			maxWidth,
 			invalid,
-			valid,
 			multiline: true,
 		});
 		return (
@@ -67,7 +53,6 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 				hint={hint}
 				message={message}
 				invalid={invalid}
-				valid={valid}
 				id={id}
 			>
 				{(a11yProps) => (


### PR DESCRIPTION
## Describe your changes

Removed `valid` from all form components, this feature is no longer be supported.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook