### PR TITLE
summary-list: Prevent term from shrinking

### DIFF
--- a/.changeset/nine-poets-chew.md
+++ b/.changeset/nine-poets-chew.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/summary-list': patch
+---
+
+Added flex shrinking to `SummaryListItemTerm` to fix where term widths were uneven.

--- a/.changeset/nine-poets-chew.md
+++ b/.changeset/nine-poets-chew.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/summary-list': patch
 ---
 
-Added flex shrinking to `SummaryListItemTerm` to fix where term widths were uneven.
+Prevented flex shrinking of `SummaryListItemTerm` to ensure the width of this element is always the same.

--- a/packages/summary-list/src/SummaryList.tsx
+++ b/packages/summary-list/src/SummaryList.tsx
@@ -14,6 +14,7 @@ export function SummaryListItemTerm({ children }: SummaryListItemTermProps) {
 			as="dt"
 			fontWeight="bold"
 			width={['100%', '30%']}
+			flexShrink={0}
 			minWidth="200px"
 			fontSize="sm"
 		>

--- a/packages/summary-list/src/__snapshots__/SummaryList.test.tsx.snap
+++ b/packages/summary-list/src/__snapshots__/SummaryList.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-1py73rt-boxStyles"
+        class="css-y9ojh3-boxStyles"
       >
         First name
       </dt>
@@ -33,7 +33,7 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-1py73rt-boxStyles"
+        class="css-y9ojh3-boxStyles"
       >
         Last name
       </dt>
@@ -57,7 +57,7 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-1py73rt-boxStyles"
+        class="css-y9ojh3-boxStyles"
       >
         Contact information
       </dt>
@@ -83,7 +83,7 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-1py73rt-boxStyles"
+        class="css-y9ojh3-boxStyles"
       >
         Date of birth
       </dt>


### PR DESCRIPTION
## Describe your changes

Prevented flex shrinking of `SummaryListItemTerm` to ensure the width of this element is always the same.

| Before      | After |
| ----------- | ----------- |
| <img width="837" alt="Screen Shot 2022-11-15 at 1 24 49 pm" src="https://user-images.githubusercontent.com/6265154/201819824-d87edad4-606c-4e6f-9bb9-5906cfb668b2.png"> | <img width="838" alt="Screen Shot 2022-11-15 at 1 24 33 pm" src="https://user-images.githubusercontent.com/6265154/201819818-05b2cc2a-4201-4c2e-9092-0b991ba7a608.png"> | 

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook