### PR TITLE
Prose: Increase spacing before block elements

### DIFF
--- a/.changeset/wild-goats-marry.md
+++ b/.changeset/wild-goats-marry.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/prose': patch
+---
+
+Increase spacing before block elements

--- a/packages/page-alert/src/PageAlert.stories.tsx
+++ b/packages/page-alert/src/PageAlert.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Text } from '@ag.ds-next/text';
+import { Prose } from '@ag.ds-next/prose';
 import { PageAlert } from './PageAlert';
 
 export default {
@@ -15,4 +16,23 @@ export const Basic: ComponentStory<typeof PageAlert> = (args) => (
 Basic.args = {
 	title: 'Page Alert',
 	tone: 'success',
+};
+
+export const WithProse: ComponentStory<typeof PageAlert> = (args) => (
+	<PageAlert {...args}>
+		<Prose>
+			<ul>
+				<li>
+					<a href="#">Full name must not be empty</a>
+				</li>
+				<li>
+					<a href="#">Phone number must not be empty</a>
+				</li>
+			</ul>
+		</Prose>
+	</PageAlert>
+);
+WithProse.args = {
+	title: 'Page Alert',
+	tone: 'error',
 };

--- a/packages/page-alert/src/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/page-alert/src/__snapshots__/PageAlert.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
         There is a problem
       </h3>
       <div
-        class="css-sz60sj-boxStyles-proseClass"
+        class="css-1llvgqx-boxStyles-proseClass"
       >
         <ul>
           <li>

--- a/packages/prose/src/Prose.tsx
+++ b/packages/prose/src/Prose.tsx
@@ -42,7 +42,7 @@ export const proseClass = css({
 	 * Prose block
 	 */
 	[`* + .${proseBlockClassname}:not(.${unsetProseStylesClassname} *)`]: {
-		marginTop: mapSpacing(1.5),
+		marginTop: mapSpacing(2),
 	},
 
 	/**


### PR DESCRIPTION
## Describe your changes
Requested in a comment in [Product Backlog Item 277300](https://dev.azure.com.mcas.ms/agriculturegovau/Digital%20Services/_workitems/edit/277300?McasTsid=26110)

Subtle improvement to increase spacing before elements with the proseBlockClassname, from 1.5rem to 2rem.

Before: 
<img width="696" alt="image" src="https://user-images.githubusercontent.com/12689383/202039082-437dc5b3-8f82-4cc5-8dfe-fd7a2d11eeeb.png">


After: 
<img width="779" alt="image" src="https://user-images.githubusercontent.com/12689383/202038945-a7f05a7b-15d9-4b9a-8e00-5999be9e69bf.png">

Also added a Storybook example for a PageAlert with Prose. While this is not related, I was prompted to add it by the regenerated snapshot.

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [x] Create stories for Storybook