### PR TITLE
DAGR-111: Add tabIndex to skip links targets

### DIFF
--- a/.changeset/big-lemons-bow.md
+++ b/.changeset/big-lemons-bow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/content': patch
+---
+
+Added support for `tabIndex` in `BaseContent`

--- a/.changeset/spotty-teachers-matter.md
+++ b/.changeset/spotty-teachers-matter.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/main-nav': patch
+---
+
+Added tab index to navigation container to improve accessibility when used with skip links

--- a/docs/components/PageLayout.tsx
+++ b/docs/components/PageLayout.tsx
@@ -46,6 +46,8 @@ export function PageLayout({
 					columnStart={{ lg: sideNav ? 5 : 1 }}
 					as="main"
 					id="main-content"
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
 				>
 					{skipLinks?.length ? <SkipLinks links={skipLinks} /> : null}
 					<Stack flexGrow={1} gap={3}>

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -11,7 +11,12 @@ export default function NotFoundPage() {
 		<>
 			<DocumentTitle title="Error 404" />
 			<AppLayout>
-				<PageContent as="main" id="main-content">
+				<PageContent
+					as="main"
+					id="main-content"
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
+				>
 					<Stack gap={1.5}>
 						<H1>Page not found</H1>
 						<Text as="p" fontSize="md">

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -19,7 +19,11 @@ export default function Homepage() {
 		<>
 			<DocumentTitle />
 			<AppLayout>
-				<main id="main-content">
+				<main
+					id="main-content"
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
+				>
 					<HeroBanner>
 						<HeroBannerTitleContainer>
 							<HeroBannerTitle>

--- a/example-form/components/AppLayout.tsx
+++ b/example-form/components/AppLayout.tsx
@@ -28,7 +28,13 @@ export const AppLayout = ({
 				minHeight="100vh"
 			>
 				<SiteHeader focusMode={focusMode} />
-				<Box as="main" id="main-content" flexGrow={1}>
+				<Box
+					as="main"
+					id="main-content"
+					flexGrow={1}
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
+				>
 					{children}
 				</Box>
 				<SiteFooter />

--- a/example-form/pages/not-found.tsx
+++ b/example-form/pages/not-found.tsx
@@ -12,7 +12,12 @@ export default function NotFoundPage() {
 		<>
 			<DocumentTitle title="Page not found" />
 			<AppLayout>
-				<PageContent as="main" id="main-content">
+				<PageContent
+					as="main"
+					id="main-content"
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
+				>
 					<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
 						<H1>Oops! This page does not exist.</H1>
 						<Text as="p" fontSize="md">

--- a/example-site/components/AppLayout.tsx
+++ b/example-site/components/AppLayout.tsx
@@ -32,7 +32,13 @@ export const AppLayout = ({
 			>
 				{template ? <TemplateBanner {...template} /> : null}
 				<SiteHeader focusMode={focusMode} />
-				<Box as="main" id="main-content" flexGrow={1}>
+				<Box
+					as="main"
+					id="main-content"
+					flexGrow={1}
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
+				>
 					{children}
 				</Box>
 				<SiteFooter />

--- a/example-site/pages/404.tsx
+++ b/example-site/pages/404.tsx
@@ -11,7 +11,12 @@ export default function NotFoundPage() {
 		<>
 			<DocumentTitle title="Error 404" />
 			<AppLayout template={{ name: '404', slug: '404' }}>
-				<PageContent as="main" id="main-content">
+				<PageContent
+					as="main"
+					id="main-content"
+					tabIndex={-1}
+					css={{ '&:focus': { outline: 'none' } }}
+				>
 					<Stack gap={1.5}>
 						<H1>Page not found</H1>
 						<Text as="p" fontSize="md">

--- a/packages/content/src/BaseContent.tsx
+++ b/packages/content/src/BaseContent.tsx
@@ -9,6 +9,7 @@ export type BaseContentProps = PropsWithChildren<
 		as?: ElementType;
 		id?: string;
 		className?: string;
+		tabIndex?: number;
 	} & Pick<BoxProps, 'background' | 'palette'>
 >;
 
@@ -20,6 +21,7 @@ export function BaseContent({
 	as = 'section',
 	id,
 	className,
+	tabIndex,
 	palette,
 	background,
 	children,
@@ -34,6 +36,7 @@ export function BaseContent({
 				background={background}
 				id={id}
 				className={className}
+				tabIndex={tabIndex}
 			>
 				<Box
 					width="100%"

--- a/packages/main-nav/src/NavContainer.tsx
+++ b/packages/main-nav/src/NavContainer.tsx
@@ -57,11 +57,13 @@ export function NavContainer({
 	return (
 		<Box
 			id={id}
+			tabIndex={-1}
 			ref={containerRef}
 			background={background}
 			color="text"
 			css={{
 				position: 'relative',
+				'&:focus': { outline: 'none' },
 				[localPaletteVars.linkHoverBg]: backgroundColorMap[hover],
 				[localPaletteVars.linkActiveBg]: backgroundColorMap[background],
 				[localPaletteVars.bottomBar]: boxPalette.accent,

--- a/packages/main-nav/src/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/main-nav/src/__snapshots__/MainNav.test.tsx.snap
@@ -3,7 +3,8 @@
 exports[`MainNav renders correctly 1`] = `
 <div>
   <div
-    class="css-ek7e6t-boxStyles-NavContainer"
+    class="css-1yqb0ov-boxStyles-NavContainer"
+    tabindex="-1"
   >
     <div
       class="css-51kibj-boxStyles-BottomBar"

--- a/packages/skip-link/docs/overview.mdx
+++ b/packages/skip-link/docs/overview.mdx
@@ -16,7 +16,7 @@ Skip links are not visual until they receive focus. Include skip links after the
 		]}
 	/>
 	<MainNav id="main-nav" ... />
-	<main id="main-content">
+	<main id="main-content" tabIndex={-1} css={{ '&:focus': { outline: 'none' } }}>
 		...
 	</main>
 </React.Fragment>

--- a/packages/skip-link/src/SkipLinks.stories.tsx
+++ b/packages/skip-link/src/SkipLinks.stories.tsx
@@ -26,7 +26,7 @@ export const Basic = () => (
 
 export const Modular = () => (
 	<Fragment>
-		<SkipLinkContainer aria-label="skip links navigation">
+		<SkipLinkContainer aria-label="skip links">
 			<SkipLinkItem href="#main-content">Skip to main content</SkipLinkItem>
 			<SkipLinkItem href="#main-nav">Skip to main navigation</SkipLinkItem>
 		</SkipLinkContainer>

--- a/packages/skip-link/src/SkipLinks.stories.tsx
+++ b/packages/skip-link/src/SkipLinks.stories.tsx
@@ -38,14 +38,18 @@ const ExampleContent = () => (
 	<Prose>
 		<Stack gap={4}>
 			<p>This example space contains a visually hidden feature.</p>
-			<nav id="main-nav">
+			<nav id="main-nav" tabIndex={-1} css={{ '&:focus': { outline: 'none' } }}>
 				<ul>
 					<li>
 						<a href="#">Some navigation</a>
 					</li>
 				</ul>
 			</nav>
-			<main id="main-content">
+			<main
+				id="main-content"
+				tabIndex={-1}
+				css={{ '&:focus': { outline: 'none' } }}
+			>
 				Some content here with <a href="#">an example link</a>
 			</main>
 		</Stack>


### PR DESCRIPTION
## Describe your changes

Alternative to #835 

This PR improves the accessibility of our skip links across all of our websites, by adding `tabIndex={-1}` to all elements which are targets of skip links. No focus ring is shown which keeps the visual behaviour the same as what we currently have.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook