### PR TITLE
example-form: Fix bug in NVDA by moving call to `startTask`

### DIFF
--- a/example-form/components/FormRegisterPetContext.tsx
+++ b/example-form/components/FormRegisterPetContext.tsx
@@ -20,8 +20,8 @@ type ContextType = {
 	/** The task form state. */
 	task1FormState: FormState[0];
 	task2FormState: FormState[1];
-	/** Function to be called to start a task */
-	startTask: (taskIdx: number) => void;
+	/** Function to be called to start a task. Ensures the statuses on the home page task list is updated correctly. */
+	startTask: (taskNumber: number) => void;
 	/** Function to get the status of a task. */
 	getTaskStatus: (taskIndex: number) => ProgressIndicatorItemStatus;
 	/** Function to be called at the end of task 1 (personal details). */
@@ -128,8 +128,8 @@ export const FormRegisterPetContext = ({
 		[currentTaskIdx, formState]
 	);
 
-	const startTask = useCallback((taskIdx: number) => {
-		setCurrentTaskIdx(taskIdx);
+	const startTask = useCallback((taskNumber: number) => {
+		setCurrentTaskIdx(taskNumber - 1);
 	}, []);
 
 	const contextValue = {

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
@@ -2,6 +2,7 @@ import {
 	createContext,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
 	useState,
 } from 'react';
@@ -107,11 +108,16 @@ export const formSchema = yup.object({
 });
 
 export const FormRegisterPetDetails = () => {
-	const { submitTask2, task2FormState } = useFormRegisterPet();
+	const { startTask, submitTask2, task2FormState } = useFormRegisterPet();
 
 	const router = useRouter();
 	const [currentStep, setCurrentStep] = useState(0);
 	const [formState, setFormState] = useState<FormState>(task2FormState);
+
+	/** Call `startTask` when the user first visits this task */
+	useEffect(() => {
+		startTask(2);
+	}, [startTask]);
 
 	const backToHomePage = useCallback(() => {
 		router.push('/services/registrations/pet');

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetails.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetails.tsx
@@ -2,6 +2,7 @@ import {
 	createContext,
 	useCallback,
 	useContext,
+	useEffect,
 	useMemo,
 	useState,
 } from 'react';
@@ -96,10 +97,15 @@ export const formSchema = yup.object({
 });
 
 export const FormRegisterPetPersonalDetails = () => {
-	const { submitTask1, task1FormState } = useFormRegisterPet();
+	const { startTask, submitTask1, task1FormState } = useFormRegisterPet();
 	const router = useRouter();
 	const [currentStep, setCurrentStep] = useState(0);
 	const [formState, setFormState] = useState<FormState>(task1FormState);
+
+	/** Call `startTask` when the user first visits this task */
+	useEffect(() => {
+		startTask(1);
+	}, [startTask]);
 
 	const backToHomePage = useCallback(() => {
 		router.push('/services/registrations/pet');

--- a/example-form/pages/services/registrations/pet/index.tsx
+++ b/example-form/pages/services/registrations/pet/index.tsx
@@ -26,7 +26,7 @@ const TASKS = [
 ];
 
 export default function FormRegisterPetHomePage() {
-	const { startTask, getTaskStatus } = useFormRegisterPet();
+	const { getTaskStatus } = useFormRegisterPet();
 	return (
 		<>
 			<DocumentTitle title="Register a pet" />
@@ -68,7 +68,6 @@ export default function FormRegisterPetHomePage() {
 								<TaskList
 									items={TASKS.map((task, idx) => ({
 										...task,
-										onClick: () => startTask(idx),
 										status: getTaskStatus(idx),
 									}))}
 								/>


### PR DESCRIPTION
## Describe your changes

For every list item in the register your pet "task list" we use the combination of an anchor tag + an `onClick` event to set some state of the "active task". In some instances, the state update causes a small re-render of the current page BEFORE navigation to the next page. 

This is causing an issue in NVDA where the focused element doesn't get moved to the body, as expected when performing a route change.

To fix this, we have removed the `onClick` from each task list item to make them just regular anchor tags. The functionality that was in the `onClick` event has now been moved into a `useEffect` on each task page.

