### PR TITLE
icon: Use 4px stroke width for small bold icons

### DIFF
--- a/.changeset/brave-days-sin.md
+++ b/.changeset/brave-days-sin.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/icon': patch
+---
+
+Enable dynamic weights to show thicker strokes at small sizes.

--- a/packages/accordion/src/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/accordion/src/__snapshots__/Accordion.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Accordion renders correctly 1`] = `
           Accordion 1
           <svg
             aria-hidden="true"
-            class="css-5ae1oq-Icon"
+            class="css-iv9u8h-Icon"
             clip-rule="evenodd"
             focusable="false"
             height="24"
@@ -73,7 +73,7 @@ exports[`Accordion renders correctly 1`] = `
           Accordion 2
           <svg
             aria-hidden="true"
-            class="css-5ae1oq-Icon"
+            class="css-iv9u8h-Icon"
             clip-rule="evenodd"
             focusable="false"
             height="24"

--- a/packages/call-to-action/src/__snapshots__/CallToAction.test.tsx.snap
+++ b/packages/call-to-action/src/__snapshots__/CallToAction.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`CallToActionButton renders correctly 1`] = `
       Sign up
       <svg
         aria-hidden="true"
-        class="css-5ae1oq-Icon"
+        class="css-iv9u8h-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -45,7 +45,7 @@ exports[`CallToActionLink renders correctly 1`] = `
       Sign up
       <svg
         aria-hidden="true"
-        class="css-5ae1oq-Icon"
+        class="css-iv9u8h-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"

--- a/packages/card/src/__snapshots__/Card.test.tsx.snap
+++ b/packages/card/src/__snapshots__/Card.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Card With link renders correctly 1`] = `
           Linking out
           <svg
             aria-hidden="true"
-            class="css-5ae1oq-Icon"
+            class="css-iv9u8h-Icon"
             clip-rule="evenodd"
             focusable="false"
             height="24"

--- a/packages/details/src/__snapshots__/Details.test.tsx.snap
+++ b/packages/details/src/__snapshots__/Details.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Details renders correctly 1`] = `
       Details
       <svg
         aria-hidden="true"
-        class="css-5ae1oq-Icon"
+        class="css-iv9u8h-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -16,6 +16,10 @@ const iconSizes = {
 	xl: 2.5, // 40px
 } as const;
 
+type IconSize = keyof typeof iconSizes;
+
+// enables a visible difference between regular
+// and bold icons for small sizes.
 const iconWeights = {
 	regular: {
 		sm: 2,
@@ -24,8 +28,6 @@ const iconWeights = {
 		xl: 2,
 	},
 	bold: {
-		// enables a visible difference between regular
-		// and bold icons for small sizes.
 		sm: 4,
 		md: 3,
 		lg: 3,
@@ -33,7 +35,6 @@ const iconWeights = {
 	},
 };
 
-type IconSize = keyof typeof iconSizes;
 type IconWeight = keyof typeof iconWeights;
 
 type NativeSvgProps = SVGAttributes<SVGSVGElement>;

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -24,8 +24,8 @@ const iconWeights = {
 		xl: 2,
 	},
 	bold: {
-		// enables a visible difference between regular and bold icons
-		// for small sizes.
+		// enables a visible difference between regular
+		// and bold icons for small sizes.
 		sm: 4,
 		md: 3,
 		lg: 3,

--- a/packages/icon/src/Icon.tsx
+++ b/packages/icon/src/Icon.tsx
@@ -16,7 +16,25 @@ const iconSizes = {
 	xl: 2.5, // 40px
 } as const;
 
+const iconWeights = {
+	regular: {
+		sm: 2,
+		md: 2,
+		lg: 2,
+		xl: 2,
+	},
+	bold: {
+		// enables a visible difference between regular and bold icons
+		// for small sizes.
+		sm: 4,
+		md: 3,
+		lg: 3,
+		xl: 3,
+	},
+};
+
 type IconSize = keyof typeof iconSizes;
+type IconWeight = keyof typeof iconWeights;
 
 type NativeSvgProps = SVGAttributes<SVGSVGElement>;
 
@@ -27,7 +45,7 @@ export type IconProps = {
 	color?: IconColor;
 	size?: IconSize;
 	style?: NativeSvgProps['style'];
-	weight?: 'regular' | 'bold';
+	weight?: IconWeight;
 };
 
 export const createIcon = (children: ReactNode, name: string) => {
@@ -41,6 +59,7 @@ export const createIcon = (children: ReactNode, name: string) => {
 		weight = 'regular',
 	}: IconProps) => {
 		const resolvedSize = `${iconSizes[size]}rem`;
+		const resolvedWeight = iconWeights[weight][size];
 		// Focusable is the opposite of `aria-hidden`
 		const focusable = [true, 'true'].includes(ariaHidden) ? 'false' : 'true';
 		return (
@@ -59,7 +78,7 @@ export const createIcon = (children: ReactNode, name: string) => {
 					stroke: 'currentColor',
 					strokeLinejoin: 'round',
 					strokeLinecap: 'round',
-					strokeWidth: weight === 'bold' ? 3 : 2,
+					strokeWidth: resolvedWeight,
 				}}
 				role="img"
 				style={style}

--- a/packages/progress-indicator/src/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/progress-indicator/src/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
       Doing step 2 of 3
       <svg
         aria-hidden="true"
-        class="css-5ae1oq-Icon"
+        class="css-iv9u8h-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -185,7 +185,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
       Doing step 2 of 3
       <svg
         aria-hidden="true"
-        class="css-5ae1oq-Icon"
+        class="css-iv9u8h-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"

--- a/packages/select/src/__snapshots__/Select.test.tsx.snap
+++ b/packages/select/src/__snapshots__/Select.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Select Basic renders correctly 1`] = `
       </select>
       <svg
         aria-hidden="true"
-        class="css-54plu1-Icon-SelectIcon"
+        class="css-bwqzjj-Icon-SelectIcon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -135,7 +135,7 @@ exports[`Select Grouped options renders correctly 1`] = `
       </select>
       <svg
         aria-hidden="true"
-        class="css-54plu1-Icon-SelectIcon"
+        class="css-bwqzjj-Icon-SelectIcon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -235,7 +235,7 @@ exports[`Select Invalid renders correctly 1`] = `
       </select>
       <svg
         aria-hidden="true"
-        class="css-54plu1-Icon-SelectIcon"
+        class="css-bwqzjj-Icon-SelectIcon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -300,7 +300,7 @@ exports[`Select With hint renders correctly 1`] = `
       </select>
       <svg
         aria-hidden="true"
-        class="css-54plu1-Icon-SelectIcon"
+        class="css-bwqzjj-Icon-SelectIcon"
         clip-rule="evenodd"
         focusable="false"
         height="24"

--- a/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
+++ b/packages/side-nav/src/__snapshots__/SideNav.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`SideNav renders correctly 1`] = `
       In this section
       <svg
         aria-hidden="true"
-        class="css-5ae1oq-Icon"
+        class="css-iv9u8h-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"


### PR DESCRIPTION
## Describe your changes
We noticed that small icons that portray a link (bold) aren't prominent enough.

In this PR, Icons with small sizes and bold weights will use 4px stroke weight instead of 3px

Examples below are before vs after

### Select

<img width="221" alt="image" src="https://user-images.githubusercontent.com/12689383/203027588-fb4ca08b-b0ff-40e7-8ac3-87dd0320a8b6.png"> <img width="240" alt="image" src="https://user-images.githubusercontent.com/12689383/203027514-5fd2cb19-7709-4fca-83fc-9fba8e8cc59c.png">

### ProgressIndicator
#### Before
<img width="371" alt="image" src="https://user-images.githubusercontent.com/12689383/203027764-d2fabfbb-b42c-4b67-922d-5c93e62bd55c.png"> <img width="357" alt="image" src="https://user-images.githubusercontent.com/12689383/203027817-ab6543dc-6e85-496d-be28-00c37a7bf750.png">

### SideNav
#### Before
<img width="355" alt="image" src="https://user-images.githubusercontent.com/12689383/203027949-3684a1ad-34af-4712-aa09-02a1f8ab8457.png"> <img width="357" alt="image" src="https://user-images.githubusercontent.com/12689383/203027996-d363a45e-19c7-4fc0-8778-160658969501.png">

### CallToAction
#### Before
<img width="122" alt="image" src="https://user-images.githubusercontent.com/12689383/203028099-ff97766b-5522-433d-af4e-626ae2a66c30.png"> <img width="117" alt="image" src="https://user-images.githubusercontent.com/12689383/203028150-940b21f7-81ab-4fd5-8fa3-626c56c7a429.png">


### Accordion
#### Before
<img width="314" alt="image" src="https://user-images.githubusercontent.com/12689383/203028306-b8cb1ce6-55fb-4b9d-b8fb-2235886b5fa9.png"> <img width="309" alt="image" src="https://user-images.githubusercontent.com/12689383/203028347-c730a0c4-b41d-4f37-a2c4-932154e4fff5.png">

### Card
#### Before
<img width="324" alt="image" src="https://user-images.githubusercontent.com/12689383/203028493-70807521-75aa-4e95-8083-8baf81ca778f.png"> <img width="329" alt="image" src="https://user-images.githubusercontent.com/12689383/203028545-3d0642c3-3960-4469-aa2c-a36e5a94147c.png">



## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
