### PR TITLE
field: Add ability to disable secondary label ("optional")

### DIFF
--- a/.changeset/odd-years-talk.md
+++ b/.changeset/odd-years-talk.md
@@ -1,0 +1,10 @@
+---
+'@ag.ds-next/autocomplete': patch
+'@ag.ds-next/combobox': patch
+'@ag.ds-next/control-input': patch
+'@ag.ds-next/select': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Added new prop `secondaryLabel` which can be set to `null` to disable `("optional")` being appended to the field label.

--- a/.changeset/silver-fireants-arrive.md
+++ b/.changeset/silver-fireants-arrive.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/text-input': minor
+---
+
+Added search icon when `type` is equal to `search`

--- a/.changeset/yellow-bananas-travel.md
+++ b/.changeset/yellow-bananas-travel.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/field': minor
+---
+
+Extended `secondaryLabel` prop to allow disabling of secondary label.

--- a/packages/autocomplete/src/Autocomplete.stories.tsx
+++ b/packages/autocomplete/src/Autocomplete.stories.tsx
@@ -58,3 +58,9 @@ Block.args = {
 	...defaultArgs,
 	block: true,
 };
+
+export const NoSecondaryLabel = Template.bind({});
+NoSecondaryLabel.args = {
+	...defaultArgs,
+	secondaryLabel: null,
+};

--- a/packages/combobox/src/Combobox.stories.tsx
+++ b/packages/combobox/src/Combobox.stories.tsx
@@ -269,3 +269,9 @@ AsyncOptionsWithError.args = {
 		throw new Error('Something went wrong while fetching options');
 	},
 };
+
+export const NoSecondaryLabel = Template.bind({});
+NoSecondaryLabel.args = {
+	...defaultArgs,
+	secondaryLabel: null,
+};

--- a/packages/combobox/src/Combobox.tsx
+++ b/packages/combobox/src/Combobox.tsx
@@ -17,6 +17,8 @@ import { DefaultComboboxOption, filterOptions, splitLabel } from './utils';
 export type ComboboxProps<Option extends DefaultComboboxOption> = {
 	/** Describes the purpose of the field. */
 	label: string;
+	/** If null, "(optional)" will be not be appended to the label (even if required). */
+	secondaryLabel?: null;
 	/** If false, "(optional)" will be appended to the label. */
 	required?: boolean;
 	/** Provides extra information about the field. */
@@ -50,6 +52,7 @@ export type ComboboxProps<Option extends DefaultComboboxOption> = {
 
 export function Combobox<Option extends DefaultComboboxOption>({
 	label,
+	secondaryLabel,
 	required,
 	hint,
 	message,
@@ -151,6 +154,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 		<div css={{ position: 'relative', maxWidth }} ref={setRefEl}>
 			<Field
 				label={label}
+				secondaryLabel={secondaryLabel}
 				required={Boolean(required)}
 				hint={hint}
 				message={message}

--- a/packages/control-input/src/ControlGroup.stories.tsx
+++ b/packages/control-input/src/ControlGroup.stories.tsx
@@ -58,6 +58,12 @@ CheckboxGroupInvalid.args = {
 	invalid: true,
 };
 
+export const CheckboxGroupInvalidNoSecondaryLabel = CheckboxTemplate.bind({});
+CheckboxGroupInvalidNoSecondaryLabel.args = {
+	...checkboxDefaultArgs,
+	secondaryLabel: null,
+};
+
 // Radio group
 const RadioTemplate: ComponentStory<typeof ControlGroup> = (args) => {
 	return (
@@ -106,4 +112,10 @@ RadioGroupInvalid.args = {
 	message: 'You must choose at least one option',
 	required: true,
 	invalid: true,
+};
+
+export const RadioGroupInvalidNoSecondaryLabel = RadioTemplate.bind({});
+RadioGroupInvalidNoSecondaryLabel.args = {
+	...radioDefaultArgs,
+	secondaryLabel: null,
 };

--- a/packages/control-input/src/ControlGroup.tsx
+++ b/packages/control-input/src/ControlGroup.tsx
@@ -20,6 +20,8 @@ export type ControlGroupProps = PropsWithChildren<{
 	invalid?: boolean;
 	/** Describes the purpose of the field. */
 	label?: string;
+	/** If null, "(optional)" will be not be appended to the label (even if required). */
+	secondaryLabel?: null;
 	/** Message to show when the field is invalid. */
 	message?: string;
 	/** If false, "(optional)" will be appended to the label. */
@@ -33,6 +35,7 @@ export const ControlGroup = ({
 	id,
 	invalid = false,
 	label,
+	secondaryLabel,
 	message,
 	required = false,
 }: ControlGroupProps) => {
@@ -55,7 +58,11 @@ export const ControlGroup = ({
 					css={{ padding: 0, margin: 0, border: 'none' }}
 				>
 					{label ? (
-						<FieldLabel as="legend" required={required}>
+						<FieldLabel
+							as="legend"
+							required={required}
+							secondaryLabel={secondaryLabel}
+						>
 							{label}
 						</FieldLabel>
 					) : null}

--- a/packages/field/docs/overview.mdx
+++ b/packages/field/docs/overview.mdx
@@ -5,23 +5,13 @@ group: Forms
 storybookPath: /story/forms-field--basic
 ---
 
-### Field
-
-The field component connects the label, description, and message to the input element.
+The `Field` component connects the label, description, and message to the input element.
 
 ```jsx live
 <Field label="Name">{(a11yProps) => <input {...a11yProps} />}</Field>
 ```
 
-### Required
-
-```jsx live
-<Field label="Name" required>
-	{(a11yProps) => <input {...a11yProps} />}
-</Field>
-```
-
-### Label
+## Label
 
 Each text field must be accompanied by a label. Effective form labeling helps users understand what information to enter into a text input.
 
@@ -29,7 +19,7 @@ Each text field must be accompanied by a label. Effective form labeling helps us
 <Field label="Name">{(a11yProps) => <input {...a11yProps} />}</Field>
 ```
 
-### Hint
+## Hint
 
 Hints can be used to provide more context that will help the user successfully complete the form field.
 
@@ -39,7 +29,9 @@ Hints can be used to provide more context that will help the user successfully c
 </Field>
 ```
 
-### Messages
+## Invalid
+
+Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
 Error messages are used to notify the user when a form field has not passed validation. Use clear messages to explain what went wrong and how to fix it.
 
@@ -53,14 +45,24 @@ Error messages are used to notify the user when a form field has not passed vali
 </Field>
 ```
 
-### Required
+## Required and optional
 
-The `Field` component will always append `(optional)` to the label based on the `required` prop.
+The `Field` component automatically appends `(optional)` to the label based on the `required` prop.
+
+This behaviour can be disabled by setting the `secondaryLabel` prop to `null`. Disabling the secondary label should be avoided and should only be used in certain situations where the `(optional)` text doesn't make sense, for example a row of filters.
 
 ```jsx live
-<Field label="Start date" required={false}>
-	{(a11yProps) => <select {...a11yProps} />}
-</Field>
+<Stack gap={1}>
+	<Field label="Required field" required={true}>
+		{(a11yProps) => <select {...a11yProps} />}
+	</Field>
+	<Field label="Optional field" required={false}>
+		{(a11yProps) => <select {...a11yProps} />}
+	</Field>
+	<Field label="Optional field with no secondary label" secondaryLabel={null}>
+		{(a11yProps) => <select {...a11yProps} />}
+	</Field>
+</Stack>
 ```
 
 ## Hooks

--- a/packages/field/src/Field.stories.tsx
+++ b/packages/field/src/Field.stories.tsx
@@ -42,6 +42,14 @@ SecondaryLabel.args = {
 	secondaryLabel: '(dd/mm/yyy)',
 };
 
+export const NoSecondaryLabel: ComponentStory<typeof Field> = (args) => (
+	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
+);
+NoSecondaryLabel.args = {
+	label: 'Label',
+	secondaryLabel: null,
+};
+
 export const Modular: ComponentStory<typeof Field> = ({
 	label,
 	secondaryLabel,

--- a/packages/field/src/Field.test.tsx
+++ b/packages/field/src/Field.test.tsx
@@ -88,19 +88,34 @@ describe('Field', () => {
 	});
 
 	describe('FieldLabel', () => {
-		it('renders correctly when optional', () => {
-			renderField({ required: false });
-			const labelEl = screen.getByText('Name')
-				.parentElement as HTMLLabelElement;
-			expect(labelEl).toBeInTheDocument();
-			expect(labelEl).toHaveTextContent('Name(optional)');
+		describe('optional', () => {
+			it('renders correctly', () => {
+				renderField({ required: false });
+				const labelEl = document.querySelector('label');
+				expect(labelEl).toBeInTheDocument();
+				expect(labelEl).toHaveTextContent('Name(optional)');
+			});
+			it('renders correctly when secondaryLabel is null', () => {
+				renderField({ required: false, secondaryLabel: null });
+				const labelEl = document.querySelector('label');
+				expect(labelEl).toBeInTheDocument();
+				expect(labelEl).toHaveTextContent('Name');
+			});
 		});
-		it('renders correctly when required', () => {
-			renderField({ required: true });
-			const labelEl = screen.getByText('Name')
-				.parentElement as HTMLLabelElement;
-			expect(labelEl).toBeInTheDocument();
-			expect(labelEl).toHaveTextContent('Name');
+
+		describe('required', () => {
+			it('renders correctly', () => {
+				renderField({ required: true });
+				const labelEl = document.querySelector('label');
+				expect(labelEl).toBeInTheDocument();
+				expect(labelEl).toHaveTextContent('Name');
+			});
+			it('renders correctly when secondaryLabel is null', () => {
+				renderField({ required: true, secondaryLabel: null });
+				const labelEl = document.querySelector('label');
+				expect(labelEl).toBeInTheDocument();
+				expect(labelEl).toHaveTextContent('Name');
+			});
 		});
 	});
 

--- a/packages/field/src/Field.tsx
+++ b/packages/field/src/Field.tsx
@@ -16,7 +16,7 @@ export type FieldProps = {
 	/** Describes the purpose of the field. */
 	label: string;
 	/** Override the default secondary label. */
-	secondaryLabel?: string;
+	secondaryLabel?: string | null;
 	/** Message to show when the field is invalid. */
 	message: string | undefined;
 	/** If false, "(optional)" will be appended to the label. */

--- a/packages/field/src/FieldLabel.tsx
+++ b/packages/field/src/FieldLabel.tsx
@@ -6,7 +6,7 @@ export type FieldLabelProps = PropsWithChildren<{
 	as?: ElementType;
 	htmlFor?: string;
 	required?: boolean;
-	secondaryLabel?: string;
+	secondaryLabel?: string | null;
 }>;
 
 export const FieldLabel = ({
@@ -17,6 +17,7 @@ export const FieldLabel = ({
 	secondaryLabel: secondaryLabelProp,
 }: FieldLabelProps) => {
 	const secondaryLabel = useMemo(() => {
+		if (secondaryLabelProp === null) return null;
 		if (secondaryLabelProp) return secondaryLabelProp;
 		if (!required) return `(optional)`;
 	}, [required, secondaryLabelProp]);

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -157,3 +157,13 @@ GroupedOptions.args = {
 		},
 	],
 };
+
+export const NoSecondaryLabel: ComponentStory<typeof Select> = (args) => (
+	<Select {...args} />
+);
+NoSecondaryLabel.args = {
+	label: 'Example',
+	placeholder: 'Please select',
+	options: EXAMPLE_OPTIONS,
+	secondaryLabel: null,
+};

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -37,6 +37,8 @@ type BaseSelectProps = {
 export type SelectProps = BaseSelectProps & {
 	/** Describes the purpose of the field. */
 	label: string;
+	/** If null, "(optional)" will be not be appended to the label (even if required). */
+	secondaryLabel?: null;
 	/** The list of options to display in the drop-down list. */
 	options: Options;
 	/** If false, "(optional)" will be appended to the label. */
@@ -57,6 +59,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 	function Select(
 		{
 			label,
+			secondaryLabel,
 			required,
 			hint,
 			message,
@@ -74,6 +77,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 		return (
 			<Field
 				label={label}
+				secondaryLabel={secondaryLabel}
 				required={Boolean(required)}
 				hint={hint}
 				message={message}

--- a/packages/text-input/docs/overview.mdx
+++ b/packages/text-input/docs/overview.mdx
@@ -70,5 +70,5 @@ As an example, input fields for postcodes should have a smaller width than field
 Changing the input type to `search` will add a search icon to start of the input.
 
 ```jsx live
-<TextInput label="Search" type="search" required />
+<TextInput label="Search" type="search" secondaryLabel={null} />
 ```

--- a/packages/text-input/docs/overview.mdx
+++ b/packages/text-input/docs/overview.mdx
@@ -5,7 +5,7 @@ group: Forms
 storybookPath: /story/forms-textinput--basic
 ---
 
-### Default
+## Default
 
 By default, the `TextInput` component does not expand to fill the available space.
 
@@ -13,7 +13,7 @@ By default, the `TextInput` component does not expand to fill the available spac
 <TextInput label="Name" />
 ```
 
-### Block
+## Block
 
 Use the `block` prop to expand the component to fill the available space.
 
@@ -21,7 +21,7 @@ Use the `block` prop to expand the component to fill the available space.
 <TextInput label="Name" block />
 ```
 
-### Required
+## Required
 
 The `TextInput` component will always append `(optional)` to the label based on the `required` prop.
 
@@ -33,7 +33,7 @@ The `TextInput` component will always append `(optional)` to the label based on 
 </Stack>
 ```
 
-### Invalid
+## Invalid
 
 Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
 
@@ -41,7 +41,7 @@ Use the `invalid` prop to indicate if the user input is invalid (does not valida
 <TextInput label="Invalid" invalid message="This input is invalid" />
 ```
 
-### Disabled
+## Disabled
 
 Disabled input elements are unusable and can not be clicked. This prevents a user from interacting with the input element until another action is complete. Disabled input elements in a form will not be submitted.
 
@@ -49,7 +49,7 @@ Disabled input elements are unusable and can not be clicked. This prevents a use
 <TextInput label="Name" disabled />
 ```
 
-### Maximum widths
+## Maximum widths
 
 The width of a text input field should indicate the amount of information expected to be entered into the field. The size of the text input acts as a visual constraint for the end user.
 
@@ -63,4 +63,12 @@ As an example, input fields for postcodes should have a smaller width than field
 	<TextInput label="lg input" maxWidth="lg" />
 	<TextInput label="xl input" maxWidth="xl" />
 </Stack>
+```
+
+## Search
+
+Changing the input type to `search` will add a search icon to start of the input.
+
+```jsx live
+<TextInput label="Search" type="search" required />
 ```

--- a/packages/text-input/package.json
+++ b/packages/text-input/package.json
@@ -11,6 +11,7 @@
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/core": "*",
 		"@ag.ds-next/field": "*",
+		"@ag.ds-next/icon": "*",
 		"@emotion/react": "^11.7.0",
 		"react": "18.1.0"
 	},
@@ -18,6 +19,7 @@
 		"@ag.ds-next/box": "8.0.0",
 		"@ag.ds-next/core": "4.1.0",
 		"@ag.ds-next/field": "11.0.0",
+		"@ag.ds-next/icon": "12.0.0",
 		"@emotion/react": "^11.7.0",
 		"react": "^16.14.0 || ^17.0.0 || ^18.0.0"
 	}

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Stack } from '@ag.ds-next/box';
+import { SearchIcon } from '@ag.ds-next/icon';
 import { TextInput } from './TextInput';
 
 export default {
@@ -79,4 +80,12 @@ Password.args = {
 	label: 'Password',
 	type: 'password',
 	required: true,
+};
+
+export const Search: ComponentStory<typeof TextInput> = (args) => (
+	<TextInput {...args} />
+);
+Search.args = {
+	label: 'Search',
+	type: 'search',
 };

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -88,3 +88,11 @@ Search.args = {
 	label: 'Search',
 	type: 'search',
 };
+
+export const NoSecondaryLabel: ComponentStory<typeof TextInput> = (args) => (
+	<TextInput {...args} />
+);
+NoSecondaryLabel.args = {
+	label: 'Example',
+	secondaryLabel: null,
+};

--- a/packages/text-input/src/TextInput.stories.tsx
+++ b/packages/text-input/src/TextInput.stories.tsx
@@ -1,6 +1,5 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Stack } from '@ag.ds-next/box';
-import { SearchIcon } from '@ag.ds-next/icon';
 import { TextInput } from './TextInput';
 
 export default {

--- a/packages/text-input/src/TextInput.test.tsx
+++ b/packages/text-input/src/TextInput.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
+import { SearchIcon } from '@ag.ds-next/icon';
 import { cleanup, render } from '../../../test-utils';
 import { TextInput, TextInputProps } from './TextInput';
 
@@ -120,6 +121,39 @@ describe('TextInput', () => {
 			});
 			const el = container.querySelector('input');
 			expect(el).toHaveAttribute('autocomplete', 'given-name');
+		});
+	});
+
+	describe('Search input', () => {
+		it('renders correctly', () => {
+			const { container } = renderTextInput({
+				label: 'Search',
+				type: 'search',
+			});
+			expect(container).toMatchSnapshot();
+		});
+
+		it('renders a valid HTML structure', () => {
+			const { container } = renderTextInput({
+				label: 'Search',
+				type: 'search',
+			});
+			expect(container).toHTMLValidate({
+				extends: ['html-validate:recommended'],
+				// react 18s `useId` break this rule
+				rules: { 'valid-id': 'off' },
+			});
+		});
+
+		it('hides the icon from screen readers', () => {
+			const { container } = renderTextInput({
+				label: 'Search',
+				type: 'search',
+			});
+			const el = container.querySelector('svg');
+			expect(el).toBeInTheDocument();
+			expect(el).toHaveAttribute('aria-hidden', 'true');
+			expect(el).toHaveAttribute('focusable', 'false');
 		});
 	});
 });

--- a/packages/text-input/src/TextInput.test.tsx
+++ b/packages/text-input/src/TextInput.test.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { SearchIcon } from '@ag.ds-next/icon';
 import { cleanup, render } from '../../../test-utils';
 import { TextInput, TextInputProps } from './TextInput';
 

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, Fragment, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { Field, fieldMaxWidth, FieldMaxWidth } from '@ag.ds-next/field';
 import { packs, boxPalette, mapSpacing, tokens } from '@ag.ds-next/core';
 import { SearchIcon } from '@ag.ds-next/icon';
@@ -70,9 +70,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 				invalid={invalid}
 				id={id}
 			>
-				{(a11yProps) => (
-					<Fragment>
-						{type === 'search' ? <SearchInputIcon disabled={disabled} /> : null}
+				{(a11yProps) => {
+					const inputElement = (
 						<input
 							ref={ref}
 							type={type}
@@ -81,8 +80,17 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 							{...a11yProps}
 							{...props}
 						/>
-					</Fragment>
-				)}
+					);
+					if (type === 'search') {
+						return (
+							<div css={{ position: 'relative' }}>
+								<SearchInputIcon disabled={disabled} />
+								{inputElement}
+							</div>
+						);
+					}
+					return inputElement;
+				}}
 			</Field>
 		);
 	}
@@ -97,9 +105,9 @@ function SearchInputIcon({ disabled }: { disabled?: boolean }) {
 			css={{
 				position: 'absolute',
 				top: '50%',
+				left: `calc(${mapSpacing(1)} + ${tokens.borderWidth.lg}px)`, // Align from the inner border
 				transform: 'translateY(-50%)',
 				pointerEvents: 'none',
-				left: mapSpacing(1),
 				opacity: disabled ? 0.3 : undefined,
 			}}
 		/>
@@ -154,7 +162,7 @@ export const textInputStyles = ({
 		}),
 
 		...(type === 'search' && {
-			paddingLeft: mapSpacing(3),
+			paddingLeft: '3rem',
 			'&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
 				{
 					display: 'none',

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -24,6 +24,8 @@ type BaseTextInputProps = {
 export type TextInputProps = BaseTextInputProps & {
 	/** Describes the purpose of the field. */
 	label: string;
+	/** If null, "(optional)" will be not be appended to the label (even if required). */
+	secondaryLabel?: null;
 	/** If false, "(optional)" will be appended to the label. */
 	required?: boolean;
 	/** Provides extra information about the field. */
@@ -42,6 +44,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 	function TextInput(
 		{
 			label,
+			secondaryLabel,
 			required,
 			hint,
 			message,
@@ -64,6 +67,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 		return (
 			<Field
 				label={label}
+				secondaryLabel={secondaryLabel}
 				required={Boolean(required)}
 				hint={hint}
 				message={message}

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -1,6 +1,7 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, Fragment, InputHTMLAttributes } from 'react';
 import { Field, fieldMaxWidth, FieldMaxWidth } from '@ag.ds-next/field';
 import { packs, boxPalette, mapSpacing, tokens } from '@ag.ds-next/core';
+import { SearchIcon } from '@ag.ds-next/icon';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
 
@@ -49,11 +50,17 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			maxWidth,
 			id,
 			type = 'text',
+			disabled,
 			...props
 		},
 		ref
 	) {
-		const styles = textInputStyles({ block, maxWidth, invalid });
+		const styles = textInputStyles({
+			block,
+			maxWidth,
+			invalid,
+			type,
+		});
 		return (
 			<Field
 				label={label}
@@ -64,23 +71,53 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 				id={id}
 			>
 				{(a11yProps) => (
-					<input ref={ref} css={styles} {...a11yProps} type={type} {...props} />
+					<Fragment>
+						{type === 'search' ? <SearchInputIcon disabled={disabled} /> : null}
+						<input
+							ref={ref}
+							type={type}
+							disabled={disabled}
+							css={styles}
+							{...a11yProps}
+							{...props}
+						/>
+					</Fragment>
 				)}
 			</Field>
 		);
 	}
 );
 
+function SearchInputIcon({ disabled }: { disabled?: boolean }) {
+	return (
+		<SearchIcon
+			size="md"
+			weight="regular"
+			color="muted"
+			css={{
+				position: 'absolute',
+				top: '50%',
+				transform: 'translateY(-50%)',
+				pointerEvents: 'none',
+				left: mapSpacing(1),
+				opacity: disabled ? 0.3 : undefined,
+			}}
+		/>
+	);
+}
+
 export const textInputStyles = ({
 	block,
 	maxWidth,
 	invalid,
 	multiline,
+	type,
 }: {
 	block?: boolean;
 	maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 	invalid?: boolean;
 	multiline?: boolean;
+	type?: string;
 }) =>
 	({
 		appearance: 'none',
@@ -114,6 +151,14 @@ export const textInputStyles = ({
 			paddingBottom: mapSpacing(0.5),
 			height: 'auto',
 			minHeight: '6rem',
+		}),
+
+		...(type === 'search' && {
+			paddingLeft: mapSpacing(3),
+			'&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
+				{
+					display: 'none',
+				},
 		}),
 
 		'&:disabled': {

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -97,6 +97,60 @@ exports[`TextInput Invalid renders correctly 1`] = `
 </div>
 `;
 
+exports[`TextInput Search input renders correctly 1`] = `
+<div>
+  <div
+    class="css-1904cz9-boxStyles-FieldContainer"
+  >
+    <label
+      class="css-n7rdvo-boxStyles"
+      for="field-:ra:"
+    >
+      <span
+        class="css-433uqb-boxStyles-Text"
+      >
+        Search
+      </span>
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
+      >
+        (optional)
+      </span>
+    </label>
+    <svg
+      aria-hidden="true"
+      class="css-1pmetab-Icon-SearchInputIcon"
+      clip-rule="evenodd"
+      focusable="false"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <line
+        x1="15.5568"
+        x2="21.9208"
+        y1="15.5562"
+        y2="21.9201"
+      />
+      <circle
+        cx="9.8995"
+        cy="9.89941"
+        r="7"
+      />
+    </svg>
+    <input
+      aria-invalid="false"
+      aria-required="false"
+      class="css-1f4pb6k-Field"
+      id="field-:ra:"
+      type="search"
+    />
+  </div>
+</div>
+`;
+
 exports[`TextInput With hint renders correctly 1`] = `
 <div>
   <div

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -117,36 +117,40 @@ exports[`TextInput Search input renders correctly 1`] = `
         (optional)
       </span>
     </label>
-    <svg
-      aria-hidden="true"
-      class="css-1pmetab-Icon-SearchInputIcon"
-      clip-rule="evenodd"
-      focusable="false"
-      height="24"
-      role="img"
-      viewBox="0 0 24 24"
-      width="24"
-      xmlns="http://www.w3.org/2000/svg"
+    <div
+      class="css-113yjgs-TextInput"
     >
-      <line
-        x1="15.5568"
-        x2="21.9208"
-        y1="15.5562"
-        y2="21.9201"
+      <svg
+        aria-hidden="true"
+        class="css-1jixeje-Icon-SearchInputIcon"
+        clip-rule="evenodd"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <line
+          x1="15.5568"
+          x2="21.9208"
+          y1="15.5562"
+          y2="21.9201"
+        />
+        <circle
+          cx="9.8995"
+          cy="9.89941"
+          r="7"
+        />
+      </svg>
+      <input
+        aria-invalid="false"
+        aria-required="false"
+        class="css-1f4pb6k-Field"
+        id="field-:ra:"
+        type="search"
       />
-      <circle
-        cx="9.8995"
-        cy="9.89941"
-        r="7"
-      />
-    </svg>
-    <input
-      aria-invalid="false"
-      aria-required="false"
-      class="css-1f4pb6k-Field"
-      id="field-:ra:"
-      type="search"
-    />
+    </div>
   </div>
 </div>
 `;

--- a/packages/textarea/src/Textarea.stories.tsx
+++ b/packages/textarea/src/Textarea.stories.tsx
@@ -65,3 +65,11 @@ export const MaxWidths: ComponentStory<typeof Textarea> = (args) => (
 	</Stack>
 );
 MaxWidths.args = {};
+
+export const NoSecondaryLabel: ComponentStory<typeof Textarea> = (args) => (
+	<Textarea {...args} />
+);
+NoSecondaryLabel.args = {
+	label: 'Example',
+	secondaryLabel: null,
+};

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -21,6 +21,8 @@ type BaseTextareaProps = {
 export type TextareaProps = BaseTextareaProps & {
 	/** Describes the purpose of the field. */
 	label: string;
+	/** If null, "(optional)" will be not be appended to the label (even if required). */
+	secondaryLabel?: null;
 	/** If false, "(optional)" will be appended to the label. */
 	required?: boolean;
 	/** Provides extra information about the field. */
@@ -37,7 +39,18 @@ export type TextareaProps = BaseTextareaProps & {
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 	function Textarea(
-		{ label, required, hint, message, invalid, block, maxWidth, id, ...props },
+		{
+			label,
+			secondaryLabel,
+			required,
+			hint,
+			message,
+			invalid,
+			block,
+			maxWidth,
+			id,
+			...props
+		},
 		ref
 	) {
 		const styles = textInputStyles({
@@ -49,6 +62,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 		return (
 			<Field
 				label={label}
+				secondaryLabel={secondaryLabel}
 				required={Boolean(required)}
 				hint={hint}
 				message={message}


### PR DESCRIPTION
## Describe your changes

Added new prop `secondaryLabel` to form components, which can be set to `null` to disable `("optional")` being appended to the labels.

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook

For new components...

- [ ] Version number in `package.json` is set to `0.0.1`
- [ ] Changeset file includes a major
- [ ] Create empty changelog file (packages/component/CHANGELOG.md)
- [ ] Export components for docs site and Playroom (docs/components/designSystemComponents.tsx)
- [ ] Add snippets to Playroom (docs/playroom/snippets.js)
- [ ] Add pictogram to Docs (docs/components/pictograms/index.tsx)
