### PR TITLE
docs: update website paths/content after domain change

### DIFF
--- a/.storybook/stories/kitchenSink.tsx
+++ b/.storybook/stories/kitchenSink.tsx
@@ -452,11 +452,11 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 								{ label: 'Home', href: '/' },
 								{
 									label: 'Storybook',
-									href: 'https://steelthreads.github.io/agds-next/storybook/index.html',
+									href: 'https://design-system.agriculture.gov.au/storybook/index.html',
 								},
 								{
 									label: 'Playroom',
-									href: 'https://steelthreads.github.io/agds-next/playroom/index.html',
+									href: 'https://design-system.agriculture.gov.au/playroom/index.html',
 								},
 								{
 									label: 'Starter kit',

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A new Design-System for the Department of Agriculture, Fisheries and Forestry.
 
 If you are starting a new project, you should clone the [starter kit](https://github.com/steelthreads/agds-starter-kit).
 
-If you are looking to implement AgDS components, you need to [install packages from NPM](https://steelthreads.github.io/agds-next/guides/getting-started#if-youre-implementing-components-in-an-existing-project).
+If you are looking to implement AgDS components, you need to [install packages from NPM](https://design-system.agriculture.gov.au/guides/getting-started#if-youre-implementing-components-in-an-existing-project).
 
 You should clone this repo if you are looking to contribute to it, such as...
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -70,7 +70,7 @@ Use the template below and update the following details:
 
 > ⚠️ Note: All releases under the `@ag.ds-next` package scope should be considered alpha pre-releases. Expect breaking changes. Once we are happy with the state of the core packages we will migrate all packages to `@ag.ds`.
 
-### **View the [complete release notes on the AG DS website](https://steelthreads.github.io/agds-next/releases/YYYY-MM-DD)**.
+### **View the [complete release notes on the AG DS website](https://design-system.agriculture.gov.au/releases/YYYY-MM-DD)**.
 
 ```sh
 "@ag.ds-next/core": "x.x.x"
@@ -79,7 +79,7 @@ Use the template below and update the following details:
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/YYYY-MM-DD), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/XXXX) in the related PR (https://github.com/steelthreads/agds-next/pull/XXXX) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/YYYY-MM-DD), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/XXXX) in the related PR (https://github.com/steelthreads/agds-next/pull/XXXX) for this release.
 
 ---
 

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -32,7 +32,7 @@ import { prismTheme } from './prism-theme';
 
 const PlaceholderImage = () => (
 	<img
-		src="/agds-next/img/placeholder/600X260.png"
+		src="/img/placeholder/600X260.png"
 		alt="Grey placeholder image"
 		css={{ width: '100%' }}
 	/>

--- a/docs/content/guides/contribution.mdx
+++ b/docs/content/guides/contribution.mdx
@@ -53,11 +53,11 @@ All contributions should satisfy a user need and offer value to the way all team
 
 AgDS uses design tokens to create a simple, consistent, and inclusive visual language. This language helps users understand the interactive behaviour of our components and creates a common language between designers and developers. Tokens are used for background and foreground colour, space, typography, border, shadow, and corner radius.
 
-All designs should use AgDS tokens to maintain visual and functional consistency with other design system components and patterns. Information about the tokens and how to apply them can be found on the [Core page](https://steelthreads.github.io/agds-next/components/core) of our documentation site and [Figma design file](https://www.figma.com/files/project/37217032/AgDS-Agriculture-Design-System?fuid=989721230907238166).
+All designs should use AgDS tokens to maintain visual and functional consistency with other design system components and patterns. Information about the tokens and how to apply them can be found on the [Core page](https://design-system.agriculture.gov.au/components/core) of our documentation site and [Figma design file](https://www.figma.com/files/project/37217032/AgDS-Agriculture-Design-System?fuid=989721230907238166).
 
 ### Aligns with our design principles.
 
-Our design system is a continuation of the Australian Government Design System, which was built on principles of simplicity and inclusion. AgDS maintains these basic design principles to ensure our services are fast, intuitive, and easy to use and can be accessed by users of all abilities in any location. More information about our principles can be found [here](/agds-next/guides/design-principles).
+Our design system is a continuation of the Australian Government Design System, which was built on principles of simplicity and inclusion. AgDS maintains these basic design principles to ensure our services are fast, intuitive, and easy to use and can be accessed by users of all abilities in any location. More information about our principles can be found [here](/guides/design-principles).
 
 ### Meets our design standard.
 

--- a/docs/content/releases/2022-01-07.mdx
+++ b/docs/content/releases/2022-01-07.mdx
@@ -29,4 +29,4 @@ Changes to improve usability of primitive components and to better enable using 
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-01-07), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/29) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-01-07), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/29) for this release.

--- a/docs/content/releases/2022-01-24.mdx
+++ b/docs/content/releases/2022-01-24.mdx
@@ -32,4 +32,4 @@ Add new components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-01-24), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/50) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-01-24), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/50) for this release.

--- a/docs/content/releases/2022-02-08.mdx
+++ b/docs/content/releases/2022-02-08.mdx
@@ -35,4 +35,4 @@ Add New components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-02-08), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/55) in the related PR (https://github.com/steelthreads/agds-next/pull/55) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-02-08), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/55) in the related PR (https://github.com/steelthreads/agds-next/pull/55) for this release.

--- a/docs/content/releases/2022-02-23.mdx
+++ b/docs/content/releases/2022-02-23.mdx
@@ -47,4 +47,4 @@ In this release, we have focused on adding new form and interactive components i
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-02-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/112) in the related PR (https://github.com/steelthreads/agds-next/pull/112) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-02-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/112) in the related PR (https://github.com/steelthreads/agds-next/pull/112) for this release.

--- a/docs/content/releases/2022-03-02.mdx
+++ b/docs/content/releases/2022-03-02.mdx
@@ -26,7 +26,7 @@ In this release we have focused on delivering improvements for existing componen
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-03-02), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/153) in the related PR (https://github.com/steelthreads/agds-next/pull/153) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-03-02), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/153) in the related PR (https://github.com/steelthreads/agds-next/pull/153) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-03-03.mdx
+++ b/docs/content/releases/2022-03-03.mdx
@@ -18,7 +18,7 @@ description: Add InPage Nav. Bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-03-03), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/178) in the related PR (https://github.com/steelthreads/agds-next/pull/178) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-03-03), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/178) in the related PR (https://github.com/steelthreads/agds-next/pull/178) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-03-16.mdx
+++ b/docs/content/releases/2022-03-16.mdx
@@ -100,7 +100,7 @@ description: Updated Icon API, new components, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-03-16), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/190) in the related PR (https://github.com/steelthreads/agds-next/pull/190) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-03-16), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/190) in the related PR (https://github.com/steelthreads/agds-next/pull/190) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-03-23.mdx
+++ b/docs/content/releases/2022-03-23.mdx
@@ -89,7 +89,7 @@ description: Added PageAlert, new tone colours, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-03-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/229) in the related PR (https://github.com/steelthreads/agds-next/pull/229) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-03-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/229) in the related PR (https://github.com/steelthreads/agds-next/pull/229) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-04-01.mdx
+++ b/docs/content/releases/2022-04-01.mdx
@@ -62,7 +62,7 @@ description: Add DatePicker, Modal and Table. Various bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-04-01), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/260) in the related PR (https://github.com/steelthreads/agds-next/pull/260) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-04-01), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/260) in the related PR (https://github.com/steelthreads/agds-next/pull/260) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-04-28.mdx
+++ b/docs/content/releases/2022-04-28.mdx
@@ -111,7 +111,7 @@ description: Add HeroBanner and Loading. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/279) in the related PR (https://github.com/steelthreads/agds-next/pull/279) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/279) in the related PR (https://github.com/steelthreads/agds-next/pull/279) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-05-16.mdx
+++ b/docs/content/releases/2022-05-16.mdx
@@ -102,7 +102,7 @@ description: Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/319) in the related PR (https://github.com/steelthreads/agds-next/pull/319) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/319) in the related PR (https://github.com/steelthreads/agds-next/pull/319) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-05-30.mdx
+++ b/docs/content/releases/2022-05-30.mdx
@@ -106,7 +106,7 @@ description: Add ButtonGroup component. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-05-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/346) in the related PR (https://github.com/steelthreads/agds-next/pull/346) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-05-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/346) in the related PR (https://github.com/steelthreads/agds-next/pull/346) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-06-15.mdx
+++ b/docs/content/releases/2022-06-15.mdx
@@ -106,7 +106,7 @@ description: Added support for React 18. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-06-15), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/399) in the related PR (https://github.com/steelthreads/agds-next/pull/399) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-06-15), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/399) in the related PR (https://github.com/steelthreads/agds-next/pull/399) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-06-28.mdx
+++ b/docs/content/releases/2022-06-28.mdx
@@ -55,7 +55,7 @@ description: New branding for Department of Agriculture, Fisheries and Forestry.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-06-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/466) in the related PR (https://github.com/steelthreads/agds-next/pull/466) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-06-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/466) in the related PR (https://github.com/steelthreads/agds-next/pull/466) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-07-27.mdx
+++ b/docs/content/releases/2022-07-27.mdx
@@ -301,7 +301,7 @@ In this release, we rethought our `<Columns />` component, improved many of our 
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](https://steelthreads.github.io/agds-next/releases/2022-07-27), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/499) in the related PR (https://github.com/steelthreads/agds-next/pull/499) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/releases/2022-07-27), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/499) in the related PR (https://github.com/steelthreads/agds-next/pull/499) for this release.
 
 ## Released packages
 

--- a/docs/content/releases/2022-08-26.mdx
+++ b/docs/content/releases/2022-08-26.mdx
@@ -214,7 +214,7 @@ Otherwise you **must** follow these steps when upgrading:
 </Box>
 ```
 
-Take a look at [Storybook](https://steelthreads.github.io/agds-next/storybook/index.html?path=/story/navigation-mainnav--header-right-links) and the [Storybook code](https://github.com/steelthreads/agds-next/blob/main/packages/main-nav/src/MainNav.stories.tsx) for more references.
+Take a look at [Storybook](https://design-system.agriculture.gov.au/storybook/index.html?path=/story/navigation-mainnav--header-right-links) and the [Storybook code](https://github.com/steelthreads/agds-next/blob/main/packages/main-nav/src/MainNav.stories.tsx) for more references.
 
 If you have any questions, please reach out to Jordan Overbye or Nathan Simpson in the Design System team.
 

--- a/docs/content/releases/2022-10-24.mdx
+++ b/docs/content/releases/2022-10-24.mdx
@@ -18,7 +18,7 @@ description: Improved accessibility of our components after a professional exter
 
 Details is a disclosure widget for supplimental information that explains a component, section or flow.
 
-You can [learn more about Details in the component docs](https://steelthreads.github.io/agds-next/components/details).
+You can [learn more about Details in the component docs](https://design-system.agriculture.gov.au/components/details).
 
 ```jsx live
 <Details label="Details" iconBefore>
@@ -33,7 +33,7 @@ You can [learn more about Details in the component docs](https://steelthreads.gi
 
 SummaryList displays a list of terms and descriptions as key value pairs. It is similar to a two-column table, but renders a HTML Description List (`<dl>`) element.
 
-You can [learn more about SummaryList in the component docs](https://steelthreads.github.io/agds-next/components/summary-list).
+You can [learn more about SummaryList in the component docs](https://design-system.agriculture.gov.au/components/summary-list).
 
 ```jsx live
 <Stack gap={1.5}>

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -4,7 +4,6 @@ const withPreconstruct = require('@preconstruct/next');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-	basePath: '/agds-next',
 	reactStrictMode: true,
 };
 

--- a/docs/pages/templates/[slug]/index.tsx
+++ b/docs/pages/templates/[slug]/index.tsx
@@ -39,7 +39,7 @@ export default function TemplateOverviewPage({
 				<Prose id="page-content">
 					<Box border borderColor="muted" css={{ img: { display: 'block' } }}>
 						<img
-							src={`/agds-next/img/templates/${template.slug}.webp`}
+							src={`/img/templates/${template.slug}.webp`}
 							role="presentation"
 							alt=""
 						/>

--- a/docs/pages/templates/index.tsx
+++ b/docs/pages/templates/index.tsx
@@ -64,7 +64,7 @@ const TemplateCard = ({
 					</Stack>
 				</CardInner>
 				<img
-					src={`/agds-next/img/templates/${slug}.webp`}
+					src={`/img/templates/${slug}.webp`}
 					role="presentation"
 					alt=""
 					height="auto"

--- a/docs/pages/tokens/colour.tsx
+++ b/docs/pages/tokens/colour.tsx
@@ -93,7 +93,7 @@ export default function TokensColorPage() {
 
 						<Box paddingTop={[1, 0]}>
 							<img
-								src="/agds-next/img/guides/home.webp"
+								src="/img/guides/home.webp"
 								alt="Screenshot of a successful usage of palettes"
 							/>
 						</Box>

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -551,7 +551,7 @@ items={[
 		code: `<HeroBanner
     image={
       <img
-        src="/agds-next/img/placeholder/hero-banner.jpeg"
+        src="/img/placeholder/hero-banner.jpeg"
         role="presentation"
         alt=""
       />
@@ -573,7 +573,7 @@ items={[
 		code: `<HeroCategoryBanner
     image={
       <img
-        src="/agds-next/img/placeholder/hero-banner.jpeg"
+        src="/img/placeholder/hero-banner.jpeg"
         role="presentation"
         alt=""
       />
@@ -624,7 +624,7 @@ items={[
 	{
 		group: 'TextLinkExternal',
 		name: 'Basic',
-		code: `<TextLinkExternal href="https://steelthreads.github.io/agds-next">External link</TextLinkExternal>`,
+		code: `<TextLinkExternal href="https://design-system.agriculture.gov.au">External link</TextLinkExternal>`,
 	},
 
 	{

--- a/docs/scripts/generateGuideImages.js
+++ b/docs/scripts/generateGuideImages.js
@@ -2,7 +2,7 @@
 const puppeteer = require('puppeteer');
 const sharp = require('sharp');
 
-const BASE_URL = `http://localhost:3000/agds-next/example-site`;
+const BASE_URL = `http://localhost:3000/example-site`;
 const OUTPUT_DIR = `public/img/guides/`;
 
 (async () => {

--- a/docs/scripts/generateTemplateImages.js
+++ b/docs/scripts/generateTemplateImages.js
@@ -5,7 +5,7 @@ const puppeteer = require('puppeteer');
 const matter = require('gray-matter');
 const sharp = require('sharp');
 
-const BASE_URL = `http://localhost:3000/agds-next/example-site`;
+const BASE_URL = `http://localhost:3000/example-site`;
 const OUTPUT_DIR = `public/img/templates/`;
 const TEMPLATES_PATH = normalize(`${process.cwd()}/../templates/`);
 

--- a/example-form/next.config.js
+++ b/example-form/next.config.js
@@ -5,7 +5,7 @@ const withPreconstruct = require('@preconstruct/next');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
-	basePath: '/agds-next/example-form',
+	basePath: '/example-form',
 };
 
 module.exports = withPreconstruct(nextConfig);

--- a/example-site/components/SiteFooter.tsx
+++ b/example-site/components/SiteFooter.tsx
@@ -9,11 +9,11 @@ const footerLinks = [
 	{ label: 'Home', href: '/' },
 	{
 		label: 'Storybook',
-		href: 'https://steelthreads.github.io/agds-next/storybook/index.html',
+		href: 'https://design-system.agriculture.gov.au/storybook/index.html',
 	},
 	{
 		label: 'Playroom',
-		href: 'https://steelthreads.github.io/agds-next/playroom/index.html',
+		href: 'https://design-system.agriculture.gov.au/playroom/index.html',
 	},
 	{
 		label: 'Starter kit',

--- a/example-site/components/TemplateBanner.tsx
+++ b/example-site/components/TemplateBanner.tsx
@@ -20,7 +20,7 @@ export const TemplateBanner = ({ name, slug }: TemplateBannerProps) => {
 		>
 			<DirectionLink
 				direction="left"
-				href={`https://steelthreads.github.io/agds-next/templates/${slug}`}
+				href={`https://design-system.agriculture.gov.au/templates/${slug}`}
 			>
 				View {name} template overview
 			</DirectionLink>

--- a/example-site/next.config.js
+++ b/example-site/next.config.js
@@ -5,7 +5,7 @@ const withPreconstruct = require('@preconstruct/next');
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
-	basePath: '/agds-next/example-site',
+	basePath: '/example-site',
 };
 
 module.exports = withPreconstruct(nextConfig);

--- a/example-site/pages/category/index.tsx
+++ b/example-site/pages/category/index.tsx
@@ -19,7 +19,7 @@ export default function CategoryPage() {
 				<HeroCategoryBanner
 					image={
 						<img
-							src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+							src="/example-site/placeholder/hero-banner.jpeg"
 							role="presentation"
 							alt=""
 						/>

--- a/example-site/pages/index.tsx
+++ b/example-site/pages/index.tsx
@@ -23,7 +23,7 @@ export default function HomePage() {
 				<HeroBanner
 					image={
 						<img
-							src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+							src="/example-site/placeholder/hero-banner.jpeg"
 							role="presentation"
 							alt=""
 						/>
@@ -80,7 +80,7 @@ export default function HomePage() {
 							</CallToActionLink>
 						</Stack>
 						<img
-							src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+							src="/example-site/placeholder/hero-banner.jpeg"
 							role="presentation"
 							alt=""
 							css={{ display: 'block', maxWidth: '100%' }}
@@ -95,7 +95,7 @@ export default function HomePage() {
 							{Array.from(Array(3).keys()).map((idx) => (
 								<Card as="li" key={idx} clickable shadow>
 									<img
-										src="/agds-next/example-site/placeholder/hero-banner.jpeg"
+										src="/example-site/placeholder/hero-banner.jpeg"
 										role="presentation"
 										alt=""
 										css={{ width: '100%' }}

--- a/packages/a11y/README.md
+++ b/packages/a11y/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/a11y
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/a11y
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/a11y

--- a/packages/a11y/docs/overview.mdx
+++ b/packages/a11y/docs/overview.mdx
@@ -39,7 +39,7 @@ function Example() {
 	</p>
 </PageAlert>
 
-As a rule, links that open in a new tab should indicate this visually with an icon. This is why we recommend using the [TextLinkExternal](https://steelthreads.github.io/agds-next/components/text-link#TextLinkExternal) component instead.
+As a rule, links that open in a new tab should indicate this visually with an icon. This is why we recommend using the [TextLinkExternal](https://design-system.agriculture.gov.au/components/text-link#TextLinkExternal) component instead.
 
 ```jsx
 // A screen reader will read this out load as:

--- a/packages/a11y/src/ExternalLinkCallout.stories.tsx
+++ b/packages/a11y/src/ExternalLinkCallout.stories.tsx
@@ -20,7 +20,7 @@ export const Basic = () => (
 
 		<Text>
 			Experiment with all of our Design System components in{' '}
-			<TextLink href="https://steelthreads.github.io/agds-next/playroom/index.html">
+			<TextLink href="https://design-system.agriculture.gov.au/playroom/index.html">
 				Playroom
 				<ExternalLinkCallout />
 			</TextLink>

--- a/packages/accordion/README.md
+++ b/packages/accordion/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/accordion
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/accordion
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/accordion

--- a/packages/accordion/docs/overview.mdx
+++ b/packages/accordion/docs/overview.mdx
@@ -148,7 +148,7 @@ This text is wrapped in the `AccordionContent` component.
 	<AccordionItem title="Edge-to-edge image">
 		<img
 			alt="Placeholder image"
-			src="/agds-next/img/placeholder/600X260.png"
+			src="/img/placeholder/600X260.png"
 			width="100%"
 		/>
 		<AccordionItemContent>

--- a/packages/accordion/src/Accordion.stories.tsx
+++ b/packages/accordion/src/Accordion.stories.tsx
@@ -256,7 +256,7 @@ export const EdgeToEdgeImage = () => (
 		<AccordionItem title="Edge-to-edge image">
 			<img
 				alt="Placeholder image"
-				src="/agds-next/img/placeholder/600X260.png"
+				src="/img/placeholder/600X260.png"
 				width="100%"
 			/>
 			<AccordionItemContent>

--- a/packages/ag-branding/README.md
+++ b/packages/ag-branding/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/ag-branding
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/ag-branding
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/ag-branding

--- a/packages/autocomplete/README.md
+++ b/packages/autocomplete/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/autocomplete
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/autocomplete
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/autocomplete

--- a/packages/badge/README.md
+++ b/packages/badge/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/badge
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/badge
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/badge

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/box
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/box
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/box

--- a/packages/breadcrumbs/README.md
+++ b/packages/breadcrumbs/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/breadcrumbs
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/breadcrumbs
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/breadcrumbs

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/button
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/button
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/button

--- a/packages/call-to-action/README.md
+++ b/packages/call-to-action/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/call-to-action
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/call-to-action
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/call-to-action

--- a/packages/callout/README.md
+++ b/packages/callout/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/callout
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/callout
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/callout

--- a/packages/card/README.md
+++ b/packages/card/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/card
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/card
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/card

--- a/packages/card/src/Card.stories.tsx
+++ b/packages/card/src/Card.stories.tsx
@@ -301,7 +301,7 @@ export const Compositions = () => {
 						<Card shadow clickable>
 							<img
 								alt="Placeholder image"
-								src="https://steelthreads.github.io/agds-next/img/placeholder/hero-banner.jpeg"
+								src="https://design-system.agriculture.gov.au/img/placeholder/hero-banner.jpeg"
 								width="100%"
 							/>
 							<CardInner>
@@ -321,7 +321,7 @@ export const Compositions = () => {
 							<Flex>
 								<img
 									alt="Placeholder image"
-									src="https://steelthreads.github.io/agds-next/img/placeholder/hero-banner.jpeg"
+									src="https://design-system.agriculture.gov.au/img/placeholder/hero-banner.jpeg"
 									css={{
 										width: '50%',
 										objectFit: 'cover',

--- a/packages/columns/README.md
+++ b/packages/columns/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/columns
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/columns
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/columns

--- a/packages/combobox/README.md
+++ b/packages/combobox/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/combobox
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/combobox
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/combobox

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/content
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/content
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/content

--- a/packages/control-input/README.md
+++ b/packages/control-input/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/control-input
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/control-input
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/control-input

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/core
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/core
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/core

--- a/packages/core/docs/overview.mdx
+++ b/packages/core/docs/overview.mdx
@@ -43,4 +43,4 @@ export default function MyApp({ Component, pageProps }) {
 
 Core includes a range of styles, variables and code that form the foundation of how the Design System works, including colour, typography and spacing.
 
-All of our Tokens are viewable [here](https://steelthreads.github.io/agds-next/tokens)
+All of our Tokens are viewable [here](https://design-system.agriculture.gov.au/tokens)

--- a/packages/date-picker/README.md
+++ b/packages/date-picker/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/date-picker
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/date-picker
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/date-picker

--- a/packages/details/README.md
+++ b/packages/details/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/details
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/details
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/details

--- a/packages/direction-link/README.md
+++ b/packages/direction-link/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/direction-link
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/direction-link
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/direction-link

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/field
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/field
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/field

--- a/packages/field/docs/overview.mdx
+++ b/packages/field/docs/overview.mdx
@@ -69,7 +69,7 @@ The `Field` component will always append `(optional)` to the label based on the 
 
 By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
 
-Please refer to the [example site single-page form example](https://steelthreads.github.io/agds-next/example-site/single-page-form) to see an example of this hook in use.
+Please refer to the [example site single-page form example](https://design-system.agriculture.gov.au/example-site/single-page-form) to see an example of this hook in use.
 
 ```jsx
 function ExampleForm() {

--- a/packages/fieldset/README.md
+++ b/packages/fieldset/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/fieldset
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/fieldset
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/fieldset

--- a/packages/file-upload/README.md
+++ b/packages/file-upload/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/file-upload
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/file-upload
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/file-upload

--- a/packages/footer/README.md
+++ b/packages/footer/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/footer
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/footer
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/footer

--- a/packages/form-stack/README.md
+++ b/packages/form-stack/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/form-stack
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/form-stack
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/form-stack

--- a/packages/header/README.md
+++ b/packages/header/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/header
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/header
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/header

--- a/packages/heading/README.md
+++ b/packages/heading/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/heading
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/heading
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/heading

--- a/packages/hero-banner/README.md
+++ b/packages/hero-banner/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/hero-banner
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/hero-banner
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/hero-banner

--- a/packages/hero-banner/docs/overview.mdx
+++ b/packages/hero-banner/docs/overview.mdx
@@ -12,11 +12,7 @@ Use the `HeroBanner` components on home or landing pages.
 ```jsx live
 <HeroBanner
 	image={
-		<img
-			src="/agds-next/img/placeholder/hero-banner.jpeg"
-			role="presentation"
-			alt=""
-		/>
+		<img src="/img/placeholder/hero-banner.jpeg" role="presentation" alt="" />
 	}
 >
 	<HeroBannerTitleContainer>
@@ -36,7 +32,7 @@ Use the `HeroBanner` components on home or landing pages.
 
 ### Image selection
 
-Images in this component are automatically resized to fit their container using the [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property. Because of this it is important to use image at an appropriate image ratio. You can reference the image size and ratio of our [example image](/agds-next/img/placeholder/hero-banner.jpeg).
+Images in this component are automatically resized to fit their container using the [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property. Because of this it is important to use image at an appropriate image ratio. You can reference the image size and ratio of our [example image](/img/placeholder/hero-banner.jpeg).
 
 ## Hero Category Banner
 
@@ -45,11 +41,7 @@ Use the `HeroCategoryBanner` components for top level category pages.
 ```jsx live
 <HeroCategoryBanner
 	image={
-		<img
-			src="/agds-next/img/placeholder/hero-banner.jpeg"
-			role="presentation"
-			alt=""
-		/>
+		<img src="/img/placeholder/hero-banner.jpeg" role="presentation" alt="" />
 	}
 >
 	<HeroCategoryBannerTitle>

--- a/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBanner.stories.tsx
@@ -47,7 +47,7 @@ const commonArgs = {
 	subtitle: 'Short hero banner sentence - md/default (P)',
 	image: (
 		<img
-			src="https://steelthreads.github.io/agds-next/img/placeholder/hero-banner.jpeg"
+			src="https://design-system.agriculture.gov.au/img/placeholder/hero-banner.jpeg"
 			role="presentation"
 			alt=""
 		/>

--- a/packages/hero-banner/src/HeroBanner/HeroBanner.test.tsx
+++ b/packages/hero-banner/src/HeroBanner/HeroBanner.test.tsx
@@ -16,7 +16,7 @@ function renderHeroBanner() {
 		<HeroBanner
 			image={
 				<img
-					src="/agds-next/img/placeholder/hero-banner.jpeg"
+					src="/img/placeholder/hero-banner.jpeg"
 					role="presentation"
 					alt=""
 				/>

--- a/packages/hero-banner/src/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
+++ b/packages/hero-banner/src/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`HeroBanner renders correctly 1`] = `
       <img
         alt=""
         role="presentation"
-        src="/agds-next/img/placeholder/hero-banner.jpeg"
+        src="/img/placeholder/hero-banner.jpeg"
       />
     </div>
     <div
@@ -62,7 +62,7 @@ exports[`HeroBanner renders correctly 1`] = `
             <img
               alt=""
               role="presentation"
-              src="/agds-next/img/placeholder/hero-banner.jpeg"
+              src="/img/placeholder/hero-banner.jpeg"
             />
           </div>
         </div>

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.stories.tsx
@@ -39,7 +39,7 @@ const commonArgs = {
 	subtitle: 'Short hero banner sentence - md/default (P)',
 	image: (
 		<img
-			src="https://steelthreads.github.io/agds-next/img/placeholder/hero-banner.jpeg"
+			src="https://design-system.agriculture.gov.au/img/placeholder/hero-banner.jpeg"
 			role="presentation"
 			alt=""
 		/>

--- a/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.test.tsx
+++ b/packages/hero-banner/src/HeroCategoryBanner/HeroCategoryBanner.test.tsx
@@ -14,7 +14,7 @@ function renderHeroCategoryBanner() {
 		<HeroCategoryBanner
 			image={
 				<img
-					src="/agds-next/img/placeholder/hero-banner.jpeg"
+					src="/img/placeholder/hero-banner.jpeg"
 					role="presentation"
 					alt=""
 				/>

--- a/packages/hero-banner/src/HeroCategoryBanner/__snapshots__/HeroCategoryBanner.test.tsx.snap
+++ b/packages/hero-banner/src/HeroCategoryBanner/__snapshots__/HeroCategoryBanner.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`HeroCategoryBanner renders correctly 1`] = `
       <img
         alt=""
         role="presentation"
-        src="/agds-next/img/placeholder/hero-banner.jpeg"
+        src="/img/placeholder/hero-banner.jpeg"
       />
     </div>
     <div
@@ -43,7 +43,7 @@ exports[`HeroCategoryBanner renders correctly 1`] = `
             <img
               alt=""
               role="presentation"
-              src="/agds-next/img/placeholder/hero-banner.jpeg"
+              src="/img/placeholder/hero-banner.jpeg"
             />
           </div>
         </div>

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/icon
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/icon
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/icon

--- a/packages/icon/docs/overview.mdx
+++ b/packages/icon/docs/overview.mdx
@@ -9,6 +9,6 @@ storybookPath: /story/foundations-icon--all-icons
 <AvatarIcon size="md" weight="regular" />
 ```
 
-See the full list of available icons [here](https://steelthreads.github.io/agds-next/storybook/index.html?path=/story/foundations-icon--all-icons).
+See the full list of available icons [here](https://design-system.agriculture.gov.au/storybook/index.html?path=/story/foundations-icon--all-icons).
 
 > Do you have a user need for new or missing icon? Get in touch to discuss an icon contribution.

--- a/packages/inpage-nav/README.md
+++ b/packages/inpage-nav/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/inpage-nav
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/inpage-nav
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/inpage-nav

--- a/packages/keyword-list/README.md
+++ b/packages/keyword-list/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/keyword-list
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/keyword-list
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/keyword-list

--- a/packages/link-list/README.md
+++ b/packages/link-list/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/link-list
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/link-list
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/link-list

--- a/packages/link-list/docs/overview.mdx
+++ b/packages/link-list/docs/overview.mdx
@@ -14,7 +14,7 @@ The default link list component removes the normal bullets and spacing associate
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
 		{
-			href: 'https://steelthreads.github.io/agds-next',
+			href: 'https://design-system.agriculture.gov.au',
 			label: 'External link',
 			target: '_blank',
 			rel: 'noopener',
@@ -34,7 +34,7 @@ Setting the `horizontal` prop will stack the links horizontally.
 		{ href: '#', label: 'Establishments' },
 		{ href: '#', label: 'Applications' },
 		{
-			href: 'https://steelthreads.github.io/agds-next',
+			href: 'https://design-system.agriculture.gov.au',
 			label: 'External link',
 			target: '_blank',
 			rel: 'noopener',

--- a/packages/link-list/src/LinkList.stories.tsx
+++ b/packages/link-list/src/LinkList.stories.tsx
@@ -12,7 +12,7 @@ const exampleLinks = [
 	{ href: '#', label: 'Establishments' },
 	{ href: '#', label: 'Applications' },
 	{
-		href: 'https://steelthreads.github.io/agds-next',
+		href: 'https://design-system.agriculture.gov.au',
 		label: 'External link',
 		target: '_blank',
 		rel: 'noopener',

--- a/packages/link-list/src/LinkList.test.tsx
+++ b/packages/link-list/src/LinkList.test.tsx
@@ -13,7 +13,7 @@ function renderLinkList(props?: Partial<LinkListProps>) {
 				{ href: '#', label: 'Establishments' },
 				{ href: '#', label: 'Applications' },
 				{
-					href: 'https://steelthreads.github.io/agds-next',
+					href: 'https://design-system.agriculture.gov.au',
 					label: 'External link',
 					target: '_blank',
 					rel: 'noopener',

--- a/packages/link-list/src/__snapshots__/LinkList.test.tsx.snap
+++ b/packages/link-list/src/__snapshots__/LinkList.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`LinkList renders correctly 1`] = `
     >
       <a
         class="css-38ppen-TextLink"
-        href="https://steelthreads.github.io/agds-next"
+        href="https://design-system.agriculture.gov.au"
         rel="noopener"
         target="_blank"
       >

--- a/packages/loading/README.md
+++ b/packages/loading/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/loading
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/loading
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/loading

--- a/packages/main-nav/README.md
+++ b/packages/main-nav/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/main-nav
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/main-nav
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/main-nav

--- a/packages/modal/README.md
+++ b/packages/modal/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/modal
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/modal
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/modal

--- a/packages/page-alert/README.md
+++ b/packages/page-alert/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/page-alert
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/page-alert
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/page-alert

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/pagination
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/pagination
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/pagination

--- a/packages/progress-indicator/README.md
+++ b/packages/progress-indicator/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/progress-indicator
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/progress-indicator
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/progress-indicator

--- a/packages/prose/README.md
+++ b/packages/prose/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/prose
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/prose
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/prose

--- a/packages/prose/docs/overview.mdx
+++ b/packages/prose/docs/overview.mdx
@@ -186,7 +186,7 @@ The `Prose` component should only be used in the context of a page to format lon
 	</figure>
 
 	<figure>
-		<img src="/agds-next/img/placeholder/600X260.png" alt="Placeholder image" />
+		<img src="/img/placeholder/600X260.png" alt="Placeholder image" />
 		<figcaption>Placeholder caption</figcaption>
 	</figure>
 

--- a/packages/prose/src/Prose.stories.tsx
+++ b/packages/prose/src/Prose.stories.tsx
@@ -186,10 +186,7 @@ const UnstyledContent = () => (
 		</figure>
 
 		<figure>
-			<img
-				src="/agds-next/img/placeholder/600X260.png"
-				alt="Placeholder image"
-			/>
+			<img src="/img/placeholder/600X260.png" alt="Placeholder image" />
 			<figcaption>Placeholder caption</figcaption>
 		</figure>
 

--- a/packages/search-box/README.md
+++ b/packages/search-box/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/search-box
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/search-box
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/search-box

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/select
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/select
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/select

--- a/packages/side-nav/README.md
+++ b/packages/side-nav/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/side-nav
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/side-nav
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/side-nav

--- a/packages/skeleton/README.md
+++ b/packages/skeleton/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/skeleton
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/skeleton
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/skeleton

--- a/packages/skip-link/README.md
+++ b/packages/skip-link/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/skip-link
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/skip-link
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/skip-link

--- a/packages/sub-nav/README.md
+++ b/packages/sub-nav/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/sub-nav
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/sub-nav
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/sub-nav

--- a/packages/summary-list/README.md
+++ b/packages/summary-list/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/summary-list
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/summary-list
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/summary-list

--- a/packages/switch/README.md
+++ b/packages/switch/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/switch
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/switch
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/switch

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/table
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/table
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/table

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/tags
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/tags
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/tags

--- a/packages/task-list/README.md
+++ b/packages/task-list/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/task-list
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/task-list
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/task-list

--- a/packages/text-input/README.md
+++ b/packages/text-input/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/text-input
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/text-input
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/text-input

--- a/packages/text-link/README.md
+++ b/packages/text-link/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/text-link
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/text-link
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/text-link

--- a/packages/text-link/docs/overview.mdx
+++ b/packages/text-link/docs/overview.mdx
@@ -29,7 +29,7 @@ For more information, please refer to:
 ```jsx live
 <Text>
 	Interact with our components in{' '}
-	<TextLinkExternal href="https://steelthreads.github.io/agds-next/playroom/index.html">
+	<TextLinkExternal href="https://design-system.agriculture.gov.au/playroom/index.html">
 		Playroom
 	</TextLinkExternal>
 	.

--- a/packages/text-link/src/TextLinkExternal.stories.tsx
+++ b/packages/text-link/src/TextLinkExternal.stories.tsx
@@ -13,5 +13,5 @@ const Template: ComponentStory<typeof TextLinkExternal> = (args) => {
 export const Basic = Template.bind({});
 Basic.args = {
 	children: 'External link',
-	href: 'https://steelthreads.github.io/agds-next',
+	href: 'https://design-system.agriculture.gov.au',
 };

--- a/packages/text-link/src/TextLinkExternal.test.tsx
+++ b/packages/text-link/src/TextLinkExternal.test.tsx
@@ -9,7 +9,7 @@ function renderTextLinkExternal() {
 	return render(
 		<TextLinkExternal
 			data-testid="example"
-			href="https://steelthreads.github.io/agds-next"
+			href="https://design-system.agriculture.gov.au"
 		>
 			External link
 		</TextLinkExternal>

--- a/packages/text-link/src/__snapshots__/TextLinkExternal.test.tsx.snap
+++ b/packages/text-link/src/__snapshots__/TextLinkExternal.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TextLinkExternal renders correctly 1`] = `
   <a
     class="css-38ppen-TextLink"
     data-testid="example"
-    href="https://steelthreads.github.io/agds-next"
+    href="https://design-system.agriculture.gov.au"
     rel="noopener"
     target="_blank"
   >

--- a/packages/text/README.md
+++ b/packages/text/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/text
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/text
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/text

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -1,3 +1,3 @@
 ## @ag.ds-next/textarea
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/textarea
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/textarea

--- a/plop-templates/component/README.md.hbs
+++ b/plop-templates/component/README.md.hbs
@@ -1,3 +1,3 @@
 ## @ag.ds-next/{{packageName}}
 
-Documentation for this package can be found here: https://steelthreads.github.io/agds-next/components/{{packageName}}
+Documentation for this package can be found here: https://design-system.agriculture.gov.au/components/{{packageName}}

--- a/scripts/plopfile.mjs
+++ b/scripts/plopfile.mjs
@@ -2,7 +2,7 @@ export default function newPackage(
 	/** @type {import('plop').NodePlopAPI} */
 	plop
 ) {
-	plop.setHelper('website', () => 'https://steelthreads.github.io/agds-next');
+	plop.setHelper('website', () => 'https://design-system.agriculture.gov.au');
 
 	plop.setGenerator('component', {
 		description: 'Add new component',


### PR DESCRIPTION
## Describe your changes

This morning we updated our website domain from `https://steelthreads.github.io/agds-next` to `https://design-system.agriculture.gov.au`.

Now that the DNS changes have been made, we need to update the paths and content on our website, example site and example form.
