### PR TITLE
docs: Add component search

### DIFF
--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -97,6 +97,7 @@ function pkgNavMetaData(
 		title: (data?.title ?? slug) as string,
 		group: slugify(data?.group ?? 'Other') as string,
 		groupName: (data?.group ?? 'Other') as string,
+		description: (data?.description ?? null) as string | null,
 		slug,
 	};
 }

--- a/docs/pages/components/index.tsx
+++ b/docs/pages/components/index.tsx
@@ -1,8 +1,11 @@
 import { normalize } from 'path';
+import { Fragment, useMemo, useState } from 'react';
 import { MDXRemote } from 'next-mdx-remote';
 import { Stack } from '@ag.ds-next/box';
 import { Prose } from '@ag.ds-next/prose';
 import { H2 } from '@ag.ds-next/heading';
+import { Text } from '@ag.ds-next/text';
+import { SearchInput } from '@ag.ds-next/search-input';
 import { getMarkdownData, serializeMarkdown } from '../../lib/mdxUtils';
 import {
 	getPkgGroupList,
@@ -23,6 +26,19 @@ export default function PackagesHome({
 	pkgList,
 	source,
 }: StaticProps) {
+	const [searchTerm, setSearchTerm] = useState('');
+
+	const filteredPkgs = useMemo(() => {
+		if (!searchTerm) return null;
+		return pkgList.filter((p) => {
+			return (
+				p.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+				p.groupName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+				p.description?.toLowerCase().includes(searchTerm.toLowerCase())
+			);
+		});
+	}, [pkgList, searchTerm]);
+
 	return (
 		<>
 			<DocumentTitle title="Components" />
@@ -38,16 +54,36 @@ export default function PackagesHome({
 					<Prose>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Prose>
-					<Stack gap={2}>
-						{groupList.map((group) => (
-							<Stack gap={1} key={group.slug}>
-								<H2>{group.title}</H2>
-								<PkgCardList
-									items={pkgList.filter((p) => p.group === group.slug)}
-								/>
-							</Stack>
-						))}
-					</Stack>
+					<div role="search" aria-label="components">
+						<SearchInput
+							label="Search components"
+							hint="Example. Search for “toggle” or “form”."
+							value={searchTerm}
+							onChange={setSearchTerm}
+							maxWidth="xl"
+							hideOptionalLabel
+						/>
+					</div>
+					{searchTerm ? (
+						filteredPkgs?.length ? (
+							<PkgCardList items={filteredPkgs} />
+						) : (
+							<Text as="p">
+								No results found. Please change your search term.
+							</Text>
+						)
+					) : (
+						<Stack gap={2}>
+							{groupList.map((group) => (
+								<Stack gap={1} key={group.slug}>
+									<H2>{group.title}</H2>
+									<PkgCardList
+										items={pkgList.filter((p) => p.group === group.slug)}
+									/>
+								</Stack>
+							))}
+						</Stack>
+					)}
 				</PageLayout>
 			</AppLayout>
 		</>

--- a/packages/switch/docs/overview.mdx
+++ b/packages/switch/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Switch
-description: Allows a user to immediately update interface settings.
+description: Allows a user to toggle a setting on or off, immediately affecting the user interface.
 group: Forms
 storybookPath: /story/forms-switch--switch
 ---
@@ -8,6 +8,8 @@ storybookPath: /story/forms-switch--switch
 A Switch allows a user to toggle a setting on or off, immediately affecting the user interface. Common use-cases include filtering interfaces and settings menus.
 
 A Switch should not be used in Forms, or where a submit button is needed. Instead, a Checkbox or Radio component should be used.
+
+## Default
 
 `Switch` is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components).
 


### PR DESCRIPTION
## Describe your changes

### Default state 

Components are grouped

<img width="1645" alt="Screen Shot 2022-11-30 at 4 29 15 pm" src="https://user-images.githubusercontent.com/6265154/204724004-f3cfa621-ee46-4d97-a467-8dd38c90c906.png">

### Search term

Components are a flat list

<img width="1646" alt="Screen Shot 2022-11-30 at 4 29 33 pm" src="https://user-images.githubusercontent.com/6265154/204724019-76d7b751-e612-4c47-a9bc-2941c7355f4b.png">

### Empty state

<img width="1706" alt="Screen Shot 2022-11-30 at 4 36 19 pm" src="https://user-images.githubusercontent.com/6265154/204724952-7c4972ea-06cc-48fb-a464-10adc412fda8.png">
