### PR TITLE
field: Adjust max widths

### DIFF
--- a/.changeset/soft-berries-taste.md
+++ b/.changeset/soft-berries-taste.md
@@ -1,0 +1,14 @@
+---
+'@ag.ds-next/combobox': patch
+'@ag.ds-next/core': patch
+'@ag.ds-next/date-picker': patch
+'@ag.ds-next/field': patch
+'@ag.ds-next/fieldset': patch
+'@ag.ds-next/search-box': patch
+'@ag.ds-next/search-input': patch
+'@ag.ds-next/select': patch
+'@ag.ds-next/text-input': patch
+'@ag.ds-next/textarea': patch
+---
+
+Adjusted form field max widths

--- a/.changeset/sour-emus-study.md
+++ b/.changeset/sour-emus-study.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/select': patch
+'@ag.ds-next/textarea': patch
+---
+
+Removed `xs` and `sm` options from the `maxWidth` prop

--- a/docs/components/TokenCharts.tsx
+++ b/docs/components/TokenCharts.tsx
@@ -62,41 +62,32 @@ export const SpacingChart = () => {
 	);
 };
 
-export const MaxWidthChart = () => {
+export const MaxWidthChart = ({
+	tokens,
+}: {
+	tokens: Record<string, unknown>;
+}) => {
 	return (
 		<Stack as="ul" gap={0.5} className={proseBlockClassname}>
-			{Object.entries(tokens.maxWidth).map(([token, value], index) => (
-				<MaxWidthItem key={index} token={token} value={value} />
-			))}
+			{Object.entries(tokens).map(([token, value], index) => {
+				if (typeof value !== 'string') return null;
+				const label = `${token} (${value})`;
+				return (
+					<Flex key={index} as="li" gap={0.25}>
+						<Box
+							padding={0.5}
+							css={{
+								backgroundColor: boxPalette.systemInfoMuted,
+								width: '100%',
+								maxWidth: value,
+							}}
+						>
+							<Text>{label}</Text>
+						</Box>
+					</Flex>
+				);
+			})}
 		</Stack>
-	);
-};
-
-export const MaxWidthFieldChart = () => {
-	return (
-		<Stack as="ul" gap={0.5} className={proseBlockClassname}>
-			{Object.entries(tokens.maxWidthField).map(([token, value], index) => (
-				<MaxWidthItem key={index} token={token} value={value} />
-			))}
-		</Stack>
-	);
-};
-
-const MaxWidthItem = ({ token, value }: { token: string; value: string }) => {
-	const label = `${token} (${value})`;
-	return (
-		<Flex as="li" gap={0.25}>
-			<Box
-				padding={0.5}
-				css={{
-					backgroundColor: boxPalette.systemInfoMuted,
-					width: '100%',
-					maxWidth: value,
-				}}
-			>
-				<Text>{label}</Text>
-			</Box>
-		</Flex>
 	);
 };
 

--- a/docs/components/TokenCharts.tsx
+++ b/docs/components/TokenCharts.tsx
@@ -64,25 +64,39 @@ export const SpacingChart = () => {
 
 export const MaxWidthChart = () => {
 	return (
-		<Stack gap={0.5} className={proseBlockClassname}>
-			{Object.entries(tokens.maxWidth).map(([token, value]) => {
-				const label = `${token} (${value})`;
-				return (
-					<Flex key={token} gap={0.25}>
-						<Box
-							padding={0.5}
-							css={{
-								backgroundColor: boxPalette.systemInfoMuted,
-								width: '100%',
-								maxWidth: value,
-							}}
-						>
-							<Text>{label}</Text>
-						</Box>
-					</Flex>
-				);
-			})}
+		<Stack as="ul" gap={0.5} className={proseBlockClassname}>
+			{Object.entries(tokens.maxWidth).map(([token, value], index) => (
+				<MaxWidthItem key={index} token={token} value={value} />
+			))}
 		</Stack>
+	);
+};
+
+export const MaxWidthFieldChart = () => {
+	return (
+		<Stack as="ul" gap={0.5} className={proseBlockClassname}>
+			{Object.entries(tokens.maxWidthField).map(([token, value], index) => (
+				<MaxWidthItem key={index} token={token} value={value} />
+			))}
+		</Stack>
+	);
+};
+
+const MaxWidthItem = ({ token, value }: { token: string; value: string }) => {
+	const label = `${token} (${value})`;
+	return (
+		<Flex as="li" gap={0.25}>
+			<Box
+				padding={0.5}
+				css={{
+					backgroundColor: boxPalette.systemInfoMuted,
+					width: '100%',
+					maxWidth: value,
+				}}
+			>
+				<Text>{label}</Text>
+			</Box>
+		</Flex>
 	);
 };
 

--- a/docs/components/TokenLayout.tsx
+++ b/docs/components/TokenLayout.tsx
@@ -7,7 +7,7 @@ export const navLinks = [
 	{ href: '/tokens/colour', label: 'Colour' },
 	{ href: '/tokens/breakpoints', label: 'Breakpoints' },
 	{ href: '/tokens/border', label: 'Border' },
-	{ href: '/tokens/max-width', label: 'Max Width' },
+	{ href: '/tokens/max-width', label: 'Max width' },
 	{ href: '/tokens/spacing', label: 'Spacing' },
 	{ href: '/tokens/typography', label: 'Typography' },
 ];

--- a/docs/pages/tokens/index.tsx
+++ b/docs/pages/tokens/index.tsx
@@ -11,9 +11,9 @@ const description =
 export default function TokensPage() {
 	return (
 		<>
-			<DocumentTitle title="Tokens" />
+			<DocumentTitle title="Tokens" description={description} />
 			<TokenLayout
-				title="Design Tokens"
+				title="Design tokens"
 				description={description}
 				editPath="/docs/pages/tokens/index.tsx"
 			>

--- a/docs/pages/tokens/max-width.tsx
+++ b/docs/pages/tokens/max-width.tsx
@@ -1,6 +1,9 @@
 import { Prose } from '@ag.ds-next/prose';
 import { DocumentTitle } from '../../components/DocumentTitle';
-import { MaxWidthChart } from '../../components/TokenCharts';
+import {
+	MaxWidthChart,
+	MaxWidthFieldChart,
+} from '../../components/TokenCharts';
 import { TokenLayout } from '../../components/TokenLayout';
 
 export default function TokensMaxWidthsPage() {
@@ -8,12 +11,15 @@ export default function TokensMaxWidthsPage() {
 		<>
 			<DocumentTitle title="Max-Width tokens" />
 			<TokenLayout
-				title="Max-Width tokens"
-				description="Used to set the maximum width of a container in a page layout."
+				title="Max Width tokens"
+				description="Used to set the maximum width of elements or containers in a page layout."
 				editPath="/docs/pages/tokens/max-width.tsx"
 			>
 				<Prose>
 					<MaxWidthChart />
+					<h2>Field</h2>
+					<p>Maximum widths of form fields.</p>
+					<MaxWidthFieldChart />
 				</Prose>
 			</TokenLayout>
 		</>

--- a/docs/pages/tokens/max-width.tsx
+++ b/docs/pages/tokens/max-width.tsx
@@ -1,25 +1,23 @@
+import { tokens } from '@ag.ds-next/core';
 import { Prose } from '@ag.ds-next/prose';
 import { DocumentTitle } from '../../components/DocumentTitle';
-import {
-	MaxWidthChart,
-	MaxWidthFieldChart,
-} from '../../components/TokenCharts';
+import { MaxWidthChart } from '../../components/TokenCharts';
 import { TokenLayout } from '../../components/TokenLayout';
 
 export default function TokensMaxWidthsPage() {
 	return (
 		<>
-			<DocumentTitle title="Max-Width tokens" />
+			<DocumentTitle title="Max width tokens" />
 			<TokenLayout
-				title="Max Width tokens"
+				title="Max width tokens"
 				description="Used to set the maximum width of elements or containers in a page layout."
 				editPath="/docs/pages/tokens/max-width.tsx"
 			>
 				<Prose>
-					<MaxWidthChart />
+					<MaxWidthChart tokens={tokens.maxWidth} />
 					<h2>Field</h2>
 					<p>Maximum widths of form fields.</p>
-					<MaxWidthFieldChart />
+					<MaxWidthChart tokens={tokens.maxWidth.field} />
 				</Prose>
 			</TokenLayout>
 		</>

--- a/packages/combobox/src/Combobox.tsx
+++ b/packages/combobox/src/Combobox.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useState, ReactNode, useCallback } from 'react';
 import { useCombobox } from 'downshift';
 import { usePopper } from 'react-popper';
-import { useId } from '@ag.ds-next/core';
+import { FieldMaxWidth, useId } from '@ag.ds-next/core';
 import { textInputStyles } from '@ag.ds-next/text-input';
 import { Field } from '@ag.ds-next/field';
 import { Text } from '@ag.ds-next/text';
@@ -29,6 +29,8 @@ export type ComboboxProps<Option extends DefaultComboboxOption> = {
 	invalid?: boolean;
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
+	/** The maximum width of the field. */
+	maxWidth?: Extract<FieldMaxWidth, 'md' | 'lg' | 'xl'>;
 	disabled?: boolean;
 	id?: string;
 	name?: string;
@@ -60,6 +62,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 	id: idProp,
 	disabled,
 	block,
+	maxWidth: maxWidthProp = 'xl',
 	showDropdownTrigger = true,
 	clearable = false,
 	options = [],
@@ -145,7 +148,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 	const { maxWidth, ...inputStyles } = {
 		...textInputStyles({
 			block,
-			maxWidth: 'xl',
+			maxWidth: maxWidthProp,
 			invalid,
 		}),
 	};

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -89,27 +89,17 @@ const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
 	mobileMenu: '17.5rem', // 280 px
+	field: {
+		xs: '5rem', // 80 px
+		sm: '8rem', // 128 px
+		md: '13rem', // 208 px
+		lg: '18rem', // 288 px
+		xl: '24rem', // 384 px
+	},
 } as const;
 
 export type MaxWidth = keyof typeof maxWidth;
-
-const maxWidthField = {
-	xs: '5rem',
-	sm: '8rem',
-	md: '13rem',
-	lg: '18rem',
-	xl: '24rem',
-} as const;
-
-// OLD
-// 	xs: '4.3rem',
-// 	sm: '6.3rem',
-// 	md: '10rem',
-// 	lg: '18rem',
-// 	xl: '24rem',
-//	default: '12.8125rem'
-
-export type MaxWidthField = keyof typeof maxWidthField;
+export type FieldMaxWidth = keyof typeof maxWidth.field;
 
 const borderRadius = unit;
 
@@ -133,7 +123,6 @@ export const tokens = {
 	lineHeight,
 	containerPadding,
 	maxWidth,
-	maxWidthField,
 	borderRadius,
 	borderWidth,
 };

--- a/packages/core/src/tokens.ts
+++ b/packages/core/src/tokens.ts
@@ -89,7 +89,27 @@ const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
 	mobileMenu: '17.5rem', // 280 px
-};
+} as const;
+
+export type MaxWidth = keyof typeof maxWidth;
+
+const maxWidthField = {
+	xs: '5rem',
+	sm: '8rem',
+	md: '13rem',
+	lg: '18rem',
+	xl: '24rem',
+} as const;
+
+// OLD
+// 	xs: '4.3rem',
+// 	sm: '6.3rem',
+// 	md: '10rem',
+// 	lg: '18rem',
+// 	xl: '24rem',
+//	default: '12.8125rem'
+
+export type MaxWidthField = keyof typeof maxWidthField;
 
 const borderRadius = unit;
 
@@ -113,6 +133,7 @@ export const tokens = {
 	lineHeight,
 	containerPadding,
 	maxWidth,
+	maxWidthField,
 	borderRadius,
 	borderWidth,
 };

--- a/packages/date-picker/src/DatePickerInput.tsx
+++ b/packages/date-picker/src/DatePickerInput.tsx
@@ -26,7 +26,7 @@ export const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 			block,
 			id,
 			buttonRef,
-			maxWidth: maxWidthProp,
+			maxWidth: maxWidthProp = 'md',
 			buttonOnClick,
 			disabled,
 			value,

--- a/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`DatePicker renders correctly 1`] = `
         </span>
       </label>
       <div
-        class="css-rj58ps-boxStyles-DateInput"
+        class="css-7swrfr-boxStyles-DateInput"
       >
         <input
           aria-invalid="false"

--- a/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DatePicker.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`DatePicker renders correctly 1`] = `
         </span>
       </label>
       <div
-        class="css-1az95r4-boxStyles-DateInput"
+        class="css-rj58ps-boxStyles-DateInput"
       >
         <input
           aria-invalid="false"

--- a/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`DateRangePicker renders correctly 1`] = `
           </span>
         </label>
         <div
-          class="css-rj58ps-boxStyles-DateInput"
+          class="css-7swrfr-boxStyles-DateInput"
         >
           <input
             aria-invalid="false"
@@ -98,7 +98,7 @@ exports[`DateRangePicker renders correctly 1`] = `
           </span>
         </label>
         <div
-          class="css-rj58ps-boxStyles-DateInput"
+          class="css-7swrfr-boxStyles-DateInput"
         >
           <input
             aria-invalid="false"

--- a/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/date-picker/src/__snapshots__/DateRangePicker.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`DateRangePicker renders correctly 1`] = `
           </span>
         </label>
         <div
-          class="css-1az95r4-boxStyles-DateInput"
+          class="css-rj58ps-boxStyles-DateInput"
         >
           <input
             aria-invalid="false"
@@ -98,7 +98,7 @@ exports[`DateRangePicker renders correctly 1`] = `
           </span>
         </label>
         <div
-          class="css-1az95r4-boxStyles-DateInput"
+          class="css-rj58ps-boxStyles-DateInput"
         >
           <input
             aria-invalid="false"

--- a/packages/field/src/fieldMaxWidth.tsx
+++ b/packages/field/src/fieldMaxWidth.tsx
@@ -1,9 +1,0 @@
-export const fieldMaxWidth = {
-	xs: '4.3rem',
-	sm: '6.3rem',
-	md: '10rem',
-	lg: '18rem',
-	xl: '24rem',
-} as const;
-
-export type FieldMaxWidth = keyof typeof fieldMaxWidth;

--- a/packages/field/src/index.tsx
+++ b/packages/field/src/index.tsx
@@ -3,5 +3,4 @@ export * from './FieldContainer';
 export * from './FieldHint';
 export * from './FieldLabel';
 export * from './FieldMessage';
-export * from './fieldMaxWidth';
 export * from './useScrollToField';

--- a/packages/fieldset/src/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/fieldset/src/__snapshots__/Fieldset.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1bu2krz-Field"
+            class="css-1cwde7c-Field"
             id="field-:r1:"
             type="text"
           />
@@ -61,7 +61,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1bu2krz-Field"
+            class="css-1cwde7c-Field"
             id="field-:r2:"
             type="text"
           />
@@ -118,7 +118,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1bu2krz-Field"
+            class="css-1cwde7c-Field"
             id="field-:ra:"
             type="text"
           />
@@ -139,7 +139,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1bu2krz-Field"
+            class="css-1cwde7c-Field"
             id="field-:rb:"
             type="text"
           />

--- a/packages/fieldset/src/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/fieldset/src/__snapshots__/Fieldset.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1cwde7c-Field"
+            class="css-18yk6qt-Field"
             id="field-:r1:"
             type="text"
           />
@@ -61,7 +61,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1cwde7c-Field"
+            class="css-18yk6qt-Field"
             id="field-:r2:"
             type="text"
           />
@@ -118,7 +118,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1cwde7c-Field"
+            class="css-18yk6qt-Field"
             id="field-:ra:"
             type="text"
           />
@@ -139,7 +139,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           <input
             aria-invalid="false"
             aria-required="true"
-            class="css-1cwde7c-Field"
+            class="css-18yk6qt-Field"
             id="field-:rb:"
             type="text"
           />

--- a/packages/search-box/src/__snapshots__/Search.test.tsx.snap
+++ b/packages/search-box/src/__snapshots__/Search.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`SearchBox renders correctly 1`] = `
           Search
         </label>
         <input
-          class="css-i4ov2d-SearchBoxInput"
+          class="css-q8ysto-SearchBoxInput"
           id="search-:r0:"
           type="search"
         />

--- a/packages/search-input/src/SearchInput.tsx
+++ b/packages/search-input/src/SearchInput.tsx
@@ -6,7 +6,7 @@ import {
 	useState,
 } from 'react';
 import { Field } from '@ag.ds-next/field';
-import { MaxWidthField, mergeRefs } from '@ag.ds-next/core';
+import { FieldMaxWidth, mergeRefs } from '@ag.ds-next/core';
 import { textInputStyles } from '@ag.ds-next/text-input';
 import { SearchInputContainer } from './SearchInputContainer';
 import { SearchInputClearButton } from './SearchInputClearButton';
@@ -25,7 +25,7 @@ type BaseSearchInputProps = {
 	value?: NativeInputProps['value'];
 };
 
-export type SearchInputMaxWidth = Extract<MaxWidthField, 'md' | 'lg' | 'xl'>;
+export type SearchInputMaxWidth = Extract<FieldMaxWidth, 'md' | 'lg' | 'xl'>;
 
 export type SearchInputProps = BaseSearchInputProps & {
 	/** Describes the purpose of the field. */

--- a/packages/search-input/src/SearchInput.tsx
+++ b/packages/search-input/src/SearchInput.tsx
@@ -5,8 +5,8 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import { Field, FieldMaxWidth } from '@ag.ds-next/field';
-import { mergeRefs } from '@ag.ds-next/core';
+import { Field } from '@ag.ds-next/field';
+import { MaxWidthField, mergeRefs } from '@ag.ds-next/core';
 import { textInputStyles } from '@ag.ds-next/text-input';
 import { SearchInputContainer } from './SearchInputContainer';
 import { SearchInputClearButton } from './SearchInputClearButton';
@@ -25,6 +25,8 @@ type BaseSearchInputProps = {
 	value?: NativeInputProps['value'];
 };
 
+export type SearchInputMaxWidth = Extract<MaxWidthField, 'md' | 'lg' | 'xl'>;
+
 export type SearchInputProps = BaseSearchInputProps & {
 	/** Describes the purpose of the field. */
 	label: string;
@@ -41,7 +43,7 @@ export type SearchInputProps = BaseSearchInputProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: Extract<FieldMaxWidth, 'md' | 'lg' | 'xl'>;
+	maxWidth?: SearchInputMaxWidth;
 	/** Function to be called when the input is cleared. */
 	onClear?: () => void;
 };
@@ -56,7 +58,7 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
 			message,
 			invalid,
 			block,
-			maxWidth: maxWidthProp,
+			maxWidth: maxWidthProp = 'md',
 			id,
 			disabled,
 			value: valueProp,
@@ -143,7 +145,7 @@ function searchInputStyles({
 	showClearButton,
 }: {
 	block?: boolean;
-	maxWidth?: SearchInputProps['maxWidth'];
+	maxWidth: NonNullable<SearchInputMaxWidth>;
 	invalid?: boolean;
 	showClearButton: boolean;
 }) {

--- a/packages/search-input/src/SearchInputContainer.tsx
+++ b/packages/search-input/src/SearchInputContainer.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren } from 'react';
 
-export type SearchInputContainerProps = PropsWithChildren<{ maxWidth: string }>;
+export type SearchInputContainerProps = PropsWithChildren<{
+	maxWidth?: string;
+}>;
 
 export function SearchInputContainer({
 	children,

--- a/packages/search-input/src/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/search-input/src/__snapshots__/SearchInput.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`SearchInput Basic renders correctly 1`] = `
       </span>
     </label>
     <div
-      class="css-1mmi5kq-SearchInputContainer"
+      class="css-fctz8d-SearchInputContainer"
     >
       <svg
         aria-hidden="true"
@@ -114,7 +114,7 @@ exports[`SearchInput Invalid renders correctly 1`] = `
       </span>
     </div>
     <div
-      class="css-1mmi5kq-SearchInputContainer"
+      class="css-fctz8d-SearchInputContainer"
     >
       <svg
         aria-hidden="true"
@@ -180,7 +180,7 @@ exports[`SearchInput With hint renders correctly 1`] = `
       Hint text
     </span>
     <div
-      class="css-1mmi5kq-SearchInputContainer"
+      class="css-fctz8d-SearchInputContainer"
     >
       <svg
         aria-hidden="true"

--- a/packages/select/docs/overview.mdx
+++ b/packages/select/docs/overview.mdx
@@ -149,3 +149,43 @@ Disabled select elements are unusable and can not be clicked. This prevents a us
 	]}
 />
 ```
+
+## Maximum widths
+
+```jsx live
+<Stack gap={1}>
+	<Select
+		label="md select"
+		maxWidth="md"
+		label="What option?"
+		placeholder="Please select"
+		options={[
+			{ value: 'a', label: 'Option A' },
+			{ value: 'b', label: 'Option B' },
+			{ value: 'c', label: 'Option C' },
+		]}
+	/>
+	<Select
+		label="lg select"
+		maxWidth="lg"
+		label="What option?"
+		placeholder="Please select"
+		options={[
+			{ value: 'a', label: 'Option A' },
+			{ value: 'b', label: 'Option B' },
+			{ value: 'c', label: 'Option C' },
+		]}
+	/>
+	<Select
+		label="xl select"
+		maxWidth="xl"
+		label="What option?"
+		placeholder="Please select"
+		options={[
+			{ value: 'a', label: 'Option A' },
+			{ value: 'b', label: 'Option B' },
+			{ value: 'c', label: 'Option C' },
+		]}
+	/>
+</Stack>
+```

--- a/packages/select/src/Select.stories.tsx
+++ b/packages/select/src/Select.stories.tsx
@@ -93,7 +93,7 @@ Block.args = {
 
 export const MaxWidths: ComponentStory<typeof Select> = (args) => (
 	<Stack gap={1}>
-		{(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
+		{(['md', 'lg', 'xl'] as const).map((size) => (
 			<Select key={size} {...args} label={size} maxWidth={size} />
 		))}
 	</Stack>

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -10,7 +10,7 @@ import {
 	boxPalette,
 	mapSpacing,
 	tokens,
-	MaxWidthField,
+	FieldMaxWidth,
 } from '@ag.ds-next/core';
 import { ChevronDownIcon } from '@ag.ds-next/icon';
 
@@ -58,7 +58,7 @@ export type SelectProps = BaseSelectProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: MaxWidthField;
+	maxWidth?: FieldMaxWidth;
 };
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
@@ -109,12 +109,14 @@ const SelectContainer = ({
 	maxWidth,
 }: PropsWithChildren<{
 	block?: boolean;
-	maxWidth: MaxWidthField;
+	maxWidth: FieldMaxWidth;
 }>) => (
 	<div
 		css={{
 			position: 'relative',
-			maxWidth: block ? undefined : tokens.maxWidthField[maxWidth],
+			...(!block && {
+				maxWidth: tokens.maxWidth.field[maxWidth],
+			}),
 		}}
 	>
 		{children}

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -40,6 +40,8 @@ type BaseSelectProps = {
 	value?: NativeSelectProps['value'];
 };
 
+type SelectMaxWidth = Extract<FieldMaxWidth, 'md' | 'lg' | 'xl'>;
+
 export type SelectProps = BaseSelectProps & {
 	/** Describes the purpose of the field. */
 	label: string;
@@ -58,7 +60,7 @@ export type SelectProps = BaseSelectProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: FieldMaxWidth;
+	maxWidth?: SelectMaxWidth;
 };
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
@@ -109,7 +111,7 @@ const SelectContainer = ({
 	maxWidth,
 }: PropsWithChildren<{
 	block?: boolean;
-	maxWidth: FieldMaxWidth;
+	maxWidth: SelectMaxWidth;
 }>) => (
 	<div
 		css={{

--- a/packages/select/src/Select.tsx
+++ b/packages/select/src/Select.tsx
@@ -4,8 +4,14 @@ import {
 	PropsWithChildren,
 	SelectHTMLAttributes,
 } from 'react';
-import { Field, FieldMaxWidth, fieldMaxWidth } from '@ag.ds-next/field';
-import { packs, boxPalette, mapSpacing, tokens } from '@ag.ds-next/core';
+import { Field } from '@ag.ds-next/field';
+import {
+	packs,
+	boxPalette,
+	mapSpacing,
+	tokens,
+	MaxWidthField,
+} from '@ag.ds-next/core';
 import { ChevronDownIcon } from '@ag.ds-next/icon';
 
 export type Option = {
@@ -52,7 +58,7 @@ export type SelectProps = BaseSelectProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: FieldMaxWidth;
+	maxWidth?: MaxWidthField;
 };
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
@@ -65,7 +71,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
 			message,
 			invalid,
 			block,
-			maxWidth,
+			maxWidth = 'md',
 			options,
 			placeholder,
 			id,
@@ -103,16 +109,12 @@ const SelectContainer = ({
 	maxWidth,
 }: PropsWithChildren<{
 	block?: boolean;
-	maxWidth?: FieldMaxWidth;
+	maxWidth: MaxWidthField;
 }>) => (
 	<div
 		css={{
 			position: 'relative',
-			maxWidth: block
-				? undefined
-				: maxWidth
-				? fieldMaxWidth[maxWidth]
-				: '12.8125rem',
+			maxWidth: block ? undefined : tokens.maxWidthField[maxWidth],
 		}}
 	>
 		{children}

--- a/packages/select/src/__snapshots__/Select.test.tsx.snap
+++ b/packages/select/src/__snapshots__/Select.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Select Basic renders correctly 1`] = `
       </span>
     </label>
     <div
-      class="css-yql58k-SelectContainer"
+      class="css-1bg5d3h-SelectContainer"
     >
       <select
         aria-invalid="false"
@@ -86,7 +86,7 @@ exports[`Select Grouped options renders correctly 1`] = `
       </span>
     </label>
     <div
-      class="css-yql58k-SelectContainer"
+      class="css-1bg5d3h-SelectContainer"
     >
       <select
         aria-invalid="false"
@@ -208,7 +208,7 @@ exports[`Select Invalid renders correctly 1`] = `
       </span>
     </div>
     <div
-      class="css-yql58k-SelectContainer"
+      class="css-1bg5d3h-SelectContainer"
     >
       <select
         aria-describedby="field-:r6:-message"
@@ -274,7 +274,7 @@ exports[`Select With hint renders correctly 1`] = `
       </span>
     </label>
     <div
-      class="css-yql58k-SelectContainer"
+      class="css-1bg5d3h-SelectContainer"
     >
       <select
         aria-invalid="false"

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -1,6 +1,12 @@
 import { forwardRef, InputHTMLAttributes } from 'react';
-import { Field, fieldMaxWidth, FieldMaxWidth } from '@ag.ds-next/field';
-import { packs, boxPalette, mapSpacing, tokens } from '@ag.ds-next/core';
+import { Field } from '@ag.ds-next/field';
+import {
+	packs,
+	boxPalette,
+	mapSpacing,
+	tokens,
+	MaxWidthField,
+} from '@ag.ds-next/core';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
 
@@ -36,7 +42,7 @@ export type TextInputProps = BaseTextInputProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: FieldMaxWidth;
+	maxWidth?: MaxWidthField;
 };
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
@@ -49,7 +55,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 			message,
 			invalid,
 			block,
-			maxWidth,
+			maxWidth = 'md',
 			id,
 			type = 'text',
 			...props
@@ -82,7 +88,7 @@ export const textInputStyles = ({
 	multiline,
 }: {
 	block?: boolean;
-	maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+	maxWidth?: MaxWidthField;
 	invalid?: boolean;
 	multiline?: boolean;
 }) =>
@@ -98,9 +104,12 @@ export const textInputStyles = ({
 		borderColor: boxPalette.border,
 		borderRadius: tokens.borderRadius,
 		color: boxPalette.foregroundText,
-		maxWidth: maxWidth ? fieldMaxWidth[maxWidth] : '12.8125rem',
 		fontFamily: tokens.font.body,
 		...packs.input.md,
+
+		...(maxWidth && {
+			maxWidth: tokens.maxWidthField[maxWidth],
+		}),
 
 		...(block && {
 			maxWidth: 'none',

--- a/packages/text-input/src/TextInput.tsx
+++ b/packages/text-input/src/TextInput.tsx
@@ -5,7 +5,7 @@ import {
 	boxPalette,
 	mapSpacing,
 	tokens,
-	MaxWidthField,
+	FieldMaxWidth,
 } from '@ag.ds-next/core';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -42,7 +42,7 @@ export type TextInputProps = BaseTextInputProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: MaxWidthField;
+	maxWidth?: FieldMaxWidth;
 };
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
@@ -88,7 +88,7 @@ export const textInputStyles = ({
 	multiline,
 }: {
 	block?: boolean;
-	maxWidth?: MaxWidthField;
+	maxWidth?: FieldMaxWidth;
 	invalid?: boolean;
 	multiline?: boolean;
 }) =>
@@ -108,7 +108,7 @@ export const textInputStyles = ({
 		...packs.input.md,
 
 		...(maxWidth && {
-			maxWidth: tokens.maxWidthField[maxWidth],
+			maxWidth: tokens.maxWidth.field[maxWidth],
 		}),
 
 		...(block && {

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`TextInput Basic renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-1bu2krz-Field"
+      class="css-1cwde7c-Field"
       id="field-:r0:"
       type="text"
     />
@@ -89,7 +89,7 @@ exports[`TextInput Invalid renders correctly 1`] = `
       aria-describedby="field-:r4:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-b9h5aa-Field"
+      class="css-13cx3z1-Field"
       id="field-:r4:"
       type="text"
     />
@@ -127,7 +127,7 @@ exports[`TextInput With hint renders correctly 1`] = `
       aria-describedby="field-:r2:-hint"
       aria-invalid="false"
       aria-required="false"
-      class="css-1bu2krz-Field"
+      class="css-1cwde7c-Field"
       id="field-:r2:"
       type="text"
     />

--- a/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/text-input/src/__snapshots__/TextInput.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`TextInput Basic renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-1cwde7c-Field"
+      class="css-18yk6qt-Field"
       id="field-:r0:"
       type="text"
     />
@@ -89,7 +89,7 @@ exports[`TextInput Invalid renders correctly 1`] = `
       aria-describedby="field-:r4:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-13cx3z1-Field"
+      class="css-1r4zr1h-Field"
       id="field-:r4:"
       type="text"
     />
@@ -127,7 +127,7 @@ exports[`TextInput With hint renders correctly 1`] = `
       aria-describedby="field-:r2:-hint"
       aria-invalid="false"
       aria-required="false"
-      class="css-1cwde7c-Field"
+      class="css-18yk6qt-Field"
       id="field-:r2:"
       type="text"
     />

--- a/packages/textarea/docs/overview.mdx
+++ b/packages/textarea/docs/overview.mdx
@@ -67,8 +67,6 @@ The maximum width of a textarea should indicate the amount of information expect
 
 ```jsx live
 <Stack gap={1}>
-	<Textarea label="xs textarea" maxWidth="xs" />
-	<Textarea label="sm textarea" maxWidth="sm" />
 	<Textarea label="md textarea" maxWidth="md" />
 	<Textarea label="lg textarea" maxWidth="lg" />
 	<Textarea label="xl textarea" maxWidth="xl" />

--- a/packages/textarea/src/Textarea.stories.tsx
+++ b/packages/textarea/src/Textarea.stories.tsx
@@ -56,7 +56,7 @@ Block.args = {
 
 export const MaxWidths: ComponentStory<typeof Textarea> = (args) => (
 	<Stack background="body" palette="light" gap={1}>
-		{(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((size) => (
+		{(['md', 'lg', 'xl'] as const).map((size) => (
 			<Textarea key={size} {...args} label={size} maxWidth={size} />
 		))}
 	</Stack>

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, TextareaHTMLAttributes } from 'react';
-import { MaxWidthField } from '@ag.ds-next/core';
+import { FieldMaxWidth } from '@ag.ds-next/core';
 import { Field } from '@ag.ds-next/field';
 import { textInputStyles } from '@ag.ds-next/text-input';
 
@@ -35,7 +35,7 @@ export type TextareaProps = BaseTextareaProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: MaxWidthField;
+	maxWidth?: FieldMaxWidth;
 };
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -35,7 +35,7 @@ export type TextareaProps = BaseTextareaProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: FieldMaxWidth;
+	maxWidth?: Extract<FieldMaxWidth, 'md' | 'lg' | 'xl'>;
 };
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(

--- a/packages/textarea/src/Textarea.tsx
+++ b/packages/textarea/src/Textarea.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, TextareaHTMLAttributes } from 'react';
-import { Field, FieldMaxWidth } from '@ag.ds-next/field';
+import { MaxWidthField } from '@ag.ds-next/core';
+import { Field } from '@ag.ds-next/field';
 import { textInputStyles } from '@ag.ds-next/text-input';
 
 type NativeTextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
@@ -34,7 +35,7 @@ export type TextareaProps = BaseTextareaProps & {
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
 	/** The maximum width of the field. */
-	maxWidth?: FieldMaxWidth;
+	maxWidth?: MaxWidthField;
 };
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
@@ -47,7 +48,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
 			message,
 			invalid,
 			block,
-			maxWidth,
+			maxWidth = 'md',
 			id,
 			...props
 		},

--- a/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Textarea Basic renders correctly 1`] = `
     <textarea
       aria-invalid="false"
       aria-required="false"
-      class="css-t9m3m-Field"
+      class="css-126vl07-Field"
       id="field-:r0:"
     />
   </div>
@@ -88,7 +88,7 @@ exports[`Textarea Invalid renders correctly 1`] = `
       aria-describedby="field-:r4:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-xktc3q-Field"
+      class="css-2pthw9-Field"
       id="field-:r4:"
     />
   </div>
@@ -125,7 +125,7 @@ exports[`Textarea With hint renders correctly 1`] = `
       aria-describedby="field-:r2:-hint"
       aria-invalid="false"
       aria-required="false"
-      class="css-t9m3m-Field"
+      class="css-126vl07-Field"
       id="field-:r2:"
     />
   </div>

--- a/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/textarea/src/__snapshots__/Textarea.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Textarea Basic renders correctly 1`] = `
     <textarea
       aria-invalid="false"
       aria-required="false"
-      class="css-126vl07-Field"
+      class="css-18gg9dt-Field"
       id="field-:r0:"
     />
   </div>
@@ -88,7 +88,7 @@ exports[`Textarea Invalid renders correctly 1`] = `
       aria-describedby="field-:r4:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-2pthw9-Field"
+      class="css-1c35e4-Field"
       id="field-:r4:"
     />
   </div>
@@ -125,7 +125,7 @@ exports[`Textarea With hint renders correctly 1`] = `
       aria-describedby="field-:r2:-hint"
       aria-invalid="false"
       aria-required="false"
-      class="css-126vl07-Field"
+      class="css-18gg9dt-Field"
       id="field-:r2:"
     />
   </div>


### PR DESCRIPTION
## Describe your changes

This PR adjusts the maximum widths of our form fields. 

The values we initially used were taken from GOLD and are a bit odd. For example the `xs` form field was `4.3rem (68.8px)` wide which can be. Also if no max width was supplied `12.8125rem` was used.  Now, the default max width is `md`.

```diff
- xs: '4.3rem',
+ xs: '5rem',
- sm: '6.3rem',
+ sm: '8rem',
- md: '10rem',
+ md: '13rem',
- lg: '18rem',
+ lg: '18rem',
- xl: '24rem',
+ xl: '24rem',
```

| Before      | After |
| ----------- | ----------- |
| <img width="815" alt="Screen Shot 2022-12-01 at 2 55 38 pm" src="https://user-images.githubusercontent.com/6265154/204968858-ffa3536f-eca0-4c36-be02-bd382ac98354.png"> | <img width="817" alt="Screen Shot 2022-12-01 at 2 55 04 pm" src="https://user-images.githubusercontent.com/6265154/204968873-7270b9a6-cef3-4f9f-a6ef-7d99566c7ab7.png">  |

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook
