### PR TITLE
docs: Add descriptions to pages

### DIFF
--- a/.changeset/twelve-chicken-walk.md
+++ b/.changeset/twelve-chicken-walk.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/prose': patch
+---
+
+Added empty styles so the container will be hidden if no content has been supplied.

--- a/docs/components/DocumentTitle.tsx
+++ b/docs/components/DocumentTitle.tsx
@@ -1,9 +1,16 @@
 import Head from 'next/head';
 
-export const DocumentTitle = ({ title }: { title?: string }) => (
+export const DocumentTitle = ({
+	title,
+	description,
+}: {
+	title?: string;
+	description?: string | null;
+}) => (
 	<Head>
 		<title>
 			{[title, 'Agriculture Design System'].filter(Boolean).join(' | ')}
 		</title>
+		{description ? <meta name="description" content={description} /> : null}
 	</Head>
 );

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -40,7 +40,7 @@ export function PkgLayout({
 			<PageTitle
 				pretext={isUnreleased ? 'In development' : `v${pkg.version}`}
 				title={pkg.title}
-				introduction={pkg.data.description}
+				introduction={pkg.description}
 				callToAction={
 					pkg.storybookPath && (
 						<CallToActionLink

--- a/docs/components/TemplateLayout.tsx
+++ b/docs/components/TemplateLayout.tsx
@@ -47,9 +47,9 @@ export const TemplateLayout = ({
 				skipLinks={skipLinks}
 			>
 				<PageTitle
-					pretext={`v${template.data.version}`}
+					pretext={`v${template.version}`}
 					title={template.title}
-					introduction={template.data.description}
+					introduction={template.description}
 					callToAction={
 						template.previewPath && (
 							<CallToActionLink href={`/example-site${template.previewPath}`}>

--- a/docs/content/components/index.mdx
+++ b/docs/content/components/index.mdx
@@ -1,0 +1,4 @@
+---
+title: Components
+description: Discover all the Agriculture Design System components here including visual examples, component props, and live code examples.
+---

--- a/docs/content/guides/index.mdx
+++ b/docs/content/guides/index.mdx
@@ -1,1 +1,4 @@
-# Guides
+---
+title: Guides
+description: Learn how to use the Agriculture Design System to design and build your project.
+---

--- a/docs/content/templates/index.mdx
+++ b/docs/content/templates/index.mdx
@@ -1,3 +1,4 @@
-# Templates
-
-Choose from any of the template below to get your project up and running faster. They’ll save your team time and resources and help get value to your users sooner.
+---
+title: Templates
+description: Choose from any of the template below to get your project up and running faster. They’ll save your team time and resources and help get value to your users sooner.
+---

--- a/docs/content/updates/index.mdx
+++ b/docs/content/updates/index.mdx
@@ -1,1 +1,4 @@
-# Updates
+---
+title: Updates
+description: Release notes and latest updates on the Agriculture Design System.
+---

--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -31,6 +31,7 @@ export async function getPkg(slug: string) {
 		name: name as string,
 		version: version as string,
 		title: (data.title ?? slug) as string,
+		description: (data.description ?? null) as string | null,
 		storybookPath: (data.storybookPath ?? null) as string | null,
 		subNavItems: subNavItems ?? null,
 	};

--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -9,6 +9,8 @@ import {
 } from '../mdxUtils';
 import { slugify } from '../slugify';
 
+export const COMPONENTS_PATH = normalize(`${process.cwd()}/content/components`);
+
 const PKG_PATH = normalize(`${process.cwd()}/../packages`);
 const pkgReadmePath = (slug: string) => `${PKG_PATH}/${slug}/docs/overview.mdx`;
 

--- a/docs/lib/mdx/templates.ts
+++ b/docs/lib/mdx/templates.ts
@@ -23,6 +23,8 @@ export async function getTemplate(slug: string) {
 		source,
 		data,
 		title: (data.title ?? slug) as string,
+		version: data.version as string,
+		description: (data.description ?? null) as string | null,
 		previewPath: (data.previewPath ?? null) as string | null,
 	};
 }

--- a/docs/lib/mdx/updates.ts
+++ b/docs/lib/mdx/updates.ts
@@ -18,6 +18,7 @@ export async function getUpdate(slug: string) {
 		source,
 		data,
 		title: (data.title ?? slug) as string,
+		description: (data.description ?? null) as string | null,
 	};
 }
 

--- a/docs/pages/components/[slug]/accessibility.tsx
+++ b/docs/pages/components/[slug]/accessibility.tsx
@@ -34,7 +34,7 @@ export default function PackagesAccessibility({
 							href: '#pkg-content',
 						},
 					]}
-					editPath={`/components/${pkg.slug}/docs/accessibility.mdx`}
+					editPath={`/packages/${pkg.slug}/docs/accessibility.mdx`}
 				>
 					<Prose id="pkg-content">
 						<MDXRemote {...content} components={mdxComponents} />

--- a/docs/pages/components/[slug]/code.tsx
+++ b/docs/pages/components/[slug]/code.tsx
@@ -34,7 +34,7 @@ export default function PackagesCode({
 							href: '#pkg-content',
 						},
 					]}
-					editPath={`/components/${pkg.slug}/docs/code.mdx`}
+					editPath={`/packages/${pkg.slug}/docs/code.mdx`}
 				>
 					<Prose id="pkg-content">
 						<h2>Source</h2>

--- a/docs/pages/components/[slug]/content.tsx
+++ b/docs/pages/components/[slug]/content.tsx
@@ -34,7 +34,7 @@ export default function PackagesContent({
 							href: '#pkg-content',
 						},
 					]}
-					editPath={`/components/${pkg.slug}/docs/content.mdx`}
+					editPath={`/packages/${pkg.slug}/docs/content.mdx`}
 				>
 					<Prose id="pkg-content">
 						<MDXRemote {...content} components={mdxComponents} />

--- a/docs/pages/components/[slug]/index.tsx
+++ b/docs/pages/components/[slug]/index.tsx
@@ -34,7 +34,7 @@ export default function Packages({
 							href: '#pkg-content',
 						},
 					]}
-					editPath={`/components/${pkg.slug}/docs/overview.mdx`}
+					editPath={`/packages/${pkg.slug}/docs/overview.mdx`}
 				>
 					<Prose id="pkg-content">
 						<MDXRemote {...content} components={mdxComponents} />

--- a/docs/pages/components/[slug]/index.tsx
+++ b/docs/pages/components/[slug]/index.tsx
@@ -22,7 +22,7 @@ export default function Packages({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={pkg.title} />
+			<DocumentTitle title={pkg.title} description={pkg.description} />
 			<AppLayout>
 				<PkgLayout
 					pkg={pkg}

--- a/docs/pages/components/[slug]/rationale.tsx
+++ b/docs/pages/components/[slug]/rationale.tsx
@@ -34,7 +34,7 @@ export default function PackagesRationale({
 							href: '#pkg-content',
 						},
 					]}
-					editPath={`/components/${pkg.slug}/docs/rationale.mdx`}
+					editPath={`/packages/${pkg.slug}/docs/rationale.mdx`}
 				>
 					<Prose id="pkg-content">
 						<MDXRemote {...content} components={mdxComponents} />

--- a/docs/pages/components/index.tsx
+++ b/docs/pages/components/index.tsx
@@ -8,6 +8,7 @@ import { Text } from '@ag.ds-next/text';
 import { SearchInput } from '@ag.ds-next/search-input';
 import { getMarkdownData, serializeMarkdown } from '../../lib/mdxUtils';
 import {
+	COMPONENTS_PATH,
 	getPkgGroupList,
 	getPkgList,
 	getPkgNavLinks,
@@ -17,6 +18,7 @@ import { AppLayout } from '../../components/AppLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { PageLayout } from '../../components/PageLayout';
 import { PkgCardList } from '../../components/PkgCardList';
+import { PageTitle } from '../../components/PageTitle';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
@@ -25,6 +27,8 @@ export default function PackagesHome({
 	groupList,
 	pkgList,
 	source,
+	title,
+	description,
 }: StaticProps) {
 	const [searchTerm, setSearchTerm] = useState('');
 
@@ -49,8 +53,9 @@ export default function PackagesHome({
 						titleLink: '/components',
 						items: navLinks,
 					}}
-					editPath="/packages/README.md"
+					editPath="/docs/content/components/index.mdx"
 				>
+					<PageTitle title={title} introduction={description} />
 					<Prose>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Prose>
@@ -91,8 +96,8 @@ export default function PackagesHome({
 }
 
 export async function getStaticProps() {
-	const { content } = await getMarkdownData(
-		normalize(`${process.cwd()}/../packages/README.md`)
+	const { content, data } = await getMarkdownData(
+		normalize(`${COMPONENTS_PATH}/index.mdx`)
 	);
 	const source = await serializeMarkdown(content);
 	const navLinks = await getPkgNavLinks();
@@ -102,6 +107,8 @@ export async function getStaticProps() {
 	return {
 		props: {
 			source,
+			title: (data?.title || null) as string | null,
+			description: (data?.description || null) as string | null,
 			navLinks,
 			groupList,
 			pkgList,

--- a/docs/pages/components/index.tsx
+++ b/docs/pages/components/index.tsx
@@ -45,7 +45,7 @@ export default function PackagesHome({
 
 	return (
 		<>
-			<DocumentTitle title="Components" />
+			<DocumentTitle title="Components" description={description} />
 			<AppLayout>
 				<PageLayout
 					sideNav={{

--- a/docs/pages/guides/[slug].tsx
+++ b/docs/pages/guides/[slug].tsx
@@ -21,7 +21,7 @@ export default function Guides({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={guide.title} />
+			<DocumentTitle title={guide.title} description={guide.description} />
 			<AppLayout>
 				<PageLayout
 					sideNav={{

--- a/docs/pages/guides/index.tsx
+++ b/docs/pages/guides/index.tsx
@@ -11,10 +11,16 @@ import { mdxComponents } from '../../components/mdxComponents';
 import { AppLayout } from '../../components/AppLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { PageLayout } from '../../components/PageLayout';
+import { PageTitle } from '../../components/PageTitle';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
-export default function GuidesHome({ source, guideLinks }: StaticProps) {
+export default function GuidesHome({
+	source,
+	title,
+	description,
+	guideLinks,
+}: StaticProps) {
 	return (
 		<>
 			<DocumentTitle title="Guides" />
@@ -27,6 +33,7 @@ export default function GuidesHome({ source, guideLinks }: StaticProps) {
 					}}
 					editPath="/docs/content/guides/index.mdx"
 				>
+					<PageTitle title={title} introduction={description} />
 					<Prose>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Prose>
@@ -51,7 +58,7 @@ export default function GuidesHome({ source, guideLinks }: StaticProps) {
 }
 
 export async function getStaticProps() {
-	const { content } = await getMarkdownData(
+	const { content, data } = await getMarkdownData(
 		normalize(`${GUIDE_PATH}/index.mdx`)
 	);
 	const source = await serializeMarkdown(content);
@@ -65,6 +72,8 @@ export async function getStaticProps() {
 	return {
 		props: {
 			source,
+			title: (data?.title || null) as string | null,
+			description: (data?.description || null) as string | null,
 			guideLinks,
 		},
 	};

--- a/docs/pages/guides/index.tsx
+++ b/docs/pages/guides/index.tsx
@@ -23,7 +23,7 @@ export default function GuidesHome({
 }: StaticProps) {
 	return (
 		<>
-			<DocumentTitle title="Guides" />
+			<DocumentTitle title="Guides" description={description} />
 			<AppLayout>
 				<PageLayout
 					sideNav={{

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -14,10 +14,13 @@ import { AppLayout } from '../components/AppLayout';
 import { PictogramCard } from '../components/PictogramCard';
 import { DocumentTitle } from '../components/DocumentTitle';
 
+const description =
+	'AgDS provides a framework and a set of tools to help designers and developers build the steel threads of the Export Service quickly, efficiently and consistently.';
+
 export default function Homepage() {
 	return (
 		<>
-			<DocumentTitle />
+			<DocumentTitle description={description} />
 			<AppLayout>
 				<main
 					id="main-content"
@@ -29,11 +32,7 @@ export default function Homepage() {
 							<HeroBannerTitle>
 								Welcome to the Agriculture Design System (AgDS)
 							</HeroBannerTitle>
-							<HeroBannerSubtitle>
-								AgDS provides a framework and a set of tools to help designers
-								and developers build the steel threads of the Export Service
-								quickly, efficiently and consistently.
-							</HeroBannerSubtitle>
+							<HeroBannerSubtitle>{description}</HeroBannerSubtitle>
 						</HeroBannerTitleContainer>
 						<CallToActionLink href="/guides/getting-started">
 							Get started
@@ -54,12 +53,6 @@ export default function Homepage() {
 										Digital Service Standard
 									</TextLink>
 									.
-								</p>
-								<p>
-									The system is in early development right now. Feel free to
-									look around and leave feedback or suggestions if you like but
-									please do not depend on these components just yet. We&apos;re
-									working hard to get a stable release out as soon as we can.
 								</p>
 							</Prose>
 							<Columns

--- a/docs/pages/templates/[slug]/code.tsx
+++ b/docs/pages/templates/[slug]/code.tsx
@@ -23,7 +23,7 @@ export default function TemplateCodePage({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={`${template.data.title} template code`} />
+			<DocumentTitle title={`${template.title} template code`} />
 			<TemplateLayout
 				template={template}
 				breadcrumbs={breadcrumbs}
@@ -32,7 +32,7 @@ export default function TemplateCodePage({
 				editPath={`/docs/content/templates/${template.slug}/code.mdx`}
 				skipLinks={[
 					{
-						label: `Skip to ${template.data.title} template code`,
+						label: `Skip to ${template.title} template code`,
 						href: '#page-content',
 					},
 				]}

--- a/docs/pages/templates/[slug]/content.tsx
+++ b/docs/pages/templates/[slug]/content.tsx
@@ -23,7 +23,7 @@ export default function TemplateContentPage({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={`${template.data.title} template content`} />
+			<DocumentTitle title={`${template.title} template content`} />
 			<TemplateLayout
 				template={template}
 				breadcrumbs={breadcrumbs}
@@ -32,7 +32,7 @@ export default function TemplateContentPage({
 				editPath={`/docs/content/templates/${template.slug}/content.mdx`}
 				skipLinks={[
 					{
-						label: `Skip to ${template.data.title} template content`,
+						label: `Skip to ${template.title} template content`,
 						href: '#page-content',
 					},
 				]}

--- a/docs/pages/templates/[slug]/index.tsx
+++ b/docs/pages/templates/[slug]/index.tsx
@@ -22,7 +22,10 @@ export default function TemplateOverviewPage({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={`${template.data.title} template`} />
+			<DocumentTitle
+				title={`${template.title} template`}
+				description={template.description}
+			/>
 			<TemplateLayout
 				template={template}
 				breadcrumbs={breadcrumbs}
@@ -31,7 +34,7 @@ export default function TemplateOverviewPage({
 				editPath={`/docs/content/templates/${template.slug}/index.mdx`}
 				skipLinks={[
 					{
-						label: `Skip to ${template.data.title} template overview`,
+						label: `Skip to ${template.title} template overview`,
 						href: '#page-content',
 					},
 				]}

--- a/docs/pages/templates/index.tsx
+++ b/docs/pages/templates/index.tsx
@@ -13,10 +13,16 @@ import { mdxComponents } from '../../components/mdxComponents';
 import { AppLayout } from '../../components/AppLayout';
 import { PageLayout } from '../../components/PageLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
+import { PageTitle } from '../../components/PageTitle';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
-export default function TemplatesPage({ source, templateLinks }: StaticProps) {
+export default function TemplatesPage({
+	source,
+	title,
+	description,
+	templateLinks,
+}: StaticProps) {
 	return (
 		<>
 			<DocumentTitle title="Templates" />
@@ -29,6 +35,7 @@ export default function TemplatesPage({ source, templateLinks }: StaticProps) {
 					}}
 					editPath="/docs/content/templates/index.mdx"
 				>
+					<PageTitle title={title} introduction={description} />
 					<Prose>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Prose>
@@ -80,7 +87,7 @@ const TemplateCard = ({
 };
 
 export async function getStaticProps() {
-	const { content } = await getMarkdownData(
+	const { content, data } = await getMarkdownData(
 		normalize(`${TEMPLATES_PATH}/index.mdx`)
 	);
 	const source = await serializeMarkdown(content);
@@ -96,6 +103,8 @@ export async function getStaticProps() {
 	return {
 		props: {
 			source,
+			title: (data?.title || null) as string | null,
+			description: (data?.description || null) as string | null,
 			templateLinks,
 		},
 	};

--- a/docs/pages/templates/index.tsx
+++ b/docs/pages/templates/index.tsx
@@ -25,7 +25,7 @@ export default function TemplatesPage({
 }: StaticProps) {
 	return (
 		<>
-			<DocumentTitle title="Templates" />
+			<DocumentTitle title="Templates" description={description} />
 			<AppLayout>
 				<PageLayout
 					sideNav={{

--- a/docs/pages/tokens/index.tsx
+++ b/docs/pages/tokens/index.tsx
@@ -5,13 +5,16 @@ import { H3 } from '@ag.ds-next/heading';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { TokenLayout, navLinks } from '../../components/TokenLayout';
 
+const description =
+	'Our Design Tokens are the foundation of our design system. They are the building blocks of our components and are used to create a consistent look and feel across all of our products.';
+
 export default function TokensPage() {
 	return (
 		<>
 			<DocumentTitle title="Tokens" />
 			<TokenLayout
 				title="Design Tokens"
-				description="Our Design Tokens are the foundation of our design system. They are the building blocks of our components and are used to create a consistent look and feel across all of our products."
+				description={description}
 				editPath="/docs/pages/tokens/index.tsx"
 			>
 				<Columns as="ul" cols={{ xs: 1, sm: 2 }}>

--- a/docs/pages/tokens/typography.tsx
+++ b/docs/pages/tokens/typography.tsx
@@ -93,7 +93,7 @@ function FontSizeTable() {
 	);
 }
 
-export function FontWeightTable() {
+function FontWeightTable() {
 	return (
 		<div className={proseBlockClassname}>
 			<TableWrapper>

--- a/docs/pages/updates/[slug].tsx
+++ b/docs/pages/updates/[slug].tsx
@@ -21,7 +21,7 @@ export default function Updates({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={update.data.title} />
+			<DocumentTitle title={update.title} description={update.description} />
 			<AppLayout>
 				<PageLayout
 					sideNav={{
@@ -32,10 +32,7 @@ export default function Updates({
 					editPath={`/docs/content/updates/${update.slug}.mdx`}
 					breadcrumbs={breadcrumbs}
 				>
-					<PageTitle
-						title={update.data.title}
-						introduction={update.data.description}
-					/>
+					<PageTitle title={update.title} introduction={update.description} />
 					<Prose>
 						<MDXRemote {...update.source} components={mdxComponents} />
 					</Prose>

--- a/docs/pages/updates/index.tsx
+++ b/docs/pages/updates/index.tsx
@@ -23,7 +23,7 @@ export default function UpdatesHome({
 }: StaticProps) {
 	return (
 		<>
-			<DocumentTitle title="Updates" />
+			<DocumentTitle title="Updates" description={description} />
 			<AppLayout>
 				<PageLayout
 					sideNav={{

--- a/docs/pages/updates/index.tsx
+++ b/docs/pages/updates/index.tsx
@@ -11,10 +11,16 @@ import { mdxComponents } from '../../components/mdxComponents';
 import { AppLayout } from '../../components/AppLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { PageLayout } from '../../components/PageLayout';
+import { PageTitle } from '../../components/PageTitle';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
-export default function UpdatesHome({ source, updateLinks }: StaticProps) {
+export default function UpdatesHome({
+	title,
+	description,
+	source,
+	updateLinks,
+}: StaticProps) {
 	return (
 		<>
 			<DocumentTitle title="Updates" />
@@ -27,6 +33,7 @@ export default function UpdatesHome({ source, updateLinks }: StaticProps) {
 					}}
 					editPath="/docs/content/updates/index.mdx"
 				>
+					<PageTitle title={title} introduction={description} />
 					<Prose>
 						<MDXRemote {...source} components={mdxComponents} />
 					</Prose>
@@ -51,7 +58,7 @@ export default function UpdatesHome({ source, updateLinks }: StaticProps) {
 }
 
 export async function getStaticProps() {
-	const { content } = await getMarkdownData(
+	const { content, data } = await getMarkdownData(
 		normalize(`${UPDATE_PATH}/index.mdx`)
 	);
 	const source = await serializeMarkdown(content);
@@ -64,6 +71,8 @@ export async function getStaticProps() {
 
 	return {
 		props: {
+			title: (data?.title || null) as string | null,
+			description: (data?.description || null) as string | null,
 			source,
 			updateLinks,
 		},

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,3 +1,0 @@
-# Components
-
-Discover all the Agriculture Design System components here including visual examples, props, and code examples. In future we will include findings we’ve collected from performing user research as well as documentation to help teams adopt the design system for their projects.

--- a/packages/page-alert/src/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/page-alert/src/__snapshots__/PageAlert.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
         There is a problem
       </h3>
       <div
-        class="css-1llvgqx-boxStyles-proseClass"
+        class="css-uuawlj-boxStyles-proseClass"
       >
         <ul>
           <li>

--- a/packages/page-alert/src/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/page-alert/src/__snapshots__/PageAlert.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
         There is a problem
       </h3>
       <div
-        class="css-uuawlj-boxStyles-proseClass"
+        class="css-hl6z5f-boxStyles-proseClass"
       >
         <ul>
           <li>

--- a/packages/prose/src/Prose.tsx
+++ b/packages/prose/src/Prose.tsx
@@ -38,7 +38,8 @@ export const proseClass = css({
 		...fontGrid('sm', 'default'),
 	},
 
-	'&:empty': {
+	/** Hide the container when there is no content. */
+	[`&:not(.${unsetProseStylesClassname}:empty)`]: {
 		display: 'none',
 	},
 

--- a/packages/prose/src/Prose.tsx
+++ b/packages/prose/src/Prose.tsx
@@ -39,7 +39,7 @@ export const proseClass = css({
 	},
 
 	/** Hide the container when there is no content. */
-	[`&:not(.${unsetProseStylesClassname}:empty)`]: {
+	[`&:empty:not(.${unsetProseStylesClassname})`]: {
 		display: 'none',
 	},
 

--- a/packages/prose/src/Prose.tsx
+++ b/packages/prose/src/Prose.tsx
@@ -38,6 +38,10 @@ export const proseClass = css({
 		...fontGrid('sm', 'default'),
 	},
 
+	'&:empty': {
+		display: 'none',
+	},
+
 	/**
 	 * Prose block
 	 */


### PR DESCRIPTION
## Describe your changes

Adjusts the descriptions for each index page (e.g. `/components`, `/guides` etc). Also uses these descriptions as the meta description to improve SEO.