### PR TITLE
task-list: Use visuallyHidden to add fullstop

### DIFF
--- a/packages/task-list/package.json
+++ b/packages/task-list/package.json
@@ -8,6 +8,7 @@
 		"@babel/runtime": "^7.4.5"
 	},
 	"devDependencies": {
+		"@ag.ds-next/a11y": "*",
 		"@ag.ds-next/box": "*",
 		"@ag.ds-next/button": "*",
 		"@ag.ds-next/core": "*",
@@ -19,6 +20,7 @@
 		"react": "18.1.0"
 	},
 	"peerDependencies": {
+		"@ag.ds-next/a11y": "^1.2.2",
 		"@ag.ds-next/box": "8.0.0",
 		"@ag.ds-next/button": "12.0.0",
 		"@ag.ds-next/core": "4.1.0",

--- a/packages/task-list/src/TaskList.test.tsx
+++ b/packages/task-list/src/TaskList.test.tsx
@@ -38,7 +38,6 @@ describe('TaskList', () => {
 				extends: ['html-validate:recommended'],
 				rules: {
 					'no-inline-style': 'off',
-					'aria-label-misuse': 'off',
 					// react 18s `useId` break this rule
 					'valid-id': 'off',
 				},
@@ -81,7 +80,6 @@ describe('TaskList', () => {
 				extends: ['html-validate:recommended'],
 				rules: {
 					'no-inline-style': 'off',
-					'aria-label-misuse': 'off',
 					// react 18s `useId` break this rule
 					'valid-id': 'off',
 				},

--- a/packages/task-list/src/TaskListItem.tsx
+++ b/packages/task-list/src/TaskListItem.tsx
@@ -11,6 +11,7 @@ import {
 } from '@ag.ds-next/icon';
 import { boxPalette, LinkProps, mq, packs, tokens } from '@ag.ds-next/core';
 import { BaseButton } from '@ag.ds-next/button';
+import { VisuallyHidden } from '@ag.ds-next/a11y';
 
 export type TaskListItemStatus = keyof typeof statusMap;
 
@@ -150,10 +151,10 @@ const TaskListItem = ({
 									},
 								}),
 							}}
-							aria-label={`${children}.`}
 						>
 							{ordered && <span aria-hidden="true">. </span>}
 							{children}
+							<VisuallyHidden>.</VisuallyHidden>
 						</Text>
 						<Flex as="span" gap={0.25} alignItems="center" css={{ order: 1 }}>
 							<Icon
@@ -163,13 +164,9 @@ const TaskListItem = ({
 									display: ['block', 'none'],
 								})}
 							/>
-							<Text
-								as="span"
-								fontSize={['xs', 'sm']}
-								lineHeight="nospace"
-								aria-label={`${label}.`}
-							>
+							<Text as="span" fontSize={['xs', 'sm']} lineHeight="nospace">
 								{label}
+								<VisuallyHidden>.</VisuallyHidden>
 							</Text>
 						</Flex>
 						<Text color="muted" fontSize="sm" css={{ order: 3 }}>

--- a/packages/task-list/src/__snapshots__/TaskList.test.tsx.snap
+++ b/packages/task-list/src/__snapshots__/TaskList.test.tsx.snap
@@ -62,11 +62,15 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Check eligibility."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Check eligibility
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -91,10 +95,14 @@ exports[`TaskList With anchors renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="Completed."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   Completed
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -159,11 +167,15 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Lorem ipsum dolor sit amet."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Lorem ipsum dolor sit amet
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -188,10 +200,14 @@ exports[`TaskList With anchors renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="Completed."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   Completed
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -269,11 +285,15 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Case Studies."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Case Studies
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -311,10 +331,14 @@ exports[`TaskList With anchors renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="In progress."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   In progress
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -379,11 +403,15 @@ exports[`TaskList With anchors renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Review and submit."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Review and submit
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -408,10 +436,14 @@ exports[`TaskList With anchors renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="Not started."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   Not started
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -508,11 +540,15 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Check eligibility."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Check eligibility
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -537,10 +573,14 @@ exports[`TaskList With buttons renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="Completed."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   Completed
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -605,11 +645,15 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Lorem ipsum dolor sit amet."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Lorem ipsum dolor sit amet
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -634,10 +678,14 @@ exports[`TaskList With buttons renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="Completed."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   Completed
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -715,11 +763,15 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Case Studies."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Case Studies
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -757,10 +809,14 @@ exports[`TaskList With buttons renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="In progress."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   In progress
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span
@@ -825,11 +881,15 @@ exports[`TaskList With buttons renders correctly 1`] = `
               class="css-1wcx0lf-boxStyles"
             >
               <span
-                aria-label="Review and submit."
                 class="css-3sibcn-boxStyles-Text-TaskListItem"
                 data-agds-task-list-item-text=""
               >
                 Review and submit
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  .
+                </span>
               </span>
               <span
                 class="css-1heyt4z-boxStyles-TaskListItem"
@@ -854,10 +914,14 @@ exports[`TaskList With buttons renders correctly 1`] = `
                   />
                 </svg>
                 <span
-                  aria-label="Not started."
                   class="css-1b077g7-boxStyles-Text"
                 >
                   Not started
+                  <span
+                    class="css-avudkd-VisuallyHidden"
+                  >
+                    .
+                  </span>
                 </span>
               </span>
               <span


### PR DESCRIPTION
## Describe your changes

Use visuallyHidden to add a full stop after the spans in TaskListItem, rather than an aria-label on the span

## Checklist

- [ ] Read and check your code before tagging someone for review.
- [ ] Run `yarn format`
- [ ] Run `yarn lint` in the root of the repository to ensure tests are passing
- [ ] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook