### PR TITLE
search-box: remove autocomplete

### DIFF
--- a/.changeset/gorgeous-rules-cry.md
+++ b/.changeset/gorgeous-rules-cry.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/search-box': patch
+---
+
+Removed browser autocomplete from the search box input component.

--- a/packages/search-box/src/SearchBoxInput.tsx
+++ b/packages/search-box/src/SearchBoxInput.tsx
@@ -33,7 +33,14 @@ export const SearchBoxInput = forwardRef<HTMLInputElement, SearchBoxInputProps>(
 				<SearchBoxLabel htmlFor={inputId} visible={labelVisible}>
 					{label}
 				</SearchBoxLabel>
-				<input ref={ref} type="search" css={styles} id={inputId} {...props} />
+				<input
+					ref={ref}
+					type="search"
+					autoComplete="off"
+					css={styles}
+					id={inputId}
+					{...props}
+				/>
 			</Stack>
 		);
 	}

--- a/packages/search-box/src/__snapshots__/Search.test.tsx.snap
+++ b/packages/search-box/src/__snapshots__/Search.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`SearchBox renders correctly 1`] = `
           Search
         </label>
         <input
+          autocomplete="off"
           class="css-q8ysto-SearchBoxInput"
           id="search-:r0:"
           type="search"


### PR DESCRIPTION
## Describe your changes

Removed browser autocomplete from the search box input component.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook