### PR TITLE
docs: fix storybook global types

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -65,19 +65,17 @@ export const globalTypes = {
 		description: 'Global branding',
 		defaultValue: 'agriculture',
 		toolbar: {
+			title: 'Brand',
 			icon: 'circlehollow',
-			// Array of plain string values or MenuItem shape (see below)
 			items: Object.keys(storybookThemes),
-			// Property that specifies if the name of the item will be displayed
-			showName: true,
 		},
 	},
 	palette: {
 		name: 'Palette',
 		defaultValue: 'light',
 		toolbar: {
+			title: 'Palette',
 			items: ['light', 'dark'],
-			showName: true,
 		},
 	},
 };


### PR DESCRIPTION
## Describe your changes

Fixes the following warning from storybook

```
715.manager.bundle.js:10292 `showName` is deprecated as `name` will stop having dual purposes in the future. Please specify a `title` in `globalTypes` instead.
```