### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/content/updates/2022-01-07.mdx
+++ b/docs/content/updates/2022-01-07.mdx
@@ -29,4 +29,4 @@ Changes to improve usability of primitive components and to better enable using 
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-01-07), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/29) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-07), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/29) for this release.

--- a/docs/content/updates/2022-01-24.mdx
+++ b/docs/content/updates/2022-01-24.mdx
@@ -32,4 +32,4 @@ Add new components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-01-24), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/50) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-01-24), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/29) in the related PR (https://github.com/steelthreads/agds-next/pull/50) for this release.

--- a/docs/content/updates/2022-02-08.mdx
+++ b/docs/content/updates/2022-02-08.mdx
@@ -35,4 +35,4 @@ Add New components!
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-02-08), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/55) in the related PR (https://github.com/steelthreads/agds-next/pull/55) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-08), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/55) in the related PR (https://github.com/steelthreads/agds-next/pull/55) for this release.

--- a/docs/content/updates/2022-02-23.mdx
+++ b/docs/content/updates/2022-02-23.mdx
@@ -47,4 +47,4 @@ In this release, we have focused on adding new form and interactive components i
 
 ## Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-02-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/112) in the related PR (https://github.com/steelthreads/agds-next/pull/112) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-02-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/112) in the related PR (https://github.com/steelthreads/agds-next/pull/112) for this release.

--- a/docs/content/updates/2022-03-02.mdx
+++ b/docs/content/updates/2022-03-02.mdx
@@ -26,7 +26,7 @@ In this release we have focused on delivering improvements for existing componen
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-03-02), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/153) in the related PR (https://github.com/steelthreads/agds-next/pull/153) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-02), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/153) in the related PR (https://github.com/steelthreads/agds-next/pull/153) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-03.mdx
+++ b/docs/content/updates/2022-03-03.mdx
@@ -18,7 +18,7 @@ description: Add InPage Nav. Bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-03-03), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/178) in the related PR (https://github.com/steelthreads/agds-next/pull/178) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-03), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/178) in the related PR (https://github.com/steelthreads/agds-next/pull/178) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-16.mdx
+++ b/docs/content/updates/2022-03-16.mdx
@@ -100,7 +100,7 @@ description: Updated Icon API, new components, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-03-16), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/190) in the related PR (https://github.com/steelthreads/agds-next/pull/190) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-16), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/190) in the related PR (https://github.com/steelthreads/agds-next/pull/190) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-03-23.mdx
+++ b/docs/content/updates/2022-03-23.mdx
@@ -89,7 +89,7 @@ description: Added PageAlert, new tone colours, bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-03-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/229) in the related PR (https://github.com/steelthreads/agds-next/pull/229) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-03-23), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/229) in the related PR (https://github.com/steelthreads/agds-next/pull/229) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-04-01.mdx
+++ b/docs/content/updates/2022-04-01.mdx
@@ -62,7 +62,7 @@ description: Add DatePicker, Modal and Table. Various bug fixes and improvements
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-04-01), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/260) in the related PR (https://github.com/steelthreads/agds-next/pull/260) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-01), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/260) in the related PR (https://github.com/steelthreads/agds-next/pull/260) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-04-28.mdx
+++ b/docs/content/updates/2022-04-28.mdx
@@ -111,7 +111,7 @@ description: Add HeroBanner and Loading. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/279) in the related PR (https://github.com/steelthreads/agds-next/pull/279) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/279) in the related PR (https://github.com/steelthreads/agds-next/pull/279) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-05-16.mdx
+++ b/docs/content/updates/2022-05-16.mdx
@@ -102,7 +102,7 @@ description: Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/319) in the related PR (https://github.com/steelthreads/agds-next/pull/319) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-04-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/319) in the related PR (https://github.com/steelthreads/agds-next/pull/319) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-05-30.mdx
+++ b/docs/content/updates/2022-05-30.mdx
@@ -106,7 +106,7 @@ description: Add ButtonGroup component. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-05-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/346) in the related PR (https://github.com/steelthreads/agds-next/pull/346) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-05-30), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/346) in the related PR (https://github.com/steelthreads/agds-next/pull/346) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-06-15.mdx
+++ b/docs/content/updates/2022-06-15.mdx
@@ -106,7 +106,7 @@ description: Added support for React 18. Various bug fixes and improvements.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-06-15), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/399) in the related PR (https://github.com/steelthreads/agds-next/pull/399) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-15), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/399) in the related PR (https://github.com/steelthreads/agds-next/pull/399) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-06-28.mdx
+++ b/docs/content/updates/2022-06-28.mdx
@@ -55,7 +55,7 @@ description: New branding for Department of Agriculture, Fisheries and Forestry.
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-06-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/466) in the related PR (https://github.com/steelthreads/agds-next/pull/466) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-06-28), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/466) in the related PR (https://github.com/steelthreads/agds-next/pull/466) for this release.
 
 ## Released packages
 

--- a/docs/content/updates/2022-07-27.mdx
+++ b/docs/content/updates/2022-07-27.mdx
@@ -301,7 +301,7 @@ In this release, we rethought our `<Columns />` component, improved many of our 
 
 ## Full Changelog
 
-Aside from the [complete release notes on the @ag.ds-next website](/https://design-system.agriculture.gov.au/updates/2022-07-27), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/499) in the related PR (https://github.com/steelthreads/agds-next/pull/499) for this release.
+Aside from the [complete release notes on the @ag.ds-next website](https://design-system.agriculture.gov.au/updates/2022-07-27), you can also view the [verbose change log](https://github.com/steelthreads/agds-next/pull/499) in the related PR (https://github.com/steelthreads/agds-next/pull/499) for this release.
 
 ## Released packages
 


### PR DESCRIPTION
## Describe your changes

Removed the first `/` from some links that start with `https://`. This was a mistake which probably happened when we moved domains and updated some content with find & replace.

```diff
- /https://design-system.agriculture.gov.au/...
+ https://design-system.agriculture.gov.au/...
```