### PR TITLE
date-picker: Fix calendar tests

### DIFF
--- a/packages/date-picker/src/Calendar.test.tsx
+++ b/packages/date-picker/src/Calendar.test.tsx
@@ -14,19 +14,32 @@ function renderCalendarSingle(props: CalendarSingleProps) {
 	return render(<CalendarSingle {...props} />);
 }
 
+const dateRange = {
+	from: new Date(2022, 5, 1),
+	to: new Date(2022, 5, 7),
+};
+
 describe('Calendar Single', () => {
 	it('renders correctly', () => {
 		const { container } = renderCalendarSingle({
-			defaultMonth: new Date(2022, 5, 1),
-			selected: new Date(2022, 5, 1),
+			defaultMonth: dateRange.from,
+			selected: dateRange.from,
+			yearRange: {
+				from: dateRange.from.getFullYear() - 10,
+				to: dateRange.from.getFullYear() + 10,
+			},
 		});
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
 		const { container } = renderCalendarSingle({
-			defaultMonth: new Date(2022, 5, 1),
-			selected: new Date(2022, 5, 1),
+			defaultMonth: dateRange.from,
+			selected: dateRange.from,
+			yearRange: {
+				from: dateRange.from.getFullYear() - 10,
+				to: dateRange.from.getFullYear() + 10,
+			},
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
@@ -46,16 +59,24 @@ function renderCalendarRange(props: CalendarRangeProps) {
 describe('Calendar Range', () => {
 	it('renders correctly', () => {
 		const { container } = renderCalendarRange({
-			defaultMonth: new Date(2022, 5, 1),
-			selected: { from: new Date(2022, 5, 1), to: new Date(2022, 5, 7) },
+			defaultMonth: dateRange.from,
+			selected: dateRange,
+			yearRange: {
+				from: dateRange.from.getFullYear() - 10,
+				to: dateRange.from.getFullYear() + 10,
+			},
 		});
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders a valid HTML structure', () => {
 		const { container } = renderCalendarRange({
-			defaultMonth: new Date(2022, 5, 1),
-			selected: { from: new Date(2022, 5, 1), to: new Date(2022, 5, 7) },
+			defaultMonth: dateRange.from,
+			selected: dateRange,
+			yearRange: {
+				from: dateRange.from.getFullYear() - 10,
+				to: dateRange.from.getFullYear() + 10,
+			},
 		});
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],


### PR DESCRIPTION
## Describe your changes

These tests were causing failures as the year range in the calendar component is dynamically generated. To fix this, we have set an explicit date range using a fixed date.

Note: Snapshots do not need to be generated again as the tests update yield the same output.