### PR TITLE
Upgraded browserslist

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5668,15 +5668,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001286:
-  version "1.0.30001346"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001346.tgz#e895551b46b9cc9cc9de852facd42f04839a8fbe"
-  integrity sha512-q6ibZUO2t88QCIPayP/euuDREq+aMAxFE5S70PkrLh0iTDj/zEhgvJRKC2+CvXY6EWc6oQwUR48lL5vCW6jiXQ==
-
-caniuse-lite@^1.0.30001406:
-  version "1.0.30001439"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz#ab7371faeb4adff4b74dad1718a6fd122e45d9cb"
-  integrity sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==
+caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001406:
+  version "1.0.30001441"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz"
+  integrity sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Describe your changes

Currently when you are running tests you see the following warning:

```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
```

After running this command, our dependency on `caniuse-lite` has been updated which results in the following target browser changes:

```diff
- and_chr 101
+ and_chr 108
- and_ff 100
+ and_ff 107
- and_qq 10.4
+ and_qq 13.1
- and_uc 12.12
+ and_uc 13.4
- android 101
+ android 108
- baidu 7.12
+ baidu 13.18
- chrome 101
- chrome 100
- chrome 99
+ chrome 108
+ chrome 107
+ chrome 106
- edge 101
- edge 100
- edge 99
+ edge 108
+ edge 107
- firefox 101
- firefox 100
- firefox 99
- firefox 98
+ firefox 107
+ firefox 106
- ios_saf 15.4
- ios_saf 15.2-15.3
- ios_saf 15.0-15.1
- ios_saf 14.0-14.4
- ios_saf 12.2-12.5
+ ios_saf 16.2
+ ios_saf 16.1
+ ios_saf 16.0
+ ios_saf 15.6
+ ios_saf 15.5
- op_mob 64
+ op_mob 72
- opera 86
- opera 85
+ opera 92
+ opera 91
- safari 15.5
- safari 15.4
- safari 14.1
+ safari 16.2
+ safari 16.1
+ safari 15.6
- samsung 16.0
- samsung 15.0
+ samsung 19.0
+ samsung 18.0
```