### PR TITLE
docs: Update component names to sentence case

### DIFF
--- a/.storybook/stories/CardsWithRemoteData.tsx
+++ b/.storybook/stories/CardsWithRemoteData.tsx
@@ -11,7 +11,7 @@ import { Heading } from '@ag.ds-next/react/heading';
 import { VisuallyHidden } from '@ag.ds-next/react/a11y';
 
 export default {
-	title: 'Examples/RemoteData',
+	title: 'Examples/Remote data',
 };
 
 const fetcher = async (url: string) => {

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -61,7 +61,7 @@ import { TextLink } from '@ag.ds-next/react/text-link';
 import { AvatarIcon } from '@ag.ds-next/react/icon';
 
 export default {
-	title: 'Examples/Kitchen Sink',
+	title: 'Examples/Kitchen sink',
 };
 
 const sideNavItems = [
@@ -224,7 +224,7 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 									{ href: '#section-5', label: 'Section 5' },
 								]}
 							/>
-							<H1>Kitchen Sink</H1>
+							<H1>Kitchen sink</H1>
 							<Text>
 								Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 								Pellentesque at arcu eleifend, varius enim non, eleifend nibh.

--- a/.storybook/stories/TableWithRemoteData.tsx
+++ b/.storybook/stories/TableWithRemoteData.tsx
@@ -17,7 +17,7 @@ import { PageContent } from '@ag.ds-next/react/content';
 import { VisuallyHidden } from '@ag.ds-next/react/a11y';
 
 export default {
-	title: 'Examples/RemoteData',
+	title: 'Examples/Remote data',
 };
 
 const fetcher = async (url: string) => {

--- a/packages/react/src/ag-branding/Logo.stories.tsx
+++ b/packages/react/src/ag-branding/Logo.stories.tsx
@@ -3,7 +3,7 @@ import { Box } from '../box';
 import { Logo as AgLogo } from './Logo';
 
 export default {
-	title: 'Brand/AG Branding',
+	title: 'Brand/AGBranding',
 	component: AgLogo,
 } as ComponentMeta<typeof AgLogo>;
 

--- a/packages/react/src/ag-branding/docs/overview.mdx
+++ b/packages/react/src/ag-branding/docs/overview.mdx
@@ -1,8 +1,8 @@
 ---
-title: AG Branding
+title: AG branding
 description: A colour palette and logo set for Agriculture
 group: Brand
-storybookPath: /story/brand-ag-branding--logo
+storybookPath: /story/brand-agbranding--logo
 ---
 
 ## Agriculture theme

--- a/packages/react/src/call-to-action/docs/overview.mdx
+++ b/packages/react/src/call-to-action/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Call To Action
+title: Call to action
 description: Call to action links are interactive UI cues that direct users to other pages.
 group: Navigation
 storybookPath: /story/navigation-calltoaction--basic

--- a/packages/react/src/control-input/docs/overview.mdx
+++ b/packages/react/src/control-input/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Control Input
+title: Control input
 description: Control inputs helps users select one or more options from a list. Our control inputs consist of checkboxes and radio buttons.
 group: Forms
 storybookPath: /story/forms-checkbox--basic

--- a/packages/react/src/date-picker/docs/overview.mdx
+++ b/packages/react/src/date-picker/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Date Picker
+title: Date picker
 description: Date picker allows users to select a single date or range of dates. There are 3 types; date select range, simple date input and date select.
 group: forms
 storybookPath: /story/forms-datepicker-datepicker--basic
@@ -21,7 +21,7 @@ figmaGalleryNodeId: 12444%3A100327
 - use Date Select for historical dates such as birthdates – use Date Input
 - hijack built-in keyboard navigation behaviour.
 
-## Date Picker
+## Date picker
 
 ```jsx live
 () => {
@@ -130,7 +130,7 @@ The `yearRange` property can be used to change the range of options to display i
 };
 ```
 
-## Date Range Picker
+## Date range picker
 
 `DateRangePicker` is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components).
 

--- a/packages/react/src/direction-link/docs/overview.mdx
+++ b/packages/react/src/direction-link/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Direction Link
+title: Direction link
 description: Direction links are accompanied by arrows to help users move to other parts of a page or process.
 group: Navigation
 storybookPath: /story/navigation-directionlink--basic
@@ -33,7 +33,7 @@ figmaGalleryNodeId: 11978%3A107081
 
 - use a link in place of a button.
 
-### DirectionButton
+### Direction button
 
 The `DirectionLink` component will render a HTML anchor tag. We strongly recommend using this wherever possible as it is the most inclusive and accessible solution for users.
 

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: File Upload
+title: File upload
 description: This component allows users to select files to upload via drag-and-drop or browsing their device.
 group: Forms
 storybookPath: /story/forms-fileupload--basic

--- a/packages/react/src/form-stack/docs/overview.mdx
+++ b/packages/react/src/form-stack/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
-title: Form Stack
-description: Use to FormStack component to apply consistent spacing between form elements.
+title: Form stack
+description: Use the FormStack component to apply consistent spacing between form elements.
 group: Forms
 ---
 

--- a/packages/react/src/global-alert/docs/overview.mdx
+++ b/packages/react/src/global-alert/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Global Alert
+title: Global alert
 description: Global Alerts show pressing and high-signal messages, such as system alerts.
 group: Content
 storybookPath: /story/content-globalalert--basic

--- a/packages/react/src/hero-banner/docs/overview.mdx
+++ b/packages/react/src/hero-banner/docs/overview.mdx
@@ -1,12 +1,12 @@
 ---
-title: Hero Banner
+title: Hero banner
 description: The hero banner sits at the top of the page under the Main nav and is used to grab a user’s attention.
 group: Layout
 storybookPath: /story/layout-herobanner-herobanner--basic
 figmaGalleryNodeId: 11978%3A104544
 ---
 
-## Hero Banner
+## Hero banner
 
 ```jsx live
 <HeroBanner
@@ -48,7 +48,7 @@ Use the `HeroBanner` components on home or landing pages.
 
 Images in this component are automatically resized to fit their container using the [`object-fit`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) CSS property. Because of this it is important to use image at an appropriate image ratio. You can reference the image size and ratio of our [example image](/img/placeholder/hero-banner.jpeg).
 
-## Hero Category Banner
+## Hero category banner
 
 Use the `HeroCategoryBanner` components for top level category pages.
 
@@ -67,7 +67,7 @@ Use the `HeroCategoryBanner` components for top level category pages.
 </HeroCategoryBanner>
 ```
 
-## Hero Subcategory Banner
+## Hero subcategory banner
 
 Use the `HeroSubcategoryBanner` components pages within a category.
 

--- a/packages/react/src/inpage-nav/docs/overview.mdx
+++ b/packages/react/src/inpage-nav/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Inpage Nav
+title: Inpage nav
 description: Also known as Page contents, Inpage nav links help users scan page contents and quickly navigate to different sections.
 group: Navigation
 storybookPath: /story/navigation-inpagenav--basic

--- a/packages/react/src/link-list/docs/overview.mdx
+++ b/packages/react/src/link-list/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Link List
+title: Link list
 description: Link list is a simple set of vertical or horizontal links used for site navigation and to order information for users.
 group: Navigation
 storybookPath: /story/navigation-linklist--basic

--- a/packages/react/src/main-nav/docs/overview.mdx
+++ b/packages/react/src/main-nav/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Main Nav
+title: Main nav
 description: The main nav is the primary way users navigate the UI. It is consistently visible throughout the service.
 group: Navigation
 storybookPath: /story/navigation-mainnav--body

--- a/packages/react/src/page-alert/PageAlert.stories.tsx
+++ b/packages/react/src/page-alert/PageAlert.stories.tsx
@@ -10,11 +10,11 @@ export default {
 
 export const Basic: ComponentStory<typeof PageAlert> = (args) => (
 	<PageAlert {...args}>
-		<Text as="p">This is a Page Alert component.</Text>
+		<Text as="p">This is a Page alert component.</Text>
 	</PageAlert>
 );
 Basic.args = {
-	title: 'Page Alert',
+	title: 'Page alert',
 	tone: 'success',
 };
 
@@ -33,6 +33,6 @@ export const WithProse: ComponentStory<typeof PageAlert> = (args) => (
 	</PageAlert>
 );
 WithProse.args = {
-	title: 'Page Alert',
+	title: 'Page alert',
 	tone: 'error',
 };

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Page Alert
+title: Page alert
 description: Page alerts are colour-coded, non-disruptive notifications that provide Success, Error, Warning or Information messages at relevant times during the user journey. They should not be confused with Callouts.
 group: Content
 storybookPath: /story/content-pagealert--basic

--- a/packages/react/src/progress-indicator/docs/overview.mdx
+++ b/packages/react/src/progress-indicator/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Progress Indicator
+title: Progress indicator
 description: Progress indicators show users the number of steps in a task, where they are up to in the process and how much is left to do.
 group: Forms
 storybookPath: /story/forms-progressindicator--basic
@@ -34,7 +34,7 @@ The background of the `ProgressIndicator` must match the background it is being 
 - use in forms and multi-page processes
 - use for processes of 2 – 10 steps
 - always present mobile menu Closed by default
-- pair with Task List if nesting is required
+- pair with Task list if nesting is required
 - ensure step names match H1s and truncate if long
 - keyword frontload
 - group related form fields.

--- a/packages/react/src/search-box/docs/overview.mdx
+++ b/packages/react/src/search-box/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search box
-description: Search input enables users to enter a word or phrase to find relevant content.
+description: An input that allows users to enter a keyword to search a website for specific content.
 group: Forms
 storybookPath: /story/forms-searchbox--basic
 figmaGalleryNodeId: 12444%3A100493

--- a/packages/react/src/search-box/docs/overview.mdx
+++ b/packages/react/src/search-box/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Search Box
+title: Search box
 description: Search input enables users to enter a word or phrase to find relevant content.
 group: Forms
 storybookPath: /story/forms-searchbox--basic

--- a/packages/react/src/search-input/docs/overview.mdx
+++ b/packages/react/src/search-input/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Search Input
+title: Search input
 description: Search input enables users to enter a word or phrase to find relevant content.
 group: Forms
 storybookPath: /story/forms-searchinput--basic

--- a/packages/react/src/side-nav/docs/overview.mdx
+++ b/packages/react/src/side-nav/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Side Nav
+title: Side nav
 description: A vertical list of links use for site navigation, typically placed next to body content.
 group: Navigation
 storybookPath: /story/navigation-sidenav--light-variant

--- a/packages/react/src/skip-link/docs/overview.mdx
+++ b/packages/react/src/skip-link/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Skip Link
+title: Skip link
 description: Skip links are internal page links that aid navigation around a page. They are detected by screen readers and help users quickly jump to and over content on the page.
 group: Navigation
 storybookPath: /story/navigation-skiplinks--basic

--- a/packages/react/src/sub-nav/docs/overview.mdx
+++ b/packages/react/src/sub-nav/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sub Nav
+title: Sub nav
 description: A horizontal list of links typically placed between the main navigation and page content.
 group: Navigation
 storybookPath: /story/navigation-subnav--basic
@@ -18,7 +18,7 @@ figmaGalleryNodeId: 11981%3A101155
 />
 ```
 
-The `SubNav` component is a horizontal list of links that can accommodate up to 5 items. It is best suited for navigation to persistent links, or to reveal additional content on the same page. The `SubNav` component sometimes accommodates the third level of the information architecture, following the [Side Nav](/components/side-nav) on a content page. If you need more space for longer lists, consider another form of navigation such as the [Side Nav](/components/side-nav), [Link List](/components/link-list), [Inpage Nav](/components/inpage-nav) or [Card lists](/components/card#card-lists).
+The `SubNav` component is a horizontal list of links that can accommodate up to 5 items. It is best suited for navigation to persistent links, or to reveal additional content on the same page. The `SubNav` component sometimes accommodates the third level of the information architecture, following the [Side nav](/components/side-nav) on a content page. If you need more space for longer lists, consider another form of navigation such as the [Side nav](/components/side-nav), [Link list](/components/link-list), [Inpage nav](/components/inpage-nav) or [Card lists](/components/card#card-lists).
 
 The `SubNav` component is designed to collapse down to a static vertical list on smaller devices. Progressive disclosure should not be used to enclose the SubNav on small screens.
 

--- a/packages/react/src/summary-list/docs/overview.mdx
+++ b/packages/react/src/summary-list/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Summary List
+title: Summary list
 description: Summary list is used to summarise information such as a user’s responses at the end of a form.
 group: Content
 storybookPath: /story/Content-SummaryList--basic

--- a/packages/react/src/task-list/docs/overview.mdx
+++ b/packages/react/src/task-list/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Task List
+title: Task list
 description: Task list is a navigation tool that show users what input is required to complete a task or transaction.
 group: Forms
 storybookPath: /story/forms-tasklist--unordered

--- a/packages/react/src/text-input/docs/overview.mdx
+++ b/packages/react/src/text-input/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Text Input
+title: Text input
 description: This component allows users to enter free-form text.
 group: Forms
 storybookPath: /story/forms-textinput--basic

--- a/packages/react/src/text-link/docs/overview.mdx
+++ b/packages/react/src/text-link/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Text Link
+title: Text link
 description: A typographic component for creating hyperlinks.
 group: Navigation
 storybookPath: /story/navigation-textlink--basic


### PR DESCRIPTION
## Describe your changes

This PR updates our component names on the documentation site from Title case (e.g. Page Alert) to sentence case (e.g. Page alert). This fixes an inconsistency in naming between our figma Gallery and documentation site.
