### PR TITLE
example-site: add privacy link to footer

### DIFF
--- a/example-site/components/SiteFooter.tsx
+++ b/example-site/components/SiteFooter.tsx
@@ -19,6 +19,10 @@ const footerLinks = [
 		label: 'Starter kit',
 		href: 'https://github.com/steelthreads/agds-starter-kit',
 	},
+	{
+		label: 'Privacy',
+		href: 'https://www.agriculture.gov.au/about/commitment/privacy',
+	},
 ];
 
 export const SiteFooter = () => {


### PR DESCRIPTION
## Describe your changes

Adds the privacy link to the example-site footer. This is a follow up to #919.