### PR TITLE
combobox: fix bugs when input is blurred

### DIFF
--- a/.changeset/dry-rules-bathe.md
+++ b/.changeset/dry-rules-bathe.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+combobox: fixed a bug where the input element became non-interactive after blur

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -45,7 +45,7 @@ export function Combobox<Option extends DefaultComboboxOption>(
 				case useCombobox.stateChangeTypes.InputBlur:
 					return {
 						...changes,
-						inputValue: state.selectedItem ? state.selectedItem.label : '',
+						inputValue: state.selectedItem?.label ?? '',
 					};
 				default:
 					return changes;

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -43,7 +43,10 @@ export function Combobox<Option extends DefaultComboboxOption>(
 			switch (actionAndChangesType) {
 				// Reset the input value when the menu is closed
 				case useCombobox.stateChangeTypes.InputBlur:
-					return { inputValue: state.selectedItem ? state.inputValue : '' };
+					return {
+						...changes,
+						inputValue: state.selectedItem ? state.selectedItem.label : '',
+					};
 				default:
 					return changes;
 			}

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -49,7 +49,10 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 			switch (actionAndChangesType) {
 				// Reset the input value when the menu is closed
 				case useCombobox.stateChangeTypes.InputBlur:
-					return { inputValue: state.selectedItem ? state.inputValue : '' };
+					return {
+						...changes,
+						inputValue: state.selectedItem ? state.selectedItem.label : '',
+					};
 				default:
 					return changes;
 			}

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -51,7 +51,7 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 				case useCombobox.stateChangeTypes.InputBlur:
 					return {
 						...changes,
-						inputValue: state.selectedItem ? state.selectedItem.label : '',
+						inputValue: state.selectedItem?.label ?? '',
 					};
 				default:
 					return changes;


### PR DESCRIPTION
## Describe your changes

fixed a bug where the input element became non-interactive after blur

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.