### PR TITLE
combobox: fix issue with async tests

### DIFF
--- a/.changeset/blue-masks-mix.md
+++ b/.changeset/blue-masks-mix.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+combobox: Fixed bug in `ComboboxAsync` where options would be loaded on initial render incorrectly.

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -81,6 +81,8 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 			state.networkError ||
 			// If a selection has just been made, no not need to load options again
 			(selectedItemLabel && selectedItemLabel === debouncedInputValue) ||
+			// When there is a dropdown trigger and dropdown is closed
+			(showDropdownTrigger && !downshift.isOpen) ||
 			// When there is no dropdown trigger (e.g. Autocomplete), only load the options if the user has interacted with the input
 			(!showDropdownTrigger && !isInputDirty.current)
 		) {

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -79,10 +79,10 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 			state.loading ||
 			// Options have failed to load
 			state.networkError ||
+			// Dropdown is closed
+			!downshift.isOpen ||
 			// If a selection has just been made, no not need to load options again
 			(selectedItemLabel && selectedItemLabel === debouncedInputValue) ||
-			// When there is a dropdown trigger and dropdown is closed
-			(showDropdownTrigger && !downshift.isOpen) ||
 			// When there is no dropdown trigger (e.g. Autocomplete), only load the options if the user has interacted with the input
 			(!showDropdownTrigger && !isInputDirty.current)
 		) {


### PR DESCRIPTION
## Describe your changes

Fixed bug in `ComboboxAsync` where options would be loaded on initial render incorrectly.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file