### PR TITLE
card: prevent link event from firing twice

### DIFF
--- a/.changeset/cold-baboons-add.md
+++ b/.changeset/cold-baboons-add.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+card: prevent link event from firing twice

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -38,8 +38,9 @@ export const Card = ({
 
 		const cardLinkEl = event.currentTarget.querySelector(
 			`[${cardLinkDataAttr}]`
-		) as HTMLAnchorElement | null | undefined;
-		if (!cardLinkEl) return;
+		);
+		if (!(cardLinkEl instanceof HTMLAnchorElement)) return;
+		if (cardLinkEl === event.target) return;
 
 		if (new Date().getTime() - mousedownTimer.current < 200) cardLinkEl.click();
 	};


### PR DESCRIPTION
## Describe your changes

Our `Card` component uses the technique from https://inclusive-components.design/cards/#theredundantclickevent for handling links. This PR fixes a bug with this technique where command clicking a link can cause the event to trigger twice.

To replicate the current issue:

1. Go to the home page
2. In the list of cards, click the text element that says 'Foundations' while holding the command key
3. The link should open in a new tab (which is expected), but the current tab should also change to the updated to the new url which is incorrect.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook