### PR TITLE
Searchbox: Revert styling change

### DIFF
--- a/packages/react/src/search-box/SearchBoxInput.tsx
+++ b/packages/react/src/search-box/SearchBoxInput.tsx
@@ -1,7 +1,7 @@
 import { InputHTMLAttributes, forwardRef } from 'react';
 import { textInputStyles } from '../text-input';
 import { Stack } from '../box';
-import { useId } from '../core';
+import { globalPalette, useId } from '../core';
 import { SearchBoxLabel } from './SearchBoxLabel';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -58,6 +58,8 @@ const inputStyles = () => {
 		borderRightWidth: 0,
 		borderTopRightRadius: 0,
 		borderBottomRightRadius: 0,
+		color: globalPalette.lightForegroundText,
+		background: globalPalette.lightBackgroundBody,
 
 		'&::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration':
 			{

--- a/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
+++ b/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`SearchBox renders correctly 1`] = `
         </label>
         <input
           autocomplete="off"
-          class="css-9f9xs6-SearchBoxInput"
+          class="css-q8ysto-SearchBoxInput"
           id="search-:r0:"
           type="search"
         />


### PR DESCRIPTION
## Describe your changes

In #925, we changed the background colours of all of our inputs to 'body' from transparent. I mistakingly applied this change to SearchBox, which is supposed to have a white background.

No need for a changeset

<img width="1441" alt="image" src="https://user-images.githubusercontent.com/12689383/214210563-145d07fb-9d1f-46d5-abed-beb3b290f863.png">


## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [ ] Add necessary tests
- [ ] Run `yarn changeset` to create a changeset file
- [ ] Write documentation (README.md)
- [ ] Create stories for Storybook
