### PR TITLE
card: revert back to pseudo-content trick

### DIFF
--- a/.changeset/calm-cycles-itch.md
+++ b/.changeset/calm-cycles-itch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+card: Revert back to pseudo-content trick for `CardLink`

--- a/packages/react/src/card/Card.tsx
+++ b/packages/react/src/card/Card.tsx
@@ -1,7 +1,6 @@
-import { PropsWithChildren, ElementType, useRef, MouseEvent } from 'react';
-import { Box, linkStyles } from '../box';
+import { PropsWithChildren, ElementType } from 'react';
+import { Box } from '../box';
 import { packs } from '../core';
-import { cardLinkDataAttr } from './CardLink';
 
 export type CardProps = PropsWithChildren<{
 	as?: ElementType;
@@ -25,31 +24,9 @@ export const Card = ({
 	shadow,
 	clickable,
 }: CardProps) => {
-	const mousedownTimer = useRef<number>();
-
-	const onMouseDown = () => {
-		mousedownTimer.current = new Date().getTime();
-	};
-
-	// This code ensures that when `CardLink` is used, the text within the card is selectable and the entire card is clickable
-	// Please read more about this technique here: https://inclusive-components.design/cards/#theredundantclickevent
-	const onMouseUp = (event: MouseEvent<HTMLDivElement>) => {
-		if (!clickable || !mousedownTimer.current) return;
-
-		const cardLinkEl = event.currentTarget.querySelector(
-			`[${cardLinkDataAttr}]`
-		);
-		if (!(cardLinkEl instanceof HTMLAnchorElement)) return;
-		if (cardLinkEl === event.target) return;
-
-		if (new Date().getTime() - mousedownTimer.current < 200) cardLinkEl.click();
-	};
-
 	return (
 		<Box
 			as={as} // Note: this should be an li when used in a card list
-			onMouseDown={onMouseDown}
-			onMouseUp={onMouseUp}
 			display="block"
 			border
 			borderColor="muted"
@@ -61,8 +38,6 @@ export const Card = ({
 				overflow: 'hidden',
 
 				...(clickable && {
-					cursor: 'pointer',
-					[`&:hover [${cardLinkDataAttr}]`]: linkStyles['&:hover'],
 					// If any element inside the card receives focus, add a focus ring around the wrapper card div
 					'&:focus-within': packs.outline,
 				}),

--- a/packages/react/src/card/CardLink.tsx
+++ b/packages/react/src/card/CardLink.tsx
@@ -3,8 +3,6 @@ import { linkStyles } from '../box';
 
 export type CardLinkProps = LinkProps;
 
-export const cardLinkDataAttr = 'data-agds-card-link';
-
 export const CardLink = (props: CardLinkProps) => {
 	const Link = useLinkComponent();
 	return (
@@ -18,10 +16,19 @@ export const CardLink = (props: CardLinkProps) => {
 					'&:focus': {
 						outline: 'none',
 					},
+					'&:after': {
+						content: '""',
+						position: 'absolute',
+						top: 0,
+						right: 0,
+						bottom: 0,
+						left: 0,
+					},
 				},
 			]}
-			{...{ [cardLinkDataAttr]: '' }}
 			{...props}
 		/>
 	);
 };
+
+//

--- a/packages/react/src/card/CardLink.tsx
+++ b/packages/react/src/card/CardLink.tsx
@@ -30,5 +30,3 @@ export const CardLink = (props: CardLinkProps) => {
 		/>
 	);
 };
-
-//

--- a/packages/react/src/card/__snapshots__/Card.test.tsx.snap
+++ b/packages/react/src/card/__snapshots__/Card.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Card Basic renders correctly 1`] = `
 exports[`Card With link renders correctly 1`] = `
 <div>
   <div
-    class="css-bfsv4q-boxStyles-Card"
+    class="css-a5w7y4-boxStyles-Card"
   >
     <div
       class="css-z5u98n-boxStyles"
@@ -49,8 +49,7 @@ exports[`Card With link renders correctly 1`] = `
           Lorem ipsum dolor, sit amet consectetur adipisicing elit. In, voluptat
         </p>
         <a
-          class="css-1ytze9p-CardLink"
-          data-agds-card-link=""
+          class="css-n0hvbj-CardLink"
           href="#"
         >
           Linking out


### PR DESCRIPTION
## Describe your changes

This PR reverts #689.

The reason for this is that we found an issue in the [redundant click event pattern](https://inclusive-components.design/cards/#theredundantclickevent). If the user is holding down the `meta` key, links will sometimes not open in a new tab - depending on where the user clicks within the `Card`. We have been in touch with Heydon Pickering to alert them of this bug.

We believe that the pseudo-content trick is a much more accessible solution for AgDS. While it does not allow the user to select text, this technique requires no javascript and users can open links in a new tabs.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook