### PR TITLE
file-input: add figma gallery link

### DIFF
--- a/packages/react/src/file-input/docs/overview.mdx
+++ b/packages/react/src/file-input/docs/overview.mdx
@@ -3,6 +3,7 @@ title: File input
 description: Allows a user to attach a file to a form.
 group: Forms
 storybookPath: /story/Forms-FileInput--basic
+figmaGalleryNodeId: 16180%3A41550
 ---
 
 A simple input for selecting files in a form. The `FileInput` component is a wrapper around the native `<input type="file" />` element. Use when you require multiple files in a form, which must be associated as seperate fields. If you only require a single file, use the [FileUpload](/components/file-upload) component instead.


### PR DESCRIPTION
## Describe your changes

This PR adds a link from the `FileInput` component to the figma gallery.