### PR TITLE
date-picker: fix inputs not updating when value changes

### DIFF
--- a/.changeset/odd-boxes-complain.md
+++ b/.changeset/odd-boxes-complain.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+date-picker: Fixed bug where the text input component was not being updated correctly when the `value` prop changed.

--- a/packages/react/src/date-picker/DatePicker.test.tsx
+++ b/packages/react/src/date-picker/DatePicker.test.tsx
@@ -1,12 +1,28 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { cleanup, render } from '../../../../test-utils';
+import { useState } from 'react';
+import userEvent from '@testing-library/user-event';
+import { cleanup, render, screen } from '../../../../test-utils';
+import { Stack } from '../box';
+import { Button } from '../button';
 import { DatePicker, DatePickerProps } from './DatePicker';
 
 afterEach(cleanup);
 
 function renderDatePicker(props: DatePickerProps) {
 	return render(<DatePicker {...props} />);
+}
+
+function ControlledDatePicker({ initialValue }: { initialValue: Date }) {
+	const [value, setValue] = useState<Date | undefined>(initialValue);
+	return (
+		<Stack gap={4} alignItems="flex-start">
+			<DatePicker label="Controlled" value={value} onChange={setValue} />
+			<Button data-testid="clear" onClick={() => setValue(undefined)}>
+				Clear
+			</Button>
+		</Stack>
+	);
 }
 
 describe('DatePicker', () => {
@@ -30,5 +46,33 @@ describe('DatePicker', () => {
 			// react 18s `useId` break this rule
 			rules: { 'valid-id': 'off' },
 		});
+	});
+
+	it('updates correctly based on the `value` prop', async () => {
+		const { container } = render(
+			<ControlledDatePicker initialValue={new Date('2000-01-01')} />
+		);
+
+		let input = container.querySelector('input');
+		let calendarTrigger = container.querySelector('button');
+
+		// The input should be a formatted display value of `initialValue`
+		expect(input).toHaveValue('01/01/2000');
+		// The calendar button trigger should have an aria-label with the formatted display value of `initialValue`
+		expect(calendarTrigger).toHaveAttribute(
+			'aria-label',
+			'Change Date, Saturday January 1st, 2000'
+		);
+
+		// Click the `clear` button to clear the value
+		await userEvent.click(screen.getByTestId('clear'));
+
+		input = container.querySelector('input');
+		calendarTrigger = container.querySelector('button');
+
+		// The input should be empty
+		expect(input).toHaveValue('');
+		// The calendar button triggers aria-label should be updated
+		expect(calendarTrigger).toHaveAttribute('aria-label', 'Choose date');
 	});
 });

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -91,9 +91,9 @@ export const DatePicker = ({
 		[maxDate, minDate, onChange]
 	);
 
-	// Update the text inputs when the value updates
+	// Update the text input when the value updates
 	useEffect(() => {
-		if (value) setInputValue(formatDate(value));
+		setInputValue(value ? formatDate(value) : '');
 	}, [value]);
 
 	// Close the calendar when the user clicks outside

--- a/packages/react/src/date-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-picker/DateRangePicker.test.tsx
@@ -1,12 +1,39 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { cleanup, render } from '../../../../test-utils';
-import { DateRangePicker, DateRangePickerProps } from './DateRangePicker';
+import { useState } from 'react';
+import userEvent from '@testing-library/user-event';
+import { cleanup, render, screen } from '../../../../test-utils';
+import { Stack } from '../box';
+import { Button } from '../button';
+import {
+	DateRange,
+	DateRangePicker,
+	DateRangePickerProps,
+} from './DateRangePicker';
 
 afterEach(cleanup);
 
 function renderDateRangePicker(props: DateRangePickerProps) {
 	return render(<DateRangePicker {...props} />);
+}
+
+function ControlledDateRangePicker({
+	initialValue,
+}: {
+	initialValue: DateRange;
+}) {
+	const [value, setValue] = useState<DateRange>(initialValue);
+	return (
+		<Stack gap={4} alignItems="flex-start">
+			<DateRangePicker value={value} onChange={setValue} />
+			<Button
+				data-testid="clear"
+				onClick={() => setValue({ from: undefined, to: undefined })}
+			>
+				Clear
+			</Button>
+		</Stack>
+	);
 }
 
 describe('DateRangePicker', () => {
@@ -30,5 +57,47 @@ describe('DateRangePicker', () => {
 				'valid-id': 'off',
 			},
 		});
+	});
+
+	it('updates correctly based on the `value` prop', async () => {
+		const { container } = render(
+			<ControlledDateRangePicker
+				initialValue={{
+					from: new Date('2000-01-01'),
+					to: new Date('2000-01-07'),
+				}}
+			/>
+		);
+
+		let inputs = container.querySelectorAll('input');
+		let calendarTriggers = container.querySelectorAll('button');
+
+		// The inputs should be a formatted display value of `initialValue`
+		expect(inputs[0]).toHaveValue('01/01/2000');
+		expect(inputs[1]).toHaveValue('07/01/2000');
+
+		// The calendar button trigger should have an aria-label with the formatted display value of `initialValue`
+		expect(calendarTriggers[0]).toHaveAttribute(
+			'aria-label',
+			'Change Date, Saturday January 1st, 2000'
+		);
+		expect(calendarTriggers[1]).toHaveAttribute(
+			'aria-label',
+			'Change Date, Friday January 7th, 2000'
+		);
+
+		// Click the `clear` button to clear the value
+		await userEvent.click(screen.getByTestId('clear'));
+
+		inputs = container.querySelectorAll('input');
+		calendarTriggers = container.querySelectorAll('button');
+
+		// The inputs should be empty
+		expect(inputs[0]).toHaveValue('');
+		expect(inputs[1]).toHaveValue('');
+
+		// The calendar button triggers aria-label should be updated
+		expect(calendarTriggers[0]).toHaveAttribute('aria-label', 'Choose date');
+		expect(calendarTriggers[1]).toHaveAttribute('aria-label', 'Choose date');
 	});
 });

--- a/packages/react/src/date-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-picker/DateRangePicker.tsx
@@ -157,8 +157,8 @@ export const DateRangePicker = ({
 
 	// Update the text inputs when the value updates
 	useEffect(() => {
-		if (value.from) setFromInputValue(formatDate(value.from));
-		if (value.to) setToInputValue(formatDate(value.to));
+		setFromInputValue(value.from ? formatDate(value.from) : '');
+		setToInputValue(value.to ? formatDate(value.to) : '');
 	}, [value]);
 
 	// Close the calendar when the user clicks outside


### PR DESCRIPTION
## Describe your changes

This PR fixes a bug in our `DatePicker` and `DateRangePicker` components. This bug is pretty visible in the following stories:

- https://design-system.agriculture.gov.au/storybook/index.html?path=/story/forms-datepicker-datepicker--controlled-example
- https://design-system.agriculture.gov.au/storybook/index.html?path=/story/forms-datepicker-daterangepicker--controlled-example

In both of these stories, if you click 'Set pre-defined range' followed by the 'Clear' button, you'll notice that the text inputs do not update as expected.

Using our deploy previews, you can see this issue has been fixed:

- https://design-system.agriculture.gov.au/pr-preview/pr-946/storybook/index.html?path=/story/forms-datepicker-datepicker--controlled-example
- https://design-system.agriculture.gov.au/pr-preview/pr-946/storybook/index.html?path=/story/forms-datepicker-daterangepicker--controlled-example

I've also added some tests to make sure this doesn't accidentally break again in the future.

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook