### PR TITLE
autocomplete, combobox: fix hint max width bug

### DIFF
--- a/.changeset/tasty-oranges-fold.md
+++ b/.changeset/tasty-oranges-fold.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+autocomplete, combobox: Fixed issue where hint and error text had incorrect max width.

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -3,64 +3,60 @@
 exports[`Autocomplete renders correctly 1`] = `
 <div>
   <div
-    class="css-ep8qz0-ComboboxBase"
+    class="css-1904cz9-boxStyles-FieldContainer"
   >
-    <div
-      class="css-1904cz9-boxStyles-FieldContainer"
+    <label
+      class="css-n7rdvo-boxStyles"
+      for="combobox-input-:r0:"
     >
-      <label
-        class="css-n7rdvo-boxStyles"
-        for="combobox-input-:r0:"
-      >
-        <span
-          class="css-433uqb-boxStyles-Text"
-        >
-          Find your state
-        </span>
-        <span
-          class="css-1rpt3h8-boxStyles-Text"
-        >
-          (optional)
-        </span>
-      </label>
       <span
-        class="css-lw0v8u-boxStyles-Text"
-        id="field-combobox-input-:r0:-hint"
+        class="css-433uqb-boxStyles-Text"
       >
-        Start typing to see results
+        Find your state
       </span>
-      <div
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-owns="downshift-0-menu"
-        class="css-sg7u9w-ComboboxBase"
-        role="combobox"
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
       >
-        <input
-          aria-autocomplete="list"
-          aria-controls="downshift-0-menu"
-          aria-describedby="field-combobox-input-:r0:-hint"
-          aria-invalid="false"
+        (optional)
+      </span>
+    </label>
+    <span
+      class="css-lw0v8u-boxStyles-Text"
+      id="field-combobox-input-:r0:-hint"
+    >
+      Start typing to see results
+    </span>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-owns="downshift-0-menu"
+      class="css-ep8qz0-ComboboxBase"
+      role="combobox"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="downshift-0-menu"
+        aria-describedby="field-combobox-input-:r0:-hint"
+        aria-invalid="false"
+        aria-labelledby="downshift-0-label"
+        aria-required="false"
+        autocomplete="off"
+        class="css-6dhko2-ComboboxBase"
+        id="combobox-input-:r0:"
+        type="text"
+        value=""
+      />
+      <div
+        class="css-15i2gz6-ComboboxBase"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <ul
           aria-labelledby="downshift-0-label"
-          aria-required="false"
-          autocomplete="off"
-          class="css-gztxie-ComboboxBase"
-          id="combobox-input-:r0:"
-          type="text"
-          value=""
+          class="css-1bz7paq-boxStyles-ComboboxList"
+          id="downshift-0-menu"
+          role="listbox"
         />
       </div>
-    </div>
-    <div
-      class="css-167bwb0-ComboboxBase"
-      style="position: absolute; left: 0px; top: 0px;"
-    >
-      <ul
-        aria-labelledby="downshift-0-label"
-        class="css-1bz7paq-boxStyles-ComboboxList"
-        id="downshift-0-menu"
-        role="listbox"
-      />
     </div>
   </div>
 </div>

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -1,7 +1,7 @@
 import { Fragment, ReactNode, useState } from 'react';
 import { UseComboboxReturnValue } from 'downshift';
 import { usePopper } from 'react-popper';
-import { FieldMaxWidth, mapSpacing } from '../../core';
+import { FieldMaxWidth, mapSpacing, mergeRefs } from '../../core';
 import { textInputStyles } from '../../text-input';
 import { Field } from '../../field';
 import { Text } from '../../text';
@@ -91,87 +91,93 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	});
 
 	const { maxWidth, ...inputStyles } = {
-		...textInputStyles({
-			block,
-			maxWidth: maxWidthProp,
-			invalid,
-		}),
+		...textInputStyles({ block, maxWidth: maxWidthProp, invalid }),
 		paddingRight: mapSpacing(3),
 	};
 
+	const { ref: comboboxRef, ...comboboxProps } = downshift.getComboboxProps();
+
 	return (
-		<div css={{ position: 'relative', maxWidth }} ref={setRefEl}>
-			<Field
-				label={label}
-				hideOptionalLabel={hideOptionalLabel}
-				required={Boolean(required)}
-				hint={hint}
-				message={message}
-				invalid={invalid}
-				id={inputId}
-			>
-				{(a11yProps) => (
-					<div css={{ position: 'relative' }} {...downshift.getComboboxProps()}>
-						<input
-							css={[inputStyles, { width: '100%' }]}
+		<Field
+			label={label}
+			hideOptionalLabel={hideOptionalLabel}
+			required={Boolean(required)}
+			hint={hint}
+			message={message}
+			invalid={invalid}
+			id={inputId}
+		>
+			{(a11yProps) => (
+				<div
+					css={{ position: 'relative', maxWidth }}
+					ref={mergeRefs([setRefEl, comboboxRef])}
+					{...comboboxProps}
+				>
+					<input
+						css={{ ...inputStyles, width: '100%' }}
+						disabled={disabled}
+						{...a11yProps}
+						{...downshift.getInputProps({ type: 'text' })}
+					/>
+					{showDropdownTrigger && (
+						<ComboboxDropdownTrigger
 							disabled={disabled}
-							{...a11yProps}
-							{...downshift.getInputProps({ type: 'text' })}
+							{...downshift.getToggleButtonProps()}
 						/>
-						{showDropdownTrigger && (
-							<ComboboxDropdownTrigger
-								disabled={disabled}
-								{...downshift.getToggleButtonProps()}
-							/>
-						)}
-						{!showDropdownTrigger && clearable && downshift.selectedItem && (
-							<ComboboxClearButton
-								disabled={disabled}
-								onClick={downshift.reset}
-							/>
-						)}
-					</div>
-				)}
-			</Field>
-			<div
-				ref={setPopperEl}
-				style={styles.popper}
-				{...attributes.popper}
-				css={{ zIndex: 1, width: '100%' }}
-			>
-				<ComboboxList {...downshift.getMenuProps()} isOpen={downshift.isOpen}>
-					{downshift.isOpen && (
-						<Fragment>
-							{loading ? (
-								<ComboboxListLoading />
-							) : networkError ? (
-								<ComboboxListError />
-							) : (
+					)}
+					{!showDropdownTrigger && clearable && downshift.selectedItem && (
+						<ComboboxClearButton
+							disabled={disabled}
+							onClick={downshift.reset}
+						/>
+					)}
+					<div
+						ref={setPopperEl}
+						style={styles.popper}
+						{...attributes.popper}
+						css={{ maxWidth, zIndex: 1, width: '100%' }}
+					>
+						<ComboboxList
+							{...downshift.getMenuProps()}
+							isOpen={downshift.isOpen}
+						>
+							{downshift.isOpen && (
 								<Fragment>
-									{inputItems?.length ? (
-										inputItems.map((item, index) => {
-											const isActiveItem = downshift.highlightedIndex === index;
-											return (
-												<ComboboxListItem
-													key={`${item.value}${index}`}
-													isActiveItem={isActiveItem}
-													isInteractive={true}
-													{...downshift.getItemProps({ item, index })}
-												>
-													{renderItem(item, downshift.inputValue)}
-												</ComboboxListItem>
-											);
-										})
+									{loading ? (
+										<ComboboxListLoading />
+									) : networkError ? (
+										<ComboboxListError />
 									) : (
-										<ComboboxListEmptyResults message={emptyResultsMessage} />
+										<Fragment>
+											{inputItems?.length ? (
+												inputItems.map((item, index) => {
+													const isActiveItem =
+														downshift.highlightedIndex === index;
+													return (
+														<ComboboxListItem
+															key={`${item.value}${index}`}
+															isActiveItem={isActiveItem}
+															isInteractive={true}
+															{...downshift.getItemProps({ item, index })}
+														>
+															{renderItem(item, downshift.inputValue)}
+														</ComboboxListItem>
+													);
+												})
+											) : (
+												<ComboboxListEmptyResults
+													message={emptyResultsMessage}
+												/>
+											)}
+										</Fragment>
 									)}
 								</Fragment>
 							)}
-						</Fragment>
-					)}
-				</ComboboxList>
-			</div>
-		</div>
+						</ComboboxList>
+					</div>
+				</div>
+			)}
+		</Field>
 	);
 }
 

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -3,87 +3,83 @@
 exports[`Combobox renders correctly 1`] = `
 <div>
   <div
-    class="css-ep8qz0-ComboboxBase"
+    class="css-1904cz9-boxStyles-FieldContainer"
   >
-    <div
-      class="css-1904cz9-boxStyles-FieldContainer"
+    <label
+      class="css-n7rdvo-boxStyles"
+      for="combobox-input-:r0:"
     >
-      <label
-        class="css-n7rdvo-boxStyles"
-        for="combobox-input-:r0:"
-      >
-        <span
-          class="css-433uqb-boxStyles-Text"
-        >
-          Find your state
-        </span>
-        <span
-          class="css-1rpt3h8-boxStyles-Text"
-        >
-          (optional)
-        </span>
-      </label>
       <span
-        class="css-lw0v8u-boxStyles-Text"
-        id="field-combobox-input-:r0:-hint"
+        class="css-433uqb-boxStyles-Text"
       >
-        Start typing to see results
+        Find your state
       </span>
-      <div
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-owns="downshift-0-menu"
-        class="css-sg7u9w-ComboboxBase"
-        role="combobox"
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
       >
-        <input
-          aria-autocomplete="list"
-          aria-controls="downshift-0-menu"
-          aria-describedby="field-combobox-input-:r0:-hint"
-          aria-invalid="false"
-          aria-labelledby="downshift-0-label"
-          aria-required="false"
-          autocomplete="off"
-          class="css-gztxie-ComboboxBase"
-          id="combobox-input-:r0:"
-          type="text"
-          value=""
-        />
-        <button
-          aria-label="Toggle menu"
-          class="css-1khxazb-BaseButton-ComboboxIconButton"
-          id="downshift-0-toggle-button"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="css-vfodg1-Icon"
-            clip-rule="evenodd"
-            focusable="false"
-            height="24"
-            role="img"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M21 8L12 17L3 8"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-    <div
-      class="css-167bwb0-ComboboxBase"
-      style="position: absolute; left: 0px; top: 0px;"
+        (optional)
+      </span>
+    </label>
+    <span
+      class="css-lw0v8u-boxStyles-Text"
+      id="field-combobox-input-:r0:-hint"
     >
-      <ul
+      Start typing to see results
+    </span>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-owns="downshift-0-menu"
+      class="css-ep8qz0-ComboboxBase"
+      role="combobox"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="downshift-0-menu"
+        aria-describedby="field-combobox-input-:r0:-hint"
+        aria-invalid="false"
         aria-labelledby="downshift-0-label"
-        class="css-1bz7paq-boxStyles-ComboboxList"
-        id="downshift-0-menu"
-        role="listbox"
+        aria-required="false"
+        autocomplete="off"
+        class="css-6dhko2-ComboboxBase"
+        id="combobox-input-:r0:"
+        type="text"
+        value=""
       />
+      <button
+        aria-label="Toggle menu"
+        class="css-1khxazb-BaseButton-ComboboxIconButton"
+        id="downshift-0-toggle-button"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-vfodg1-Icon"
+          clip-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 8L12 17L3 8"
+          />
+        </svg>
+      </button>
+      <div
+        class="css-15i2gz6-ComboboxBase"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="css-1bz7paq-boxStyles-ComboboxList"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
     </div>
   </div>
 </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -3,87 +3,83 @@
 exports[`ComboboxAsync renders correctly 1`] = `
 <div>
   <div
-    class="css-ep8qz0-ComboboxBase"
+    class="css-1904cz9-boxStyles-FieldContainer"
   >
-    <div
-      class="css-1904cz9-boxStyles-FieldContainer"
+    <label
+      class="css-n7rdvo-boxStyles"
+      for="combobox-input-:r0:"
     >
-      <label
-        class="css-n7rdvo-boxStyles"
-        for="combobox-input-:r0:"
-      >
-        <span
-          class="css-433uqb-boxStyles-Text"
-        >
-          Find your state
-        </span>
-        <span
-          class="css-1rpt3h8-boxStyles-Text"
-        >
-          (optional)
-        </span>
-      </label>
       <span
-        class="css-lw0v8u-boxStyles-Text"
-        id="field-combobox-input-:r0:-hint"
+        class="css-433uqb-boxStyles-Text"
       >
-        Start typing to see results
+        Find your state
       </span>
-      <div
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-owns="downshift-0-menu"
-        class="css-sg7u9w-ComboboxBase"
-        role="combobox"
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
       >
-        <input
-          aria-autocomplete="list"
-          aria-controls="downshift-0-menu"
-          aria-describedby="field-combobox-input-:r0:-hint"
-          aria-invalid="false"
-          aria-labelledby="downshift-0-label"
-          aria-required="false"
-          autocomplete="off"
-          class="css-gztxie-ComboboxBase"
-          id="combobox-input-:r0:"
-          type="text"
-          value=""
-        />
-        <button
-          aria-label="Toggle menu"
-          class="css-1khxazb-BaseButton-ComboboxIconButton"
-          id="downshift-0-toggle-button"
-          tabindex="-1"
-          type="button"
-        >
-          <svg
-            aria-hidden="true"
-            class="css-vfodg1-Icon"
-            clip-rule="evenodd"
-            focusable="false"
-            height="24"
-            role="img"
-            viewBox="0 0 24 24"
-            width="24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M21 8L12 17L3 8"
-            />
-          </svg>
-        </button>
-      </div>
-    </div>
-    <div
-      class="css-167bwb0-ComboboxBase"
-      style="position: absolute; left: 0px; top: 0px;"
+        (optional)
+      </span>
+    </label>
+    <span
+      class="css-lw0v8u-boxStyles-Text"
+      id="field-combobox-input-:r0:-hint"
     >
-      <ul
+      Start typing to see results
+    </span>
+    <div
+      aria-expanded="false"
+      aria-haspopup="listbox"
+      aria-owns="downshift-0-menu"
+      class="css-ep8qz0-ComboboxBase"
+      role="combobox"
+    >
+      <input
+        aria-autocomplete="list"
+        aria-controls="downshift-0-menu"
+        aria-describedby="field-combobox-input-:r0:-hint"
+        aria-invalid="false"
         aria-labelledby="downshift-0-label"
-        class="css-1bz7paq-boxStyles-ComboboxList"
-        id="downshift-0-menu"
-        role="listbox"
+        aria-required="false"
+        autocomplete="off"
+        class="css-6dhko2-ComboboxBase"
+        id="combobox-input-:r0:"
+        type="text"
+        value=""
       />
+      <button
+        aria-label="Toggle menu"
+        class="css-1khxazb-BaseButton-ComboboxIconButton"
+        id="downshift-0-toggle-button"
+        tabindex="-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="css-vfodg1-Icon"
+          clip-rule="evenodd"
+          focusable="false"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 8L12 17L3 8"
+          />
+        </svg>
+      </button>
+      <div
+        class="css-15i2gz6-ComboboxBase"
+        style="position: absolute; left: 0px; top: 0px;"
+      >
+        <ul
+          aria-labelledby="downshift-0-label"
+          class="css-1bz7paq-boxStyles-ComboboxList"
+          id="downshift-0-menu"
+          role="listbox"
+        />
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Describe your changes

This PR fixes an inconsistency in hint text max widths for our form components.

**Before**

Notice in the `Combobox` component how the hint text has the same max-width as the input element. This behaviour is inconsistent with other form components. [See playroom link](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF5gAmAXwD4AdYzTJAMQgCcBbAZQBdcYANaNmLVm0IAbGAEli2AK78mEidNwAjGNPIMQAUXS5u2WQbXrMACxL99IADJcY3TIWwBnJe6gRpLkwvQn5MUxh%2BABpMSGIvGDB%2BSKVOcKJsQi8wElJMXVCAOkwABU4IEkwuHPzyrxiANxgvfkItJWlffNJI-Kwm6UaAlTwwuKJuGGJ%2BLu5CQstxFgB6MSsWJAAVGHRBThhcdY1tXUdjU3MYRetbe0cXffdPHz8AoJCwiOjYiHjE5JmaXwniyOTI%2BWkRVK5Uq1UItQg9UwTRabQ6XRgPTCO2RuiGnX4ox%2BxAmUxm7jmCxAR1WRyQvF0-yOLE0Oj0BnOZgs1KWEjs03urie3i6-kCaQ%2B4Um3ziCSSKSBGVBuQhULKFWYcIRSJRrXanXcmN6OIG%2BJGuDGv1J01m82u1gg2Favy8lAA2gBdGg0sTqekHThgGwKZSqXksk7sowmLlXHk3fkOAwPNweEWvcXBUJSyIxWX-BXpEHZFUFfjFdWwwPwmB1RrNPXow1Yvq4wbI4aEi3E63kzCU%2B0rX0SdgyGAAVXMEHwzMwrNOHJjl0HfLuyaFaZemDF72zXzzLoLgKLmRL4LLFZhmur2vrqP1GJbJrxHYJRPGhEmNopdvjElpvJIAAIhaMAlIQIi1rO85Rpyy5-uoiaCo8m6im8Ep7tKB5-PKx7AqeYJ5Be0IalUN61oid6Nga3TGv0L4NJ275Wp%2BZK2lSPp0gAwr8-DlNIADi5RKNg0GRo4ABKwIQFUTqEL8K4sEh64oc8aGZpK%2B7EnKAKpCeyrnpC5YkVWNQUTqDZojRRrYvR7aMW%2B3Yfl%2BfYDghmDDn6UlEDJQaJMIMBQJQABmuDSAk9AlDYvwwEgyzefJnkjglvk2P5gUhWFEV0Js2iyPwcUpUlGwpbEaWQUFwB8UoMD0E4uBOo6hXSUlcU8dM-FCRAImtdsuwhioYlsmcS7crOynOBuakZrunxYdpR56fhBlEUZl6kVq5lUVZj50W2ZpdpaJKsd%2B-a-pxgEAIIqBAkCxskQ0LiAUgkpgACe3VpDk-BvYptwCipqbTdu6FZnNuYLbhS1Kmeq1qleZFmXWuL3k2tG2ftr7mkdvbsX9gT4AA8nJLqUAAFAAlJg5B0JgbqziwwDImFNXwJgBiHCAMQwWzBjE86zCXQYmA0FEDOYEzDQszAvMgFoBjc5Gsv8-JzAoMLovi5L0uy2ACtzkr7MgCrvyYFxGti%2BGmBehdfo8dwWgQI76CPVGDKyEkPxKB1v3uUpa6Tap6YgxpmEQ-mUOKsWhGqsZlbXkjlEo9Ru0Y6aWOHT2J2ued4izo6AuusA9NW4zzOdDLRuc4rbLKyTgsW1r5es0b8tcwbtdGybauN6XEvN5XBh6%2B3PNd-XZu9zcNu8gBGzLBwPACEIohMHFaDoGIIA0EAA)

<img width="937" alt="Screen Shot 2023-02-06 at 10 06 45 am" src="https://user-images.githubusercontent.com/6265154/216854401-8e99a75d-9e94-4ada-bb31-0436620a79f6.png">

**After**

`Combobox` now follows the same convention for max-widths as other form input elements. [See playroom link using PR preview](https://design-system.agriculture.gov.au/pr-preview/pr-949/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF5gAmAXwD4AdYzTJAMQgCcBbAZQBdcYANaNmLVm0IAbGAEli2AK78mEidNwAjGNPIMQAUXS5u2WQbXrMACxL99IADJcY3TIWwBnJe6gRpLkwvQn5MUxh%2BABpMSGIvGDB%2BSKVOcKJsQi8wElJMXVCAOkwABU4IEkwuHPzyrxiANxgvfkItJWlffNJI-Kwm6UaAlTwwuKJuGGJ%2BLu5CQstxFgB6MSsWJAAVGHRBThhcdY1tXUdjU3MYRetbe0cXffdPHz8AoJCwiOjYiHjE5JmaXwniyOTI%2BWkRVK5Uq1UItQg9UwTRabQ6XRgPTCO2RuiGnX4ox%2BxAmUxm7jmCxAR1WRyQvF0-yOLE0Oj0BnOZgs1KWEjs03urie3i6-kCaQ%2B4Um3ziCSSKSBGVBuQhULKFWYcIRSJRrXanXcmN6OIG%2BJGuDGv1J01m82u1gg2Favy8lAA2gBdGg0sTqekHThgGwKZSqXksk7sowmLlXHk3fkOAwPNweEWvcXBUJSyIxWX-BXpEHZFUFfjFdWwwPwmB1RrNPXow1Yvq4wbI4aEi3E63kzCU%2B0rX0SdgyGAAVXMEHwzMwrNOHJjl0HfLuyaFaZemDF72zXzzLoLgKLmRL4LLFZhmur2vrqP1GJbJrxHYJRPGhEmNopdvjElpvJIAAIhaMAlIQIi1rO85Rpyy5-uoiaCo8m6im8Ep7tKB5-PKx7AqeYJ5Be0IalUN61oid6Nga3TGv0L4NJ275Wp%2BZK2lSPp0gAwr8-DlNIADi5RKNg0GRo4ABKwIQFUTqEL8K4sEh64oc8aGZpK%2B7EnKAKpCeyrnpC5YkVWNQUTqDZojRRrYvR7aMW%2B3Yfl%2BfYDghmDDn6UlEDJQaJMIMBQJQABmuDSAk9AlDYvwwEgyzefJnkjglvk2P5gUhWFEV0Js2iyPwcUpUlGwpbEaWQUFwB8UoMD0E4uBOo6hXSUlcU8dM-FCRAImtdsuwhioYlsmcS7crOynOBuakZrunxYdpR56fhBlEUZl6kVq5lUVZj50W2ZpdpaJKsd%2B-a-pxgEAIIqBAkCxskQ0LiAUgkpgACe3VpDk-BvYptwCipqbTdu6FZnNuYLbhS1Kmeq1qleZFmXWuL3k2tG2ftr7mkdvbsX9gT4AA8nJLqUAAFAAlJg5B0JgbqziwwDImFNXwJgBiHCAMQwWzBjE86zCXQYmA0FEDOYEzDQszAvMgFoBjc5Gsv8-JzAoMLovi5L0uy2ACtzkr7MgCrvyYFxGti%2BGmBehdfo8dwWgQI76CPVGDKyEkPxKB1v3uUpa6Tap6YgxpmEQ-mUOKsWhGqsZlbXkjlEo9Ru0Y6aWOHT2J2uedVuOgLrrAPTVuM8znQy0bnOK2yysk4LFta2XrNG-LXMGzXRsm2rDclxLTcVwYettzznd12bPc3DbvIARsywcDwAhCKITBxWg6BiCANBAA).

<img width="1008" alt="Screen Shot 2023-02-06 at 10 09 23 am" src="https://user-images.githubusercontent.com/6265154/216854399-839b90c5-9f86-4ea8-a81c-534b2bee4fe9.png">


## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook