### PR TITLE
docs: guides design improvements

### DIFF
--- a/docs/content/guides/contribution.mdx
+++ b/docs/content/guides/contribution.mdx
@@ -1,7 +1,7 @@
 ---
 order: 2
 title: Contribution guidelines
-description: Contributing to the Agriculture Design System
+opener: Contributing to the Agriculture Design System
 ---
 
 You can contribute to the Agriculture Design System (AgDS) in many ways including:

--- a/docs/content/guides/contribution.mdx
+++ b/docs/content/guides/contribution.mdx
@@ -1,7 +1,7 @@
 ---
 order: 2
 title: Contribution guidelines
-opener: Contributing to the Agriculture Design System
+opener: Contributing to the Agriculture Design System.
 ---
 
 You can contribute to the Agriculture Design System (AgDS) in many ways including:

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -1,6 +1,6 @@
 ---
 title: Creating a custom theme
-description: How to create theme for your brand in the React component library.
+opener: How to create theme for your brand in the React component library
 ---
 
 Our Design System has tokens for spacing, typography, borders, and colours. The colours used in our design system come from a **Theme**, which is a structure (schema) of colour tokens that semantically describe how they will be used. A Theme is made up of light and dark **palettes**, which are made up of backgrounds, foregrounds, and system colours. The full schema can be found at the bottom of this page.

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -1,6 +1,6 @@
 ---
 title: Creating a custom theme
-opener: How to create theme for your brand in the React component library
+opener: How to create theme for your brand in the React component library.
 ---
 
 Our Design System has tokens for spacing, typography, borders, and colours. The colours used in our design system come from a **Theme**, which is a structure (schema) of colour tokens that semantically describe how they will be used. A Theme is made up of light and dark **palettes**, which are made up of backgrounds, foregrounds, and system colours. The full schema can be found at the bottom of this page.

--- a/docs/content/guides/figma.mdx
+++ b/docs/content/guides/figma.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Figma
-description: How to access the AgDS design files
+opener: How to access the AgDS design files
 ---
 
 <FigmaEmbed src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FSgSHfK8AUadp7aEzD34ZG3%2FAgDS---Agriculture-Design-System-1.2.1%3Fnode-id%3D10942%253A92273%26t%3DJ4Xy0yzc44JjeRPS-1" />

--- a/docs/content/guides/figma.mdx
+++ b/docs/content/guides/figma.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Figma
-opener: How to access the AgDS design files
+opener: How to access the AgDS design files.
 ---
 
 <FigmaEmbed src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FSgSHfK8AUadp7aEzD34ZG3%2FAgDS---Agriculture-Design-System-1.2.1%3Fnode-id%3D10942%253A92273%26t%3DJ4Xy0yzc44JjeRPS-1" />

--- a/docs/content/guides/forms.mdx
+++ b/docs/content/guides/forms.mdx
@@ -1,5 +1,6 @@
 ---
 title: Forms
+overview: Building a simple sign in form using AgDS components, react-hook-form and yup.
 opener: Web forms are one of the main points of interaction between a user and a web site or application. In this guide, we will be building a simple sign in form using two popular libraries react-hook-form and yup.
 ---
 

--- a/docs/content/guides/forms.mdx
+++ b/docs/content/guides/forms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Forms
-description: Web forms are one of the main points of interaction between a user and a web site or application. In this guide, we will be building a simple sign in form using two popular libraries react-hook-form and yup.
+opener: Web forms are one of the main points of interaction between a user and a web site or application. In this guide, we will be building a simple sign in form using two popular libraries react-hook-form and yup.
 ---
 
 > Note: The AgDS component library does not have any opinions for how form state should be handled. All of our form components have been designed to work with any form library.

--- a/docs/content/guides/getting-started.mdx
+++ b/docs/content/guides/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 order: 1
 title: Getting started
-overview: Get up and running with the AgDS React component library
+overview: Get up and running with the AgDS React component library.
 opener: Welcome to AgDS - the Design System for the Australian Government Department of Agriculture, Fisheries and Forestry. In this guide we are going to go through the steps necessary to get started with the React component library from our Design System.
 ---
 

--- a/docs/content/guides/getting-started.mdx
+++ b/docs/content/guides/getting-started.mdx
@@ -1,7 +1,8 @@
 ---
 order: 1
 title: Getting started
-description: Welcome to AgDS - the Design System for the Australian Government Department of Agriculture, Fisheries and Forestry. In this guide we are going to go through the steps necessary to get started with the React component library from our Design System.
+overview: Get up and running with the AgDS React component library
+opener: Welcome to AgDS - the Design System for the Australian Government Department of Agriculture, Fisheries and Forestry. In this guide we are going to go through the steps necessary to get started with the React component library from our Design System.
 ---
 
 ## What is React?

--- a/docs/content/guides/responsive-props.mdx
+++ b/docs/content/guides/responsive-props.mdx
@@ -1,6 +1,6 @@
 ---
 title: Responsive props
-description: The Agriculture Design System provides first class support for mobile-first responsive styles. Instead of manually writing CSS media queries throughout your codebase, our primitive components allow you to provide arrays and objects to generate responsive styles in your project.
+opener: The Agriculture Design System provides first class support for mobile-first responsive styles. Instead of manually writing CSS media queries throughout your codebase, our primitive components allow you to provide arrays and objects to generate responsive styles in your project.
 ---
 
 ## Breakpoints

--- a/docs/content/guides/responsive-props.mdx
+++ b/docs/content/guides/responsive-props.mdx
@@ -1,5 +1,6 @@
 ---
 title: Responsive props
+overview: AgDS provides first class support for mobile-first responsive styles.
 opener: The Agriculture Design System provides first class support for mobile-first responsive styles. Instead of manually writing CSS media queries throughout your codebase, our primitive components allow you to provide arrays and objects to generate responsive styles in your project.
 ---
 

--- a/docs/lib/mdx/guides.ts
+++ b/docs/lib/mdx/guides.ts
@@ -12,15 +12,9 @@ const guidePath = (slug: string) => normalize(`${GUIDE_PATH}/${slug}.mdx`);
 
 const getGuideOverview = (overview: string | null, opener: string | null) => {
 	const stringLength = 72;
-	if (overview) {
-		return overview;
-	}
-	if (opener) {
-		if (opener.length < stringLength) {
-			return opener;
-		}
-		return `${opener.slice(0, stringLength)}...`;
-	}
+	if (overview) return overview;
+	if (opener && opener.length < stringLength) return opener;
+	if (opener) return `${opener.slice(0, stringLength)}...`;
 	return null;
 };
 

--- a/docs/lib/mdx/guides.ts
+++ b/docs/lib/mdx/guides.ts
@@ -10,6 +10,20 @@ import { slugify } from '../slugify';
 export const GUIDE_PATH = normalize(`${process.cwd()}/content/guides`);
 const guidePath = (slug: string) => normalize(`${GUIDE_PATH}/${slug}.mdx`);
 
+const getGuideOverview = (overview: string | null, opener: string | null) => {
+	const stringLength = 72;
+	if (overview) {
+		return overview;
+	}
+	if (opener) {
+		if (opener.length < stringLength) {
+			return opener;
+		}
+		return `${opener.slice(0, stringLength)}...`;
+	}
+	return null;
+};
+
 export async function getGuide(slug: string) {
 	const { content, data } = await getMarkdownData(guidePath(slug));
 	const source = await serializeMarkdown(content, data);
@@ -18,7 +32,8 @@ export async function getGuide(slug: string) {
 		source,
 		data,
 		title: (data.title ?? slug) as string,
-		description: (data.description ?? null) as string | null,
+		opener: (data.opener ?? null) as string | null,
+		overview: getGuideOverview(data.overview, data.opener),
 	};
 }
 
@@ -44,7 +59,8 @@ export async function getGuideList() {
 			getMarkdownData(guidePath(slug)).then(({ data }) => ({
 				order: (data.order as number | null) || 100,
 				title: (data?.title ?? slug) as string,
-				description: (data.description ?? null) as string | null,
+				opener: (data.opener ?? null) as string | null,
+				overview: getGuideOverview(data.overview, data.opener),
 				slug,
 			}))
 		)

--- a/docs/lib/mdx/guides.ts
+++ b/docs/lib/mdx/guides.ts
@@ -10,14 +10,6 @@ import { slugify } from '../slugify';
 export const GUIDE_PATH = normalize(`${process.cwd()}/content/guides`);
 const guidePath = (slug: string) => normalize(`${GUIDE_PATH}/${slug}.mdx`);
 
-const getGuideOverview = (overview: string | null, opener: string | null) => {
-	const stringLength = 72;
-	if (overview) return overview;
-	if (opener && opener.length < stringLength) return opener;
-	if (opener) return `${opener.slice(0, stringLength)}...`;
-	return null;
-};
-
 export async function getGuide(slug: string) {
 	const { content, data } = await getMarkdownData(guidePath(slug));
 	const source = await serializeMarkdown(content, data);
@@ -27,7 +19,6 @@ export async function getGuide(slug: string) {
 		data,
 		title: (data.title ?? slug) as string,
 		opener: (data.opener ?? null) as string | null,
-		overview: getGuideOverview(data.overview, data.opener),
 	};
 }
 
@@ -54,7 +45,7 @@ export async function getGuideList() {
 				order: (data.order as number | null) || 100,
 				title: (data?.title ?? slug) as string,
 				opener: (data.opener ?? null) as string | null,
-				overview: getGuideOverview(data.overview, data.opener),
+				overview: (data.overview ?? data.opener ?? null) as string | null,
 				slug,
 			}))
 		)

--- a/docs/pages/guides/[slug].tsx
+++ b/docs/pages/guides/[slug].tsx
@@ -3,7 +3,6 @@ import { MDXRemote } from 'next-mdx-remote';
 import { Prose } from '@ag.ds-next/react/prose';
 import {
 	getGuide,
-	getGuideList,
 	getGuidesBreadcrumbs,
 	getGuideSlugs,
 	Guide,
@@ -16,7 +15,6 @@ import { PageTitle } from '../../components/PageTitle';
 
 export default function Guides({
 	guide,
-	guideLinks,
 	breadcrumbs,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
@@ -24,11 +22,6 @@ export default function Guides({
 			<DocumentTitle title={guide.title} description={guide.description} />
 			<AppLayout>
 				<PageLayout
-					sideNav={{
-						title: 'Guides',
-						titleLink: '/guides',
-						items: guideLinks,
-					}}
 					editPath={`/docs/content/guides/${guide.slug}.mdx`}
 					breadcrumbs={breadcrumbs}
 				>
@@ -45,29 +38,19 @@ export default function Guides({
 export const getStaticProps: GetStaticProps<
 	{
 		guide: Guide;
-		guideLinks: { href: string; label: string }[];
 		breadcrumbs: Awaited<ReturnType<typeof getGuidesBreadcrumbs>>;
 	},
 	{ slug: string }
 > = async ({ params }) => {
 	const { slug } = params ?? {};
 	const guide = slug ? await getGuide(slug) : undefined;
-	const guideList = await getGuideList();
-	const guideLinks = guideList.map(({ title, slug }) => ({
-		href: `/guides/${slug}`,
-		label: title,
-	}));
-
 	if (!(slug && guide)) {
 		return { notFound: true };
 	}
-
 	const breadcrumbs = await getGuidesBreadcrumbs(slug);
-
 	return {
 		props: {
 			guide,
-			guideLinks,
 			breadcrumbs,
 			slug,
 		},

--- a/docs/pages/guides/[slug].tsx
+++ b/docs/pages/guides/[slug].tsx
@@ -19,13 +19,13 @@ export default function Guides({
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
-			<DocumentTitle title={guide.title} description={guide.description} />
+			<DocumentTitle title={guide.title} description={guide.opener} />
 			<AppLayout>
 				<PageLayout
 					editPath={`/docs/content/guides/${guide.slug}.mdx`}
 					breadcrumbs={breadcrumbs}
 				>
-					<PageTitle title={guide.title} introduction={guide.description} />
+					<PageTitle title={guide.title} introduction={guide.opener} />
 					<Prose>
 						<MDXRemote {...guide.source} components={mdxComponents} />
 					</Prose>

--- a/docs/pages/guides/index.tsx
+++ b/docs/pages/guides/index.tsx
@@ -13,7 +13,7 @@ type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 export default function GuidesHome({
 	title,
 	description,
-	guideLinks,
+	guideList,
 }: StaticProps) {
 	return (
 		<>
@@ -24,14 +24,14 @@ export default function GuidesHome({
 				editPath="/docs/content/guides/index.mdx"
 			>
 				<Columns as="ul" gap={1.5} cols={{ xs: 1, sm: 2, lg: 3 }}>
-					{guideLinks.map(({ href, label, description }) => (
-						<Card as="li" key={label} clickable shadow>
+					{guideList.map(({ slug, title, overview }) => (
+						<Card as="li" key={title} clickable shadow>
 							<CardInner>
 								<Stack gap={1}>
 									<Box as="h3">
-										<CardLink href={href}>{label}</CardLink>
+										<CardLink href={`/guides/${slug}`}>{title}</CardLink>
 									</Box>
-									{description ? <Text as="p">{description}</Text> : null}
+									{overview ? <Text as="p">{overview}</Text> : null}
 								</Stack>
 							</CardInner>
 						</Card>
@@ -45,17 +45,12 @@ export default function GuidesHome({
 export async function getStaticProps() {
 	const { data } = await getMarkdownData(normalize(`${GUIDE_PATH}/index.mdx`));
 	const guideList = await getGuideList();
-	const guideLinks = guideList.map(({ slug, title, description }) => ({
-		href: `/guides/${slug}`,
-		label: title,
-		description,
-	}));
 
 	return {
 		props: {
 			title: data?.title as string,
 			description: data?.description as string,
-			guideLinks,
+			guideList,
 		},
 	};
 }


### PR DESCRIPTION
## Describe your changes
 - Remove side nav from guide page, to add focus on the content
 - Shorten paragraphs under cards in the guide list page, via a new 'overview' field in Markdown
 - Rename 'description' Markdown field to 'opener' to reflect its purpose.

![guide article page](https://user-images.githubusercontent.com/12689383/217395434-dcc1e310-53ef-4c6e-93d2-0129cae28f03.png)
![guide list page](https://user-images.githubusercontent.com/12689383/217395469-6265b586-1ce9-4909-b4a1-b238d34c2521.png)
