### PR TITLE
example-form: fixed incorrect step status

### DIFF
--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
@@ -135,15 +135,14 @@ export const FormRegisterPetDetails = () => {
 		(stepFormState?: StepFormState) => {
 			setIsSubmittingStep(true);
 
-			if (stepFormState) {
-				setFormState((current) => ({
-					...current,
-					[currentStep]: { ...stepFormState, completed: true },
-				}));
-			}
-
 			// Using a `setTimeout` to replicate a call to a back-end API
 			setTimeout(() => {
+				if (stepFormState) {
+					setFormState((current) => ({
+						...current,
+						[currentStep]: { ...stepFormState, completed: true },
+					}));
+				}
 				setIsSubmittingStep(false);
 				if (currentStep === TOTAL_STEPS) {
 					submitTask2(formState);
@@ -188,6 +187,7 @@ export const FormRegisterPetDetails = () => {
 		(idx: number) => {
 			if (idx === currentStep) return 'doing';
 			if (hasCompletedStep(idx)) return 'done';
+			if (idx === 0 || hasCompletedStep(idx - 1)) return 'todo';
 			return 'blocked';
 		},
 		[currentStep, hasCompletedStep]

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep4.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetailsStep4.tsx
@@ -1,4 +1,5 @@
 import { FormEvent } from 'react';
+import format from 'date-fns/format';
 import { Stack } from '@ag.ds-next/react/box';
 import { H2 } from '@ag.ds-next/react/heading';
 import { Button } from '@ag.ds-next/react/button';
@@ -53,7 +54,9 @@ export const FormRegisterPetDetailsStep4 = () => {
 						},
 						{
 							label: 'Date of birth',
-							value: formState[1]?.dob.toLocaleDateString(),
+							value: formState[1]?.dob
+								? format(formState[1].dob, 'dd/MM/yyyy')
+								: undefined,
 						},
 						{
 							label: 'Sex',
@@ -87,7 +90,9 @@ export const FormRegisterPetDetailsStep4 = () => {
 					items={[
 						{
 							label: 'Registration start date',
-							value: formState[3]?.date.toLocaleDateString(),
+							value: formState[3]?.date
+								? format(formState[3].date, 'dd/MM/yyyy')
+								: undefined,
 						},
 					]}
 				/>

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetails.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetails.tsx
@@ -122,16 +122,14 @@ export const FormRegisterPetPersonalDetails = () => {
 	const next = useCallback(
 		(stepFormState?: StepFormState) => {
 			setIsSubmittingStep(true);
-
-			if (stepFormState) {
-				setFormState((current) => ({
-					...current,
-					[currentStep]: { ...stepFormState, completed: true },
-				}));
-			}
-
 			// Using a `setTimeout` to replicate a call to a back-end API
 			setTimeout(() => {
+				if (stepFormState) {
+					setFormState((current) => ({
+						...current,
+						[currentStep]: { ...stepFormState, completed: true },
+					}));
+				}
 				setIsSubmittingStep(false);
 				if (currentStep === TOTAL_STEPS) {
 					submitTask1(formState);
@@ -176,6 +174,7 @@ export const FormRegisterPetPersonalDetails = () => {
 		(idx: number) => {
 			if (idx === currentStep) return 'doing';
 			if (hasCompletedStep(idx)) return 'done';
+			if (idx === 0 || hasCompletedStep(idx - 1)) return 'todo';
 			return 'blocked';
 		},
 		[currentStep, hasCompletedStep]

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep0.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
+import format from 'date-fns/format';
 import { Box, Stack } from '@ag.ds-next/react/box';
 import { Button, ButtonGroup } from '@ag.ds-next/react/button';
 import { FormStack } from '@ag.ds-next/react/form-stack';
@@ -254,7 +255,7 @@ export const FormRegisterPetPersonalDetailsStep0 = () => {
 								<SummaryListItem>
 									<SummaryListItemTerm>Date of birth</SummaryListItemTerm>
 									<SummaryListItemDescription>
-										{localFormState.dob?.toLocaleDateString()}
+										{format(localFormState.dob, 'dd/MM/yyyy')}
 									</SummaryListItemDescription>
 								</SummaryListItem>
 							</SummaryList>

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep3.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep3.tsx
@@ -1,4 +1,5 @@
 import { FormEvent } from 'react';
+import format from 'date-fns/format';
 import { Stack } from '@ag.ds-next/react/box';
 import { H2 } from '@ag.ds-next/react/heading';
 import { Button } from '@ag.ds-next/react/button';
@@ -42,7 +43,9 @@ export const FormRegisterPetPersonalDetailsStep3 = () => {
 						},
 						{
 							label: 'Date of birth',
-							value: formState[0]?.dob.toLocaleDateString(),
+							value: formState[0]?.dob
+								? format(formState[0].dob, 'dd/MM/yyyy')
+								: undefined,
 						},
 					]}
 				/>


### PR DESCRIPTION
## Describe your changes

This pull request fixes a small issue our the [example-form](https://design-system.agriculture.gov.au/example-form/) application. 

If you are on step 1 and move to another step, the progress indicator for step 1 will be shown as `blocked` when it should be `todo`.

I've also made a couple of small improvements while I was here, by fixing a react hydrating error that first popped up when we introduced the 'side flow' in step 1.