### PR TITLE
Add new `modalDialog` max-width token

### DIFF
--- a/.changeset/giant-emus-build.md
+++ b/.changeset/giant-emus-build.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: Added new `modalPanel` max-width token
+
+modal: Updated max-width of modal dialog

--- a/docs/pages/foundations/tokens/max-width.tsx
+++ b/docs/pages/foundations/tokens/max-width.tsx
@@ -28,10 +28,10 @@ const tokenDescriptions: Record<
 		value: tokens.maxWidth.container,
 		description: 'Used for setting the max-width of the page container.',
 	},
-	modalPanel: {
-		value: tokens.maxWidth.modalPanel,
+	modalDialog: {
+		value: tokens.maxWidth.modalDialog,
 		description:
-			'Used for setting the max-width of the panel in the Modal component.',
+			'Used for setting the max-width of the dialog in the Modal component.',
 	},
 	mobileMenu: {
 		value: tokens.maxWidth.mobileMenu,

--- a/docs/pages/foundations/tokens/max-width.tsx
+++ b/docs/pages/foundations/tokens/max-width.tsx
@@ -28,6 +28,11 @@ const tokenDescriptions: Record<
 		value: tokens.maxWidth.container,
 		description: 'Used for setting the max-width of the page container.',
 	},
+	modalPanel: {
+		value: tokens.maxWidth.modalPanel,
+		description:
+			'Used for setting the max-width of the panel in the Modal component.',
+	},
 	mobileMenu: {
 		value: tokens.maxWidth.mobileMenu,
 		description:

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -89,7 +89,7 @@ const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
 	mobileMenu: '17.5rem', // 280 px
-	modalPanel: '45rem', // 720 px
+	modalDialog: '45rem', // 720 px
 	field: {
 		xs: '5rem', // 80 px
 		sm: '8rem', // 128 px

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -89,6 +89,7 @@ const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
 	mobileMenu: '17.5rem', // 280 px
+	modalPanel: '45rem', // 720 px
 	field: {
 		xs: '5rem', // 80 px
 		sm: '8rem', // 128 px

--- a/packages/react/src/modal/Modal.tsx
+++ b/packages/react/src/modal/Modal.tsx
@@ -5,6 +5,7 @@ import { ModalCover } from './ModalCover';
 import { ModalPanel, ModalPanelProps } from './ModalPanel';
 
 export type ModalProps = ModalPanelProps & {
+	/** If true, the modal will be rendered.  */
 	isOpen?: boolean;
 };
 

--- a/packages/react/src/modal/Modal.tsx
+++ b/packages/react/src/modal/Modal.tsx
@@ -2,9 +2,9 @@ import { Fragment, FunctionComponent, useEffect, useRef } from 'react';
 import { Global } from '@emotion/react';
 import { createPortal } from 'react-dom';
 import { ModalCover } from './ModalCover';
-import { ModalPanel, ModalPanelProps } from './ModalPanel';
+import { ModalDialog, ModalDialogProps } from './ModalDialog';
 
-export type ModalProps = ModalPanelProps & {
+export type ModalProps = ModalDialogProps & {
 	/** If true, the modal will be rendered.  */
 	isOpen?: boolean;
 };
@@ -69,9 +69,9 @@ export const Modal: FunctionComponent<ModalProps> = ({
 		<Fragment>
 			<LockScroll />
 			<ModalCover ref={coverRef}>
-				<ModalPanel onDismiss={onDismiss} title={title} actions={actions}>
+				<ModalDialog onDismiss={onDismiss} title={title} actions={actions}>
 					{children}
-				</ModalPanel>
+				</ModalDialog>
 			</ModalCover>
 		</Fragment>,
 		document.body

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -8,7 +8,7 @@ import { Button } from '../button';
 import { ModalTitle } from './ModalTitle';
 import { useModalId } from './utils';
 
-export type ModalPanelProps = PropsWithChildren<{
+export type ModalDialogProps = PropsWithChildren<{
 	/** The actions to display at the bottom of the modal panel. Typically a `ButtonGroup`. */
 	actions?: ReactNode;
 	/** Function to be called when the modal is closed. */
@@ -19,12 +19,12 @@ export type ModalPanelProps = PropsWithChildren<{
 
 const AnimatedStack = animated(Stack);
 
-export const ModalPanel = ({
+export const ModalDialog = ({
 	actions,
 	children,
 	title,
 	onDismiss,
-}: ModalPanelProps) => {
+}: ModalDialogProps) => {
 	const { titleId } = useModalId();
 
 	const prefersReducedMotion = usePrefersReducedMotion();
@@ -46,7 +46,7 @@ export const ModalPanel = ({
 				padding={1.5}
 				paddingTop={4}
 				gap={1}
-				maxWidth={tokens.maxWidth.modalPanel}
+				maxWidth={tokens.maxWidth.modalDialog}
 				css={{
 					position: 'relative',
 					margin: '0 auto',

--- a/packages/react/src/modal/ModalPanel.tsx
+++ b/packages/react/src/modal/ModalPanel.tsx
@@ -9,8 +9,11 @@ import { ModalTitle } from './ModalTitle';
 import { useModalId } from './utils';
 
 export type ModalPanelProps = PropsWithChildren<{
+	/** The actions to display at the bottom of the modal panel. Typically a `ButtonGroup`. */
 	actions?: ReactNode;
+	/** Function to be called when the modal is closed. */
 	onDismiss: () => void;
+	/** The title of the modal dialog. It can span lines but should not be too long. */
 	title: string;
 }>;
 
@@ -43,7 +46,7 @@ export const ModalPanel = ({
 				padding={1.5}
 				paddingTop={4}
 				gap={1}
-				maxWidth={tokens.maxWidth.bodyText}
+				maxWidth={tokens.maxWidth.modalPanel}
 				css={{
 					position: 'relative',
 					margin: '0 auto',

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Modal renders correctly 1`] = `
       <div
         aria-labelledby="modal-:r0:-title"
         aria-modal="true"
-        class="css-1rzg5w1-boxStyles-ModalPanel"
+        class="css-3106a6-boxStyles-ModalDialog"
         role="dialog"
         style="opacity: 0; transform: translate3d(0,20px,0);"
       >
@@ -41,7 +41,7 @@ exports[`Modal renders correctly 1`] = `
           </p>
         </div>
         <div
-          class="css-1i9i114-boxStyles-ModalPanel"
+          class="css-1kzq3kl-boxStyles-ModalDialog"
         >
           <button
             class="css-3jmmp1-BaseButton-Button"
@@ -61,7 +61,7 @@ exports[`Modal renders correctly 1`] = `
         </div>
         <button
           aria-label="Close modal"
-          class="css-1b8gcds-BaseButton-ModalPanel"
+          class="css-1tn8j9z-BaseButton-ModalDialog"
           type="button"
         >
           <span>


### PR DESCRIPTION
## Describe your changes

### Core 

Added new `modalPanel` max-width token which has a value of 45rem. This value has been calculated by taking the `bodyText` max-width and adding 3rem which is the horizontal padding inside of the modal.

### Modal
 
- Updated max-width of modal dialog
- Renamed `ModalPanel` to `ModalDialog` (internal use only)

## Checklist

- [x] Read and check your code before tagging someone for review.
- [x] Run `yarn format`
- [x] Run `yarn lint` in the root of the repository to ensure tests are passing
- [x] Run `yarn test` to ensure tests are passing. Run `yarn test -u` to update any snapshots tests.
- [x] Add necessary tests
- [x] Run `yarn changeset` to create a changeset file
- [x] Write documentation (README.md)
- [x] Create stories for Storybook