### PR TITLE
docs: fix sidebar warning in `TokenLayout`

### DIFF
--- a/docs/components/TokenLayout.tsx
+++ b/docs/components/TokenLayout.tsx
@@ -25,7 +25,10 @@ export const TokenLayout = ({
 				sideNav={{
 					title: 'Tokens',
 					titleLink: '/foundations/tokens',
-					items: TOKEN_NAV_LINKS,
+					items: TOKEN_NAV_LINKS.map(({ label, href }) => ({
+						href,
+						label,
+					})),
 				}}
 				editPath={editPath}
 				breadcrumbs={breadcrumbs}


### PR DESCRIPTION
## Describe your changes

This PR fixes  a small issue in our `TokenLayout` component.

```
Warning: React does not recognize the `pageTitle` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `pagetitle` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

This issue was happening as we were spreading invalid anchor attributes into each item in the `SideNav`
