### PR TITLE
storybook: Remove padding from fullscreen layouts

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import { Box } from '@ag.ds-next/react/box';
 import { Core } from '@ag.ds-next/react/core';
 import { theme as agriculture } from '@ag.ds-next/react/ag-branding';
 import { LinkComponent } from './components/LinkComponent';
+import { Fragment } from 'react';
 
 function makeViewports() {
 	const viewports = [
@@ -83,7 +84,6 @@ export const globalTypes = {
 };
 
 export const parameters = {
-	layout: 'fullscreen',
 	actions: { argTypesRegex: '^on[A-Z].*' },
 	controls: {
 		matchers: {
@@ -103,17 +103,13 @@ const withBrandTheme: DecoratorFn = (Story, context) => {
 	const theme = getTheme(context.globals.brand);
 	const palette = context.globals.palette;
 	return (
-		<Core theme={theme} linkComponent={LinkComponent}>
-			<Box
-				width="100%"
-				minHeight="100vh"
-				padding={1}
-				palette={palette}
-				background="body"
-			>
-				<Story />
-			</Box>
-		</Core>
+		<Fragment>
+			<Core theme={theme} linkComponent={LinkComponent}>
+				<Box width="100%" minHeight="100vh" palette={palette} background="body">
+					<Story />
+				</Box>
+			</Core>
+		</Fragment>
 	);
 };
 

--- a/.storybook/stories/CardsWithRemoteData.tsx
+++ b/.storybook/stories/CardsWithRemoteData.tsx
@@ -12,6 +12,9 @@ import { VisuallyHidden } from '@ag.ds-next/react/a11y';
 
 export default {
 	title: 'Patterns/Remote data',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 const fetcher = async (url: string) => {

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -66,6 +66,9 @@ import { Combobox } from '@ag.ds-next/react/src/combobox';
 
 export default {
 	title: 'Testing/Kitchen sink',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 const sideNavItems = [

--- a/.storybook/stories/TableWithRemoteData.tsx
+++ b/.storybook/stories/TableWithRemoteData.tsx
@@ -18,6 +18,9 @@ import { VisuallyHidden } from '@ag.ds-next/react/a11y';
 
 export default {
 	title: 'Patterns/Remote data',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 const fetcher = async (url: string) => {

--- a/example-site/components/templates/Category.stories.tsx
+++ b/example-site/components/templates/Category.stories.tsx
@@ -3,6 +3,9 @@ import { Category as CategoryComponent } from './Category';
 
 export default {
 	title: 'Templates/Category',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export function Category() {

--- a/example-site/components/templates/Content.stories.tsx
+++ b/example-site/components/templates/Content.stories.tsx
@@ -3,6 +3,9 @@ import { Content as ContentComponent } from './Content';
 
 export default {
 	title: 'Templates/Content',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export function Basic() {

--- a/example-site/components/templates/Home.stories.tsx
+++ b/example-site/components/templates/Home.stories.tsx
@@ -3,6 +3,9 @@ import { Home as HomeComponent } from './Home';
 
 export default {
 	title: 'Templates/Home',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export function Home() {

--- a/example-site/components/templates/MultiPageForm.stories.tsx
+++ b/example-site/components/templates/MultiPageForm.stories.tsx
@@ -5,6 +5,9 @@ import { MultiPageFormSuccess } from './MultiPageFormSuccess';
 
 export default {
 	title: 'Templates/Multi-page Form',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export const IntroPage = () => {

--- a/example-site/components/templates/NotFound.stories.tsx
+++ b/example-site/components/templates/NotFound.stories.tsx
@@ -3,6 +3,9 @@ import { NotFound as NotFoundComponent } from './NotFound';
 
 export default {
 	title: 'Templates/NotFound',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export const NotFound = () => {

--- a/example-site/components/templates/SignInForm.stories.tsx
+++ b/example-site/components/templates/SignInForm.stories.tsx
@@ -3,6 +3,9 @@ import { SignInFormPage } from './SignInForm';
 
 export default {
 	title: 'Templates/Sign In Form',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export const SignInForm = () => {

--- a/example-site/components/templates/SinglePageForm.stories.tsx
+++ b/example-site/components/templates/SinglePageForm.stories.tsx
@@ -4,6 +4,9 @@ import { SinglePageFormSuccess } from './SinglePageFormSuccess';
 
 export default {
 	title: 'Templates/Single-page Form',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export const FormPage = () => {

--- a/example-site/components/templates/Subcategory.stories.tsx
+++ b/example-site/components/templates/Subcategory.stories.tsx
@@ -3,6 +3,9 @@ import { Subcategory as SubcategoryContent } from './Subcategory';
 
 export default {
 	title: 'Templates/Subcategory',
+	parameters: {
+		layout: 'fullscreen',
+	},
 };
 
 export function Subcategory() {


### PR DESCRIPTION
## Describe your changes

In storybook, individual stories can have one of the following [layout options](https://storybook.js.org/docs/react/configure/story-layout):

- `centered`: center the component horizontally and vertically in the Canvas
- `fullscreen`: allow the component to expand to the full width and height of the Canvas
- `padded`: (default) Add extra padding around the component

We currently use `fullscreen` for everything but add our own padding. I believe this is incorrect as we now have stories where we don't want padding applied, for example in the kitchen sink or in the template stories.

In this PR, I have defaulted back to the `padded` layout param and explicitly added `fullscreen` to the kitchen sink and template stories.

