### PR TITLE
docs: Add hint text to form components

### DIFF
--- a/packages/react/src/control-input/docs/overview.mdx
+++ b/packages/react/src/control-input/docs/overview.mdx
@@ -20,7 +20,7 @@ figmaGalleryNodeId: 12926%3A104981
 - provide disabled options unless unavoidable
 - use horizontal groups.
 
-### Checkbox
+## Checkbox
 
 Check boxes allow users to select one or more items.
 
@@ -28,10 +28,11 @@ Check boxes allow users to select one or more items.
 <ControlGroup label="Example">
 	<Checkbox value="phone">Phone</Checkbox>
 	<Checkbox value="tablet">Tablet</Checkbox>
+	<Checkbox value="tablet">Laptop</Checkbox>
 </ControlGroup>
 ```
 
-### Radio
+## Radio
 
 Radio inputs allow users to select one item at a time.
 
@@ -40,7 +41,6 @@ Radio inputs allow users to select one item at a time.
 	const [value, setValue] = React.useState();
 	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
 	const isChecked = (key) => key === value;
-
 	return (
 		<ControlGroup label="Example">
 			<Radio checked={isChecked('phone')} onChange={handlerForKey('phone')}>
@@ -57,9 +57,11 @@ Radio inputs allow users to select one item at a time.
 };
 ```
 
-### Checkbox block
+## Block
 
-Inline checkbox options can sometimes be difficult to scan. Users may find it challenging to determine with which label the checkbox option corresponds: the one before the checkbox or the one after. Vertical positioning of checkbox, with one choice per line, eliminates this potential cause for confusion.
+Inline options can sometimes be difficult to scan. Users may find it challenging to determine with which label the checkbox option corresponds: the one before the checkbox or the one after.
+
+Vertical stacking of options, with one choice per line, eliminates this potential cause for confusion.
 
 ```jsx live
 <ControlGroup label="Block example" block>
@@ -68,10 +70,6 @@ Inline checkbox options can sometimes be difficult to scan. Users may find it ch
 	<Checkbox value="laptop">Laptop</Checkbox>
 </ControlGroup>
 ```
-
-### Radio block
-
-Vertically stacked radio buttons.
 
 ```jsx live
 () => {
@@ -95,9 +93,33 @@ Vertically stacked radio buttons.
 };
 ```
 
-### Invalid
+## Hint
+
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+
+```jsx live
+<ControlGroup label="Example" hint="Hint text">
+	<Checkbox value="phone">Phone</Checkbox>
+	<Checkbox value="tablet">Tablet</Checkbox>
+	<Checkbox value="laptop">Laptop</Checkbox>
+</ControlGroup>
+```
+
+## Invalid
 
 Use the `invalid` prop to indicate if the user input is invalid (does not validate according to the elements settings).
+
+```jsx live
+<ControlGroup label="Invalid example" message="Please choose an option" invalid>
+	<Checkbox>Phone</Checkbox>
+	<Checkbox>Tablet</Checkbox>
+	<Checkbox>Laptop</Checkbox>
+</ControlGroup>
+```
 
 ```jsx live
 () => {
@@ -125,28 +147,112 @@ Use the `invalid` prop to indicate if the user input is invalid (does not valida
 };
 ```
 
-### Disabled control inputs
+## Required
+
+The `required` prop can be used to indicate that user input is required on the field before a form can be submitted.
+
+Using the `required` prop, this component will automatically append "(optional)" to the label as well as using [aria-required](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) to indicate to screen reader user that the field is required.
+
+### Hide optional label
+
+The `hideOptionalLabel` prop can be used in situations where you want to indiciate to screen reader users that a field is optional but don't want to show the "(optional)" label.
+
+The usage of `hideOptionalLabel` should be reserved for inputs that filter data in a table or chart, and should never be used in standard forms for submitting information.
+
+```jsx live
+<Stack gap={1}>
+	<ControlGroup label="Required" required>
+		<Checkbox value="phone">Phone</Checkbox>
+	</ControlGroup>
+	<ControlGroup label="Optional" required={false}>
+		<Checkbox value="phone">Phone</Checkbox>
+	</ControlGroup>
+	<ControlGroup
+		label="Optional with hideOptionalLabel"
+		required={false}
+		hideOptionalLabel={true}
+	>
+		<Checkbox value="phone">Phone</Checkbox>
+	</ControlGroup>
+</Stack>
+```
+
+## Disabled control inputs
 
 Disabled control inputs can be used to indicate inputs that are no longer valid or expired.
 
 ```jsx live
 <ControlGroup label="Disabled example">
-	<Radio checked={false} disabled>
+	<Checkbox value="phone" disabled>
 		Phone
-	</Radio>
-	<Radio checked={true} disabled>
+	</Checkbox>
+	<Checkbox value="tablet" checked disabled>
 		Tablet
-	</Radio>
+	</Checkbox>
+	<Checkbox value="laptop" disabled>
+		Laptop
+	</Checkbox>
 </ControlGroup>
 ```
 
-### Small inputs
+```jsx live
+<ControlGroup label="Disabled example">
+	<Radio disabled>Phone</Radio>
+	<Radio checked disabled>
+		Tablet
+	</Radio>
+	<Radio disabled>Laptop</Radio>
+</ControlGroup>
+```
+
+## Small control inputs
 
 Smaller versions of control inputs.
 
 ```jsx live
 <ControlGroup label="Small example">
-	<Checkbox size="sm">Phone</Checkbox>
-	<Checkbox size="sm">Tablet</Checkbox>
+	<Checkbox size="sm" value="phone">
+		Phone
+	</Checkbox>
+	<Checkbox size="sm" value="tablet">
+		Tablet
+	</Checkbox>
+	<Checkbox size="sm" value="laptop">
+		Laptop
+	</Checkbox>
 </ControlGroup>
+```
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState();
+	const handlerForKey = React.useCallback((key) => () => setValue(key), []);
+	const isChecked = (key) => key === value;
+
+	return (
+		<ControlGroup label="Small example">
+			<Radio
+				checked={isChecked('phone')}
+				onChange={handlerForKey('phone')}
+				size="sm"
+			>
+				Phone
+			</Radio>
+			<Radio
+				checked={isChecked('tablet')}
+				onChange={handlerForKey('tablet')}
+				size="sm"
+			>
+				Tablet
+			</Radio>
+			<Radio
+				checked={isChecked('laptop')}
+				onChange={handlerForKey('laptop')}
+				size="sm"
+			>
+				Laptop
+			</Radio>
+		</ControlGroup>
+	);
+};
 ```

--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -7,7 +7,7 @@ storybookPath: /story/forms-field--basic
 
 ## Default
 
-The field component connects the label, description, and message to the input element.
+The field component connects the label, description and message to the input element.
 
 ```jsx live
 <Field label="Name">{(a11yProps) => <input {...a11yProps} />}</Field>
@@ -15,7 +15,7 @@ The field component connects the label, description, and message to the input el
 
 ## Label
 
-Each text field must be accompanied by a label. Effective form labeling helps users understand what information to enter into a text input.
+Each field must be accompanied by a label. Effective form labeling helps users understand what information to enter into the input.
 
 ```jsx live
 <Field label="Name">{(a11yProps) => <input {...a11yProps} />}</Field>
@@ -35,7 +35,7 @@ Don't include links within hint text. While screen readers will read out the lin
 </Field>
 ```
 
-## Messages
+## Invalid
 
 Error messages are used to notify the user when a form field has not passed validation. Use clear messages to explain what went wrong and how to fix it.
 

--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -23,7 +23,11 @@ Each text field must be accompanied by a label. Effective form labeling helps us
 
 ## Hint
 
-Hints can be used to provide more context that will help the user successfully complete the form field.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <Field label="Email" hint="We will only use this to respond to your question">

--- a/packages/react/src/file-input/docs/overview.mdx
+++ b/packages/react/src/file-input/docs/overview.mdx
@@ -9,10 +9,19 @@ figmaGalleryNodeId: 16180%3A41550
 A simple input for selecting files in a form. The `FileInput` component is a wrapper around the native `<input type="file" />` element. Use when you require multiple files in a form, which must be associated as seperate fields. If you only require a single file, use the [FileUpload](/components/file-upload) component instead.
 
 ```jsx live
-<FormStack>
-	<FileInput label="Drivers license" required />
-	<FileInput label="Passport" required />
-</FormStack>
+<FileInput label="Passport" />
+```
+
+## Hint
+
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
+
+```jsx live
+<FileInput label="Passport" hint="Hint text" />
 ```
 
 ## Required

--- a/packages/react/src/search-input/docs/overview.mdx
+++ b/packages/react/src/search-input/docs/overview.mdx
@@ -28,12 +28,16 @@ By default, the `SearchInput` component does not expand to fill the available sp
 - hide the search icon or clear button
 - use for global site search - use SearchBox.
 
-## Block
+## Hint
 
-Use the `block` prop to expand the component to fill the available space.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
-<SearchInput label="Search" block />
+<SearchInput label="Search" hint="Hint text" />
 ```
 
 ## Required
@@ -78,4 +82,12 @@ Disabled input elements are unusable and can not be clicked. This prevents a use
 
 ```jsx live
 <SearchInput label="Search" disabled />
+```
+
+## Block
+
+Use the `block` prop to expand the component to fill the available space.
+
+```jsx live
+<SearchInput label="Search" block />
 ```

--- a/packages/react/src/select/docs/overview.mdx
+++ b/packages/react/src/select/docs/overview.mdx
@@ -37,20 +37,24 @@ By default, the `Select` component does not expand to fill the available space.
 - use for small lists – use Radio input
 - use for long lists – consider using Combobox.
 
-## Block
+## Hint
 
-Use the `block` prop to expand the component to fill the available space.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
 <Select
 	label="What option?"
+	hint="Hint text"
 	placeholder="Please select"
 	options={[
 		{ value: 'a', label: 'Option A' },
 		{ value: 'b', label: 'Option B' },
 		{ value: 'c', label: 'Option C' },
 	]}
-	block
 />
 ```
 
@@ -213,4 +217,21 @@ The small size is reserved for use cases where the value is no more than 3 chara
 		]}
 	/>
 </Stack>
+```
+
+## Block
+
+Use the `block` prop to expand the component to fill the available space.
+
+```jsx live
+<Select
+	label="What option?"
+	placeholder="Please select"
+	options={[
+		{ value: 'a', label: 'Option A' },
+		{ value: 'b', label: 'Option B' },
+		{ value: 'c', label: 'Option C' },
+	]}
+	block
+/>
 ```

--- a/packages/react/src/text-input/docs/overview.mdx
+++ b/packages/react/src/text-input/docs/overview.mdx
@@ -27,12 +27,16 @@ By default, the `TextInput` component does not expand to fill the available spac
 - hide the 'optional' label within a form
 - use placeholder text as a substitute for a label.
 
-## Block
+## Hint
 
-Use the `block` prop to expand the component to fill the available space.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
-<TextInput label="Name" block />
+<TextInput label="Name" hint="Hint text" />
 ```
 
 ## Required
@@ -89,4 +93,12 @@ As an example, input fields for postcodes should have a smaller width than field
 	<TextInput label="lg input" maxWidth="lg" />
 	<TextInput label="xl input" maxWidth="xl" />
 </Stack>
+```
+
+## Block
+
+Use the `block` prop to expand the component to fill the available space.
+
+```jsx live
+<TextInput label="Name" block />
 ```

--- a/packages/react/src/textarea/docs/overview.mdx
+++ b/packages/react/src/textarea/docs/overview.mdx
@@ -28,12 +28,16 @@ By default, the `Textarea` component does not expand to fill the available space
 - use when a specific value is needed
 - use for inputs that expect a single value or a couple of words.
 
-## Block
+## Hint
 
-Use the `block` prop to expand the component to fill the available space.
+Use the `hint` prop to provide help that’s relevant to the majority of users, like how their information will be used, or where to find it.
+
+Don't use long paragraphs and lists in hint text. Screen readers read out the entire text when users interact with the form element. This could frustrate users if the text is long.
+
+Don't include links within hint text. While screen readers will read out the link text when describing the field, they will not tell users that the text is a link.
 
 ```jsx live
-<Textarea label="Message" block />
+<Textarea label="Message" hint="Hint text" />
 ```
 
 ## Required
@@ -86,4 +90,12 @@ The maximum width of a textarea should indicate the amount of information expect
 	<Textarea label="lg textarea" maxWidth="lg" />
 	<Textarea label="xl textarea" maxWidth="xl" />
 </Stack>
+```
+
+## Block
+
+Use the `block` prop to expand the component to fill the available space.
+
+```jsx live
+<Textarea label="Message" block />
 ```


### PR DESCRIPTION
## Describe your changes

- Added a section about hint text to form component documentation pages
- Where applicable, moved the `block` prop documentation section to the bottom of the page. This prop isnt very widely used, so having it first on the page doesn't really make sense.
- Improved `ControlInput` documentation while I was there, as it was a bit outdated.