### PR TITLE
file-input: Update button size

### DIFF
--- a/.changeset/clever-zoos-wash.md
+++ b/.changeset/clever-zoos-wash.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+file-input: Update button size

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -70,7 +70,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 export const fileInputStyles = ({ invalid }: { invalid?: boolean }) =>
 	({
 		'::file-selector-button': {
-			...buttonStyles({ size: 'sm', variant: 'secondary', block: false }),
+			...buttonStyles({ size: 'md', variant: 'secondary', block: false }),
 			margin: undefined,
 		},
 

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, InputHTMLAttributes } from 'react';
 import { Field } from '../field';
-import { packs, boxPalette } from '../core';
+import { packs, boxPalette, fontGrid, mapSpacing, tokens } from '../core';
 import { buttonStyles } from '../button';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
@@ -69,9 +69,13 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 
 export const fileInputStyles = ({ invalid }: { invalid?: boolean }) =>
 	({
+		...fontGrid('sm', 'default'),
+		fontFamily: tokens.font.body,
+		color: boxPalette.foregroundText,
+
 		'::file-selector-button': {
 			...buttonStyles({ size: 'md', variant: 'secondary', block: false }),
-			margin: undefined,
+			margin: `0 ${mapSpacing(1)} 0 0`,
 		},
 
 		...(invalid && {

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-14j1aky-Field"
+      class="css-1hjj1fi-Field"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-1l83kgv-Field"
+      class="css-14j1aky-Field"
       id="field-:r0:"
       type="file"
     />


### PR DESCRIPTION
## Describe your changes

Updated the "Upload file" button size from `sm` to `md` as per design review session.

<img width="829" alt="Screen Shot 2023-02-23 at 11 27 52 am" src="https://user-images.githubusercontent.com/6265154/220801797-092db8a9-55c4-4b6d-a7b2-4927d7f2696a.png">


## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file