### PR TITLE
field: Added `className` prop to `FieldLabel`

### DIFF
--- a/.changeset/pink-cats-kneel.md
+++ b/.changeset/pink-cats-kneel.md
@@ -4,3 +4,4 @@
 
 - field: Added `className` prop to `FieldLabel`
 - field: Fixed typos in hook `useScrollToField`
+- field: Exported component props and added comments to props.

--- a/.changeset/pink-cats-kneel.md
+++ b/.changeset/pink-cats-kneel.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/react': patch
+---
+
+- field: Added `className` prop to `FieldLabel`
+- field: Fixed typos in hook `useScrollToField`

--- a/packages/react/src/field/Field.test.tsx
+++ b/packages/react/src/field/Field.test.tsx
@@ -139,8 +139,8 @@ describe('Field', () => {
 		describe('Optional', () => {
 			it('renders correctly', () => {
 				renderField({ label, required: false });
-				const labelEl = document.querySelector('label');
-				expect(labelEl?.textContent).toBe('Name(optional)');
+				const labelEl = getLabelElement();
+				expect(labelEl.textContent).toBe(`${label}(optional)`);
 			});
 			it('renders correctly when optional label is hidden', () => {
 				renderField({
@@ -148,15 +148,16 @@ describe('Field', () => {
 					required: false,
 					hideOptionalLabel: true,
 				});
-				const labelEl = document.querySelector('label');
-				expect(labelEl?.textContent).toBe('Name');
+				const labelEl = getLabelElement();
+				expect(labelEl.textContent).toBe(label);
 			});
 		});
+
 		describe('Required', () => {
 			it('renders correctly', () => {
 				renderField({ label, required: true });
-				const labelEl = document.querySelector('label');
-				expect(labelEl?.textContent).toBe('Name');
+				const labelEl = getLabelElement();
+				expect(labelEl.textContent).toBe(label);
 			});
 			it('renders correctly when optional label is hidden', () => {
 				renderField({
@@ -164,8 +165,17 @@ describe('Field', () => {
 					required: false,
 					hideOptionalLabel: true,
 				});
-				const labelEl = document.querySelector('label');
-				expect(labelEl?.textContent).toBe('Name');
+				const labelEl = getLabelElement();
+				expect(labelEl.textContent).toBe('Name');
+			});
+		});
+
+		describe('Secondary Label', () => {
+			it('renders correctly', () => {
+				const secondaryLabel = '(dd/mm/yyy)';
+				renderField({ label, secondaryLabel });
+				const labelEl = getLabelElement();
+				expect(labelEl.textContent).toBe(`${label}${secondaryLabel}`);
 			});
 		});
 	});
@@ -174,9 +184,10 @@ describe('Field', () => {
 		it('renders correctly', () => {
 			renderField({ label, hint });
 			const hintEl = screen.getByText(hint);
-			const inputEl = getInputElement();
 			expect(hintEl).toBeInTheDocument();
+			expect(hintEl).toBeInstanceOf(HTMLSpanElement);
 			expect(hintEl).toHaveTextContent(hint);
+			const inputEl = getInputElement();
 			expect(inputEl.getAttribute('aria-describedby')).toBe(hintEl.id);
 		});
 	});
@@ -185,10 +196,17 @@ describe('Field', () => {
 		it('renders correctly', () => {
 			renderField({ label, message, invalid: true });
 			const messageEl = screen.getByText(message);
-			const inputEl = getInputElement();
 			expect(messageEl).toBeInTheDocument();
+			expect(messageEl).toBeInstanceOf(HTMLSpanElement);
 			expect(messageEl).toHaveTextContent(message);
+			const inputEl = getInputElement();
 			expect(inputEl.getAttribute('aria-describedby')).toBe(messageEl.id);
+		});
+
+		it('does not render when invalid is false', () => {
+			renderField({ label, message, invalid: false });
+			const messageEl = screen.queryByText(message);
+			expect(messageEl).not.toBeInTheDocument();
 		});
 	});
 });

--- a/packages/react/src/field/FieldContainer.tsx
+++ b/packages/react/src/field/FieldContainer.tsx
@@ -3,7 +3,9 @@ import { Stack } from '../box';
 import { boxPalette } from '../core';
 
 export type FieldContainerProps = PropsWithChildren<{
+	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
+	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
 }>;
 

--- a/packages/react/src/field/FieldHint.tsx
+++ b/packages/react/src/field/FieldHint.tsx
@@ -1,12 +1,12 @@
+import { PropsWithChildren } from 'react';
 import { Text } from '../text';
 
-export const FieldHint = ({
-	children,
-	id,
-}: {
-	children: string;
-	id?: string;
-}) => (
+export type FieldHintProps = PropsWithChildren<{
+	/** Defines an identifier (ID) which must be unique. */
+	id: string;
+}>;
+
+export const FieldHint = ({ children, id }: FieldHintProps) => (
 	<Text display="block" color="muted" id={id}>
 		{children}
 	</Text>

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -26,8 +26,8 @@ export const FieldLabel = ({
 	hideOptionalLabel,
 }: FieldLabelProps) => {
 	const secondaryLabel = useMemo(() => {
-		if (secondaryLabelProp) return secondaryLabelProp;
 		if (hideOptionalLabel) return null;
+		if (secondaryLabelProp) return secondaryLabelProp;
 		if (!required) return `(optional)`;
 	}, [required, secondaryLabelProp, hideOptionalLabel]);
 	return (

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -4,27 +4,34 @@ import { Text } from '../text';
 
 export type FieldLabelProps = PropsWithChildren<{
 	as?: ElementType;
+	/** The ID of the form element this label relates to. */
 	htmlFor?: string;
+	/** The CSS class name, typically generated from the `css` prop. */
+	className?: string;
+	/** If false, "(optional)" will be appended to the label. */
 	required: boolean;
-	secondaryLabel?: string;
+	/** If true, "(optional)" will never be appended to the label even when `required` is `false`. */
 	hideOptionalLabel?: boolean;
+	/** Override the default secondary label. */
+	secondaryLabel?: string;
 }>;
 
 export const FieldLabel = ({
 	as = 'label',
 	children,
+	className,
 	htmlFor,
 	required,
 	secondaryLabel: secondaryLabelProp,
 	hideOptionalLabel,
 }: FieldLabelProps) => {
 	const secondaryLabel = useMemo(() => {
-		if (hideOptionalLabel) return null;
 		if (secondaryLabelProp) return secondaryLabelProp;
+		if (hideOptionalLabel) return null;
 		if (!required) return `(optional)`;
 	}, [required, secondaryLabelProp, hideOptionalLabel]);
 	return (
-		<Flex as={as} htmlFor={htmlFor} gap={0.25}>
+		<Flex as={as} htmlFor={htmlFor} gap={0.25} className={className}>
 			<Text as="span" fontWeight="bold">
 				{children}
 			</Text>

--- a/packages/react/src/field/FieldMessage.tsx
+++ b/packages/react/src/field/FieldMessage.tsx
@@ -1,14 +1,14 @@
+import { PropsWithChildren } from 'react';
 import { Box, Flex } from '../box';
 import { AlertFilledIcon } from '../icon';
 import { Text } from '../text';
 
-export const FieldMessage = ({
-	children,
-	id,
-}: {
-	children: string;
+export type FieldMessageProps = PropsWithChildren<{
+	/** Defines an identifier (ID) which must be unique. */
 	id: string;
-}) => (
+}>;
+
+export const FieldMessage = ({ children, id }: FieldMessageProps) => (
 	<Flex gap={0.5} alignItems="center">
 		<Box flexShrink={0}>
 			<AlertFilledIcon

--- a/packages/react/src/field/useScrollToField.ts
+++ b/packages/react/src/field/useScrollToField.ts
@@ -12,7 +12,7 @@ export function useScrollToField() {
 function focusTarget(event: MouseEvent<HTMLAnchorElement>) {
 	const target = event.target;
 	if (!(target instanceof HTMLAnchorElement)) return false;
-	// Atempt to the find target ID from the anchor tag href
+	// Attempt to the find target ID from the anchor tag href
 	const targetId = getTargetId(event);
 	if (!targetId) return false;
 	// Attempt to find the target element using the target Id
@@ -24,7 +24,7 @@ function focusTarget(event: MouseEvent<HTMLAnchorElement>) {
 		// If the target element is a div (e.g. a `ControlGroup`), focus the first child input
 		targetEl.querySelector('input')?.focus();
 	} else {
-		// Othwerise, focus the target element
+		// Otherwise, focus the target element
 		targetEl.focus();
 	}
 	// Scroll the field container into view if possible, otherwise fallback to scrolling to the target


### PR DESCRIPTION
## Describe your changes

This PR has come from the work that I have been doing over in PR #997. We need to be able to able to add a `className` to the `FieldLabel` element so I have done this as as a seperate PR. While I was touching these files, I made a few minor improvements which have included:

- Fixed typos in hook `useScrollToField`
- Exported component types and added prop comments
- Improved tests

## Checklist

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
