### PR TITLE
Kitchen sink: Use page-template. Add background control

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,10 +2,6 @@
 
 Include screenshots, photos or links if necessary.
 
-> Please update this link with the PR number and story path.
-
-[See changes in Storybook](https://design-system.agriculture.gov.au/pr-preview/pr-XXX/storybook/index.html?path=/story/testing-kitchen-sink--kitchen-sink)
-
 ## Checklist
 
 ### Updating existing component

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 Include screenshots, photos or links if necessary.
 
+> Please update this link with the PR number and story path.
+
+[See changes in Storybook](https://design-system.agriculture.gov.au/pr-preview/pr-XXX/storybook/index.html?path=/story/testing-kitchen-sink--kitchen-sink)
+
 ## Checklist
 
 ### Updating existing component

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -69,7 +69,7 @@ import { SearchInput } from '@ag.ds-next/react/search-input';
 import { PageTemplate } from '../components/PageTemplate';
 
 export default {
-	title: 'Testing/Kitchen Sink',
+	title: 'Testing/Kitchen sink',
 	parameters: {
 		layout: 'fullscreen',
 	},
@@ -532,6 +532,7 @@ export const KitchenSink = ({
 		</PageTemplate>
 	);
 };
+KitchenSink.storyName = 'Kitchen sink';
 KitchenSink.args = {
 	background: 'body',
 };

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -10,7 +10,7 @@ import {
 	SearchBoxButton,
 	SearchBoxInput,
 } from '@ag.ds-next/react/search-box';
-import { Box, Flex, Stack } from '@ag.ds-next/react/box';
+import { Flex, Stack } from '@ag.ds-next/react/box';
 import { Breadcrumbs } from '@ag.ds-next/react/breadcrumbs';
 import { Button, ButtonGroup } from '@ag.ds-next/react/button';
 import { Callout } from '@ag.ds-next/react/callout';
@@ -40,12 +40,6 @@ import { Text } from '@ag.ds-next/react/text';
 import { Textarea } from '@ag.ds-next/react/textarea';
 import { TextInput } from '@ag.ds-next/react/text-input';
 import { DatePicker } from '@ag.ds-next/react/date-picker';
-import { Header } from '@ag.ds-next/react/header';
-import { Logo } from '@ag.ds-next/react/ag-branding';
-import { MainNav } from '@ag.ds-next/react/main-nav';
-import { Footer, FooterDivider } from '@ag.ds-next/react/footer';
-import { LinkList } from '@ag.ds-next/react/link-list';
-import { tokens } from '@ag.ds-next/react/core';
 import {
 	HeroBanner,
 	HeroBannerSubtitle,
@@ -63,7 +57,6 @@ import {
 	TableBody,
 } from '@ag.ds-next/react/table';
 import { TextLink } from '@ag.ds-next/react/text-link';
-import { AvatarIcon } from '@ag.ds-next/react/icon';
 import { Autocomplete } from '@ag.ds-next/react/src/autocomplete/Autocomplete';
 import { Combobox } from '@ag.ds-next/react/src/combobox';
 import {
@@ -73,11 +66,18 @@ import {
 	SummaryListItemTerm,
 } from '@ag.ds-next/react/summary-list';
 import { SearchInput } from '@ag.ds-next/react/search-input';
+import { PageTemplate } from '../components/PageTemplate';
 
 export default {
-	title: 'Testing/Kitchen sink',
+	title: 'Testing/Kitchen Sink',
 	parameters: {
 		layout: 'fullscreen',
+	},
+	argTypes: {
+		bg: {
+			options: ['body', 'bodyAlt'],
+			control: { type: 'radio' },
+		},
 	},
 };
 
@@ -102,43 +102,26 @@ const sideNavItems = [
 
 const backgroundMapper = {
 	body: {
+		page: 'body',
 		shade: 'shade',
 		opposite: 'bodyAlt',
 	},
 	bodyAlt: {
+		page: 'bodyAlt',
 		shade: 'shadeAlt',
 		opposite: 'body',
 	},
 } as const;
 
-const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
-	const backgroundSet = backgroundMapper[background];
+export const KitchenSink = ({
+	background,
+}: {
+	background: 'body' | 'bodyAlt';
+}) => {
+	const { page, shade, opposite } = backgroundMapper[background];
 	return (
-		<Box background={background}>
-			<Stack palette="dark">
-				<Header
-					background="bodyAlt"
-					logo={<Logo />}
-					heading="Export Service"
-					subline="Supporting Australian agricultural exports"
-				/>
-				<MainNav
-					id="main-nav"
-					activePath="#home"
-					items={[
-						{ label: 'Home', href: '#home' },
-						{ label: 'Category', href: '#category' },
-					]}
-					secondaryItems={[
-						{
-							label: 'Sign in',
-							href: '#sign-in',
-							endElement: <AvatarIcon color="action" />,
-						},
-					]}
-				/>
-			</Stack>
-			<HeroBanner background={backgroundSet.opposite}>
+		<PageTemplate background={page}>
+			<HeroBanner background={opposite}>
 				<HeroBannerTitleContainer>
 					<HeroBannerTitle>
 						Website hero banner title - xxxl/display (H1)
@@ -160,7 +143,7 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 					<Column columnSpan={{ xs: 12, md: 4 }}>
 						<Stack gap={2}>
 							<SideNav
-								background={background}
+								background={page}
 								title="Lodging your tax return"
 								titleLink="#"
 								collapseTitle="In this section"
@@ -168,7 +151,7 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 								activePath="#in-detail/record-keeping/incorrect-amounts"
 							/>
 							<ProgressIndicator
-								background={background}
+								background={page}
 								items={[
 									{ href: '#', label: 'Introduction', status: 'doing' },
 									{ href: '#', label: 'Business Contacts', status: 'todo' },
@@ -181,7 +164,7 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 					<Column columnSpan={{ xs: 12, md: 8 }}>
 						<Stack gap={2}>
 							<SubNav
-								background={background}
+								background={page}
 								activePath="#usage"
 								links={[
 									{ href: '#usage', label: 'Usage' },
@@ -255,12 +238,12 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 								tortor eu, finibus lacinia libero.
 							</Text>
 
-							<Callout title="Callout heading" background={backgroundSet.shade}>
+							<Callout title="Callout heading" background={shade}>
 								<Text as="p">Description of the callout.</Text>
 							</Callout>
 
 							<Accordion>
-								<AccordionItem title="Accordion One" background={background}>
+								<AccordionItem title="Accordion One" background={page}>
 									<AccordionItemContent>
 										<Text as="p">
 											Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -277,7 +260,7 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 										</Text>
 									</AccordionItemContent>
 								</AccordionItem>
-								<AccordionItem title="Accordion Two" background={background}>
+								<AccordionItem title="Accordion Two" background={page}>
 									<AccordionItemContent>
 										<Text as="p">
 											Lorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -546,48 +529,9 @@ const KitchenSink = ({ background }: { background: 'body' | 'bodyAlt' }) => {
 					</Column>
 				</Columns>
 			</PageContent>
-			<Box palette="dark">
-				<Footer background="bodyAlt">
-					<nav aria-label="footer">
-						<LinkList
-							links={[
-								{ label: 'Home', href: '/' },
-								{
-									label: 'Storybook',
-									href: 'https://design-system.agriculture.gov.au/storybook/index.html',
-								},
-								{
-									label: 'Playroom',
-									href: 'https://design-system.agriculture.gov.au/playroom/index.html',
-								},
-								{
-									label: 'Starter kit',
-									href: 'https://github.com/steelthreads/agds-starter-kit',
-								},
-							]}
-							horizontal
-						/>
-					</nav>
-					<FooterDivider />
-					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-						We acknowledge the traditional owners of country throughout
-						Australia and recognise their continuing connection to land, waters
-						and culture. We pay our respects to their Elders past, present and
-						emerging.
-					</Text>
-					<Text fontSize="xs" maxWidth={tokens.maxWidth.bodyText}>
-						&copy; 2022 Department of Agriculture, Fisheries and Forestry
-					</Text>
-				</Footer>
-			</Box>
-		</Box>
+		</PageTemplate>
 	);
 };
-
-export const BodyBackground = () => {
-	return <KitchenSink background="body" />;
-};
-
-export const BodyAltBackground = () => {
-	return <KitchenSink background="bodyAlt" />;
+KitchenSink.args = {
+	background: 'body',
 };

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -74,7 +74,7 @@ export default {
 		layout: 'fullscreen',
 	},
 	argTypes: {
-		bg: {
+		background: {
 			options: ['body', 'bodyAlt'],
 			control: { type: 'radio' },
 		},


### PR DESCRIPTION
## Describe your changes

- Use the page template component which is defined in the .storybook directory
- Make Storybook controls for the background colours
- Have a single 'default' story for Kitchen sink (no more child stories)
<img width="218" alt="image" src="https://user-images.githubusercontent.com/12689383/224261662-9c098779-2832-47bd-8978-f7f5268d45a6.png">


## Checklist

### Updating existing component

- [ ] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
