### PR TITLE
date-picker: Removed `placeholder` prop, updated `maxWidth` options

### DIFF
--- a/.changeset/sixty-pants-flow.md
+++ b/.changeset/sixty-pants-flow.md
@@ -2,4 +2,7 @@
 '@ag.ds-next/react': minor
 ---
 
-date-picker: Removed unused and undocumented props `placeholder` and `maxWidth`
+Date picker
+
+- Removed unused prop `placeholder` 
+- Removed options `xs` and `sm` from `maxWidth` prop. These widths were too small to be used in this component.

--- a/.changeset/sixty-pants-flow.md
+++ b/.changeset/sixty-pants-flow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+date-picker: Removed unused and undocumented props `placeholder` and `maxWidth`

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -87,6 +87,7 @@ export const DatePicker = ({
 	yearRange,
 	inputRef,
 	invalid = false,
+	maxWidth = 'md',
 	...props
 }: DatePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
@@ -181,6 +182,7 @@ export const DatePicker = ({
 		<div ref={setRefEl}>
 			<DateInput
 				{...props}
+				maxWidth={maxWidth}
 				invalid={{ field: invalid, input: invalid }}
 				ref={inputRef}
 				value={inputValue}

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -1,5 +1,6 @@
 import {
 	ChangeEvent,
+	InputHTMLAttributes,
 	Ref,
 	useCallback,
 	useEffect,
@@ -11,7 +12,7 @@ import { usePopper } from 'react-popper';
 import { SelectSingleEventHandler } from 'react-day-picker';
 import { useClickOutside, useTernaryState } from '../core';
 import { CalendarSingle } from './Calendar';
-import { DateInput, DateInputProps } from './DatePickerInput';
+import { DateInput } from './DatePickerInput';
 import {
 	parseDate,
 	formatDate,
@@ -19,10 +20,34 @@ import {
 	transformValuePropToInputValue,
 } from './utils';
 
-type DatePickerInputProps = Omit<
-	DateInputProps,
-	'value' | 'onChange' | 'buttonRef' | 'buttonOnClick' | 'invalid'
->;
+type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
+
+type BaseTextInputProps = {
+	autoComplete?: NativeInputProps['autoComplete'];
+	autoFocus?: NativeInputProps['autoFocus'];
+	disabled?: NativeInputProps['disabled'];
+	id?: NativeInputProps['id'];
+	name?: NativeInputProps['name'];
+	onBlur?: NativeInputProps['onBlur'];
+	onFocus?: NativeInputProps['onFocus'];
+};
+
+export type DatePickerInputProps = BaseTextInputProps & {
+	/** Describes the purpose of the field. */
+	label: string;
+	/** If true, "(optional)" will never be appended to the label. */
+	hideOptionalLabel?: boolean;
+	/** If false, "(optional)" will be appended to the label. */
+	required?: boolean;
+	/** Provides extra information about the field. */
+	hint?: string;
+	/** Message to show when the field is invalid. */
+	message?: string;
+	/** If true, the invalid state will be rendered. */
+	invalid?: boolean;
+	/** If true, the field will stretch to the fill the width of its container. */
+	block?: boolean;
+};
 
 type DatePickerCalendarProps = {
 	/** If set, any days before this date will not be selectable. */
@@ -44,8 +69,6 @@ type DatePickerBaseProps = {
 	onInputChange?: (inputValue: string) => void;
 	/** Ref to the input element. */
 	inputRef?: Ref<HTMLInputElement>;
-	/** If true, the invalid state will be rendered. */
-	invalid?: boolean;
 };
 
 export type DatePickerProps = DatePickerInputProps &

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import { usePopper } from 'react-popper';
 import { SelectSingleEventHandler } from 'react-day-picker';
-import { useClickOutside, useTernaryState } from '../core';
+import { FieldMaxWidth, useClickOutside, useTernaryState } from '../core';
 import { CalendarSingle } from './Calendar';
 import { DateInput } from './DatePickerInput';
 import {
@@ -47,6 +47,8 @@ export type DatePickerInputProps = BaseTextInputProps & {
 	invalid?: boolean;
 	/** If true, the field will stretch to the fill the width of its container. */
 	block?: boolean;
+	/** The maximum width of the field. */
+	maxWidth?: Extract<FieldMaxWidth, 'md' | 'lg' | 'xl'>;
 };
 
 type DatePickerCalendarProps = {

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -7,10 +7,7 @@ import { Button } from '../button';
 import { Field } from '../field';
 import { parseDate, formatHumanReadableDate } from './utils';
 
-export type DateInputProps = Omit<
-	TextInputProps,
-	'inputMode' | 'pattern' | 'type' | 'invalid'
-> & {
+export type DateInputProps = Omit<TextInputProps, 'invalid'> & {
 	invalid: {
 		/** If true, the entire field will be rendered in an invalid state.  */
 		field: boolean;


### PR DESCRIPTION
## Describe your changes

### Date picker prop type updates

- Removed unused prop `placeholder` 
- Removed options `xs` and `sm` from `maxWidth` prop. These widths were too small to be used in this component.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).