### PR TITLE
box: Updated `palette` prop to accept responsive values

### DIFF
--- a/.changeset/lovely-gorillas-care.md
+++ b/.changeset/lovely-gorillas-care.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+box: Updated the `palette` prop to accept responsive values. For example `<Box palette={["dark", "light"]} />`.

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -16,16 +16,37 @@ import {
 	FontSize,
 	LineHeight,
 	Font,
+	breakpointNames,
 } from '../core';
 
 type PaletteProps = Partial<{
-	palette: BoxPalette;
+	palette: ResponsiveProp<BoxPalette>;
 	dark: boolean;
 	light: boolean;
 }>;
 
 function paletteStyles({ palette, dark, light }: PaletteProps) {
-	if (palette) return boxPalettes[palette];
+	if (palette) {
+		// If the palette prop is a string, nothing special is required
+		if (typeof palette === 'string') return boxPalettes[palette];
+
+		// Convert the prop to an array matching the breakpoints
+		const mappedResponsiveProp = mapResponsiveProp(palette) as BoxPalette[];
+
+		return [
+			boxPalettes[mappedResponsiveProp[0]],
+			Object.fromEntries(
+				breakpointNames
+					.filter((name) => name !== 'xs')
+					.map((name, idx) => {
+						return [
+							tokens.mediaQuery.min[name],
+							boxPalettes[mappedResponsiveProp[idx]],
+						];
+					})
+			),
+		];
+	}
 	if (dark) return boxPalettes.dark;
 	if (light) return boxPalettes.light;
 }
@@ -429,7 +450,6 @@ export function boxStyles({
 	return [
 		css([
 			paletteStyles({ palette, dark, light }),
-
 			// common resets
 			{
 				boxSizing: 'border-box',
@@ -437,7 +457,6 @@ export function boxStyles({
 				margin: 0,
 				padding: 0,
 			},
-
 			mq({
 				...colorStyles({ background, color }),
 

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -27,23 +27,24 @@ type PaletteProps = Partial<{
 
 function paletteStyles({ palette, dark, light }: PaletteProps) {
 	if (palette) {
-		// If the palette prop is a string, nothing special is required
+		// If the `palette` prop is a string, nothing special is required
 		if (typeof palette === 'string') return boxPalettes[palette];
 
-		// Convert the prop to an array matching the breakpoints
-		const mappedResponsiveProp = mapResponsiveProp(palette) as BoxPalette[];
+		// Use the `mapResponsiveProp` utility to convert the prop to an array matching each named breakpoints
+		const [xsBreakpointPalette, ...breakpointPalettes] = mapResponsiveProp(
+			palette
+		) as BoxPalette[];
 
+		// The first item in the array does not need a media query since it is for devices larger than 0px
 		return [
-			boxPalettes[mappedResponsiveProp[0]],
+			boxPalettes[xsBreakpointPalette],
 			Object.fromEntries(
 				breakpointNames
 					.filter((name) => name !== 'xs')
-					.map((name, idx) => {
-						return [
-							tokens.mediaQuery.min[name],
-							boxPalettes[mappedResponsiveProp[idx]],
-						];
-					})
+					.map((name, idx) => [
+						tokens.mediaQuery.min[name],
+						boxPalettes[breakpointPalettes[idx]],
+					])
 			),
 		];
 	}

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -450,6 +450,7 @@ export function boxStyles({
 	return [
 		css([
 			paletteStyles({ palette, dark, light }),
+
 			// common resets
 			{
 				boxSizing: 'border-box',
@@ -457,6 +458,7 @@ export function boxStyles({
 				margin: 0,
 				padding: 0,
 			},
+
 			mq({
 				...colorStyles({ background, color }),
 

--- a/packages/react/src/core/responsive.ts
+++ b/packages/react/src/core/responsive.ts
@@ -19,7 +19,7 @@ export const mq = facepaint([
 ]);
 
 type NamedBreakpoint = keyof typeof tokens.breakpoint;
-const breakpointNames = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export const breakpointNames = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 
 export function mapResponsiveProp<T>(
 	value: ResponsiveProp<T>,


### PR DESCRIPTION
## Describe your changes

Updated the `palette` prop to accept responsive value. [View changes in this Playroom example](https://design-system.agriculture.gov.au/pr-preview/pr-1021/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPAOgOwAS4AcBDAGxgBdyYBeYAbUxCiICcBrRgGl0ZIEsA5gAtyXHk1YcQAXQC%2BOfACMiYNgJYQArtijVGi6AE9GC3JBIQWekFXSiQp4lCh9sA2gEZ52AHymAEjAkFrgA6pYkUDhIAPRo6H7YILJAA).

### Example usage screenshot

<img width="1839" alt="Screen Shot 2023-03-16 at 10 42 42 am" src="https://user-images.githubusercontent.com/6265154/225479986-1fd1b3e5-33bd-4a15-b9f2-ce6a23106710.png">

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [] Create stories for Storybook
- [] Add necessary unit tests (HTML validation, snapshots etc)
- [] Manually test component in various modern browsers
- [] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).