### PR TITLE
summary-list: Fix text colour bug in dark palette

### DIFF
--- a/.changeset/poor-bees-obey.md
+++ b/.changeset/poor-bees-obey.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+summary-list: Fixed a text colour bug when this component was placed inside dark palette. This was done by adding a explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`.

--- a/.changeset/poor-bees-obey.md
+++ b/.changeset/poor-bees-obey.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-summary-list: Fixed a text colour bug when this component was placed inside dark palette. This was done by adding a explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`.
+summary-list: Fixed a text colour bug when this component was placed inside dark palette. This was done by adding an explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`.

--- a/packages/react/src/summary-list/SummaryList.tsx
+++ b/packages/react/src/summary-list/SummaryList.tsx
@@ -17,6 +17,7 @@ export function SummaryListItemTerm({ children }: SummaryListItemTermProps) {
 			flexShrink={0}
 			minWidth="200px"
 			fontSize="sm"
+			color="text"
 		>
 			{children}
 		</Flex>
@@ -30,7 +31,7 @@ export function SummaryListItemDescription({
 	children,
 }: SummaryListItemDescriptionProps) {
 	return (
-		<Flex as="dd" flexGrow={1} fontSize="sm">
+		<Flex as="dd" flexGrow={1} fontSize="sm" color="text">
 			{children}
 		</Flex>
 	);

--- a/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
+++ b/packages/react/src/summary-list/__snapshots__/SummaryList.test.tsx.snap
@@ -9,12 +9,12 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-y9ojh3-boxStyles"
+        class="css-1w3kdnx-boxStyles"
       >
         First name
       </dt>
       <dd
-        class="css-12qraxj-boxStyles"
+        class="css-6wwdos-boxStyles"
       >
         Will
       </dd>
@@ -33,12 +33,12 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-y9ojh3-boxStyles"
+        class="css-1w3kdnx-boxStyles"
       >
         Last name
       </dt>
       <dd
-        class="css-12qraxj-boxStyles"
+        class="css-6wwdos-boxStyles"
       >
         Power
       </dd>
@@ -57,12 +57,12 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-y9ojh3-boxStyles"
+        class="css-1w3kdnx-boxStyles"
       >
         Contact information
       </dt>
       <dd
-        class="css-12qraxj-boxStyles"
+        class="css-6wwdos-boxStyles"
       >
         +61 9912 3456
         <br />
@@ -83,12 +83,12 @@ exports[`SummaryList renders correctly 1`] = `
       class="css-1gkaq3c-boxStyles"
     >
       <dt
-        class="css-y9ojh3-boxStyles"
+        class="css-1w3kdnx-boxStyles"
       >
         Date of birth
       </dt>
       <dd
-        class="css-12qraxj-boxStyles"
+        class="css-6wwdos-boxStyles"
       >
         09/06/1995
       </dd>


### PR DESCRIPTION
## Describe your changes

Fixed a text colour bug when this component was placed inside dark palette. 

This was done by adding an explicit colour to `SummaryListItemTerm` and `SummaryListItemDescription`.

| Before | After | 
|--------|-------|
| <img width="827" alt="Screen Shot 2023-03-16 at 10 48 34 am" src="https://user-images.githubusercontent.com/6265154/225481726-53b9a5ef-5591-4ddc-9161-31fa6ad94cbe.png">       |  <img width="840" alt="Screen Shot 2023-03-16 at 10 48 23 am" src="https://user-images.githubusercontent.com/6265154/225481650-3bd1822a-6075-4f34-856f-b4d90ebc1137.png">      |

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).