### PR TITLE
combobox: Upgrade to latest version of `downshift`

### DIFF
--- a/.changeset/angry-items-wash.md
+++ b/.changeset/angry-items-wash.md
@@ -1,0 +1,12 @@
+---
+'@ag.ds-next/react': minor
+---
+
+autocomplete
+
+- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern
+
+Combobox
+
+- Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern
+- Added new prop `openDropdownOnFocus` to `ComboboxAsync` which when true, the dropdown will open when the user focuses on the element

--- a/.changeset/angry-items-wash.md
+++ b/.changeset/angry-items-wash.md
@@ -9,4 +9,4 @@ autocomplete
 Combobox
 
 - Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern
-- Added new prop `openDropdownOnFocus` to `ComboboxAsync` which when true, the dropdown will open when the user focuses on the element
+- Added new prop `openDropdownOnFocus` to `ComboboxAsync` which controls if the dropdown menu will open when the input element is focused

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,7 +9,7 @@
 		"@popperjs/core": "^2.11.4",
 		"@react-spring/web": "^9.4.5",
 		"date-fns": "^2.28.0",
-		"downshift": "^6.1.7",
+		"downshift": "^7.4.1",
 		"filesize": "^8.0.7",
 		"react-day-picker": "^8.3.5",
 		"react-dropzone": "^12.0.5",

--- a/packages/react/src/autocomplete/Autocomplete.tsx
+++ b/packages/react/src/autocomplete/Autocomplete.tsx
@@ -15,6 +15,7 @@ export function Autocomplete<Option extends DefaultComboboxOption>(
 	return (
 		<ComboboxAsync
 			{...props}
+			openDropdownOnFocus={false}
 			showDropdownTrigger={false}
 			clearable={true}
 			emptyResultsMessage="No results found."

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -27,36 +27,31 @@ exports[`Autocomplete renders correctly 1`] = `
       Start typing to see results
     </span>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-owns="downshift-0-menu"
       class="css-ep8qz0-ComboboxBase"
-      role="combobox"
     >
       <input
+        aria-activedescendant=""
         aria-autocomplete="list"
         aria-controls="downshift-0-menu"
         aria-describedby="field-combobox-input-:r0:-hint"
+        aria-expanded="false"
         aria-invalid="false"
         aria-labelledby="downshift-0-label"
         aria-required="false"
         autocomplete="off"
         class="css-1fv0ovm-ComboboxBase"
         id="combobox-input-:r0:"
+        role="combobox"
         type="text"
         value=""
       />
-      <div
-        class="css-15i2gz6-ComboboxBase"
+      <ul
+        aria-labelledby="downshift-0-label"
+        class="css-13zg723-boxStyles-ComboboxList"
+        id="downshift-0-menu"
+        role="listbox"
         style="position: absolute; left: 0px; top: 0px;"
-      >
-        <ul
-          aria-labelledby="downshift-0-label"
-          class="css-1bz7paq-boxStyles-ComboboxList"
-          id="downshift-0-menu"
-          role="listbox"
-        />
-      </div>
+      />
     </div>
   </div>
 </div>

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -10,6 +10,8 @@ import {
 
 export type ComboboxAsyncProps<Option extends DefaultComboboxOption> =
 	CommonComboboxProps<Option> & {
+		/** If true, the dropdown will open when the user focuses on the element  */
+		openDropdownOnFocus?: boolean;
 		/** Function to be used when options need to be loaded over the network. */
 		loadOptions: (inputValue: string) => Promise<Option[]>;
 	};
@@ -17,6 +19,7 @@ export type ComboboxAsyncProps<Option extends DefaultComboboxOption> =
 export function ComboboxAsync<Option extends DefaultComboboxOption>({
 	loadOptions: loadOptionsProp,
 	showDropdownTrigger = true,
+	openDropdownOnFocus = true,
 	...props
 }: ComboboxAsyncProps<Option>) {
 	const inputId = useComboboxInputId(props.id);
@@ -47,6 +50,10 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 		stateReducer: (state, actionAndChanges) => {
 			const { type: actionAndChangesType, changes } = actionAndChanges;
 			switch (actionAndChangesType) {
+				case useCombobox.stateChangeTypes.InputFocus:
+					// In downshift v7 the dropdown is opened automatically when the user focuses
+					// We want to disable this functionality in the `Autocomplete` component
+					return { ...changes, isOpen: openDropdownOnFocus };
 				// Reset the input value when the menu is closed
 				case useCombobox.stateChangeTypes.InputBlur:
 					return {

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -95,7 +95,10 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 		paddingRight: mapSpacing(3),
 	};
 
-	const { ref: comboboxRef, ...comboboxProps } = downshift.getComboboxProps();
+	const { ref: menuRef, ...menuProps } = downshift.getMenuProps({
+		...attributes.popper,
+		style: styles.popper,
+	});
 
 	return (
 		<Field
@@ -108,16 +111,11 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 			id={inputId}
 		>
 			{(a11yProps) => (
-				<div
-					css={{ position: 'relative', maxWidth }}
-					ref={mergeRefs([setRefEl, comboboxRef])}
-					{...comboboxProps}
-				>
+				<div ref={setRefEl} css={{ position: 'relative', maxWidth }}>
 					<input
 						css={{ ...inputStyles, width: '100%' }}
 						disabled={disabled}
-						{...a11yProps}
-						{...downshift.getInputProps({ type: 'text' })}
+						{...downshift.getInputProps({ ...a11yProps, type: 'text' })}
 					/>
 					{showDropdownTrigger && (
 						<ComboboxDropdownTrigger
@@ -131,50 +129,43 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 							onClick={downshift.reset}
 						/>
 					)}
-					<div
-						ref={setPopperEl}
-						style={styles.popper}
-						{...attributes.popper}
-						css={{ maxWidth, zIndex: 1, width: '100%' }}
+					<ComboboxList
+						{...menuProps}
+						ref={mergeRefs([menuRef, setPopperEl])}
+						maxWidth={maxWidthProp}
+						isOpen={downshift.isOpen}
 					>
-						<ComboboxList
-							{...downshift.getMenuProps()}
-							isOpen={downshift.isOpen}
-						>
-							{downshift.isOpen && (
-								<Fragment>
-									{loading ? (
-										<ComboboxListLoading />
-									) : networkError ? (
-										<ComboboxListError />
-									) : (
-										<Fragment>
-											{inputItems?.length ? (
-												inputItems.map((item, index) => {
-													const isActiveItem =
-														downshift.highlightedIndex === index;
-													return (
-														<ComboboxListItem
-															key={`${item.value}${index}`}
-															isActiveItem={isActiveItem}
-															isInteractive={true}
-															{...downshift.getItemProps({ item, index })}
-														>
-															{renderItem(item, downshift.inputValue)}
-														</ComboboxListItem>
-													);
-												})
-											) : (
-												<ComboboxListEmptyResults
-													message={emptyResultsMessage}
-												/>
-											)}
-										</Fragment>
-									)}
-								</Fragment>
-							)}
-						</ComboboxList>
-					</div>
+						{downshift.isOpen && (
+							<Fragment>
+								{loading ? (
+									<ComboboxListLoading />
+								) : networkError ? (
+									<ComboboxListError />
+								) : (
+									<Fragment>
+										{inputItems?.length ? (
+											inputItems.map((item, index) => {
+												const isActiveItem =
+													downshift.highlightedIndex === index;
+												return (
+													<ComboboxListItem
+														key={`${item.value}${index}`}
+														isActiveItem={isActiveItem}
+														isInteractive={true}
+														{...downshift.getItemProps({ item, index })}
+													>
+														{renderItem(item, downshift.inputValue)}
+													</ComboboxListItem>
+												);
+											})
+										) : (
+											<ComboboxListEmptyResults message={emptyResultsMessage} />
+										)}
+									</Fragment>
+								)}
+							</Fragment>
+						)}
+					</ComboboxList>
 				</div>
 			)}
 		</Field>

--- a/packages/react/src/combobox/ComboboxBase/ComboboxList.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxList.tsx
@@ -1,12 +1,14 @@
 import { forwardRef, PropsWithChildren } from 'react';
 import { Box } from '../../box';
+import { FieldMaxWidth, tokens } from '../../core';
 
 export type ComboboxListProps = PropsWithChildren<{
 	isOpen: boolean;
+	maxWidth: FieldMaxWidth;
 }>;
 
 export const ComboboxList = forwardRef<HTMLUListElement, ComboboxListProps>(
-	function ComboboxList({ children, isOpen, ...props }, ref) {
+	function ComboboxList({ children, isOpen, maxWidth, ...props }, ref) {
 		return (
 			<Box
 				ref={ref}
@@ -17,10 +19,15 @@ export const ComboboxList = forwardRef<HTMLUListElement, ComboboxListProps>(
 				rounded
 				{...props}
 				css={{
-					opacity: isOpen ? 1 : 0,
-					position: 'relative',
 					overflowY: 'scroll',
 					maxHeight: 295,
+					maxWidth: tokens.maxWidth.field[maxWidth],
+					width: '100%',
+					zIndex: 1,
+					...(!isOpen && {
+						opacity: 0,
+						visibility: 'hidden',
+					}),
 				}}
 			>
 				{children}

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -27,26 +27,27 @@ exports[`Combobox renders correctly 1`] = `
       Start typing to see results
     </span>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-owns="downshift-0-menu"
       class="css-ep8qz0-ComboboxBase"
-      role="combobox"
     >
       <input
+        aria-activedescendant=""
         aria-autocomplete="list"
         aria-controls="downshift-0-menu"
         aria-describedby="field-combobox-input-:r0:-hint"
+        aria-expanded="false"
         aria-invalid="false"
         aria-labelledby="downshift-0-label"
         aria-required="false"
         autocomplete="off"
         class="css-1fv0ovm-ComboboxBase"
         id="combobox-input-:r0:"
+        role="combobox"
         type="text"
         value=""
       />
       <button
+        aria-controls="downshift-0-menu"
+        aria-expanded="false"
         aria-label="Toggle menu"
         class="css-16i21f4-BaseButton-ComboboxIconButton"
         id="downshift-0-toggle-button"
@@ -69,17 +70,13 @@ exports[`Combobox renders correctly 1`] = `
           />
         </svg>
       </button>
-      <div
-        class="css-15i2gz6-ComboboxBase"
+      <ul
+        aria-labelledby="downshift-0-label"
+        class="css-13zg723-boxStyles-ComboboxList"
+        id="downshift-0-menu"
+        role="listbox"
         style="position: absolute; left: 0px; top: 0px;"
-      >
-        <ul
-          aria-labelledby="downshift-0-label"
-          class="css-1bz7paq-boxStyles-ComboboxList"
-          id="downshift-0-menu"
-          role="listbox"
-        />
-      </div>
+      />
     </div>
   </div>
 </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -27,26 +27,27 @@ exports[`ComboboxAsync renders correctly 1`] = `
       Start typing to see results
     </span>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-owns="downshift-0-menu"
       class="css-ep8qz0-ComboboxBase"
-      role="combobox"
     >
       <input
+        aria-activedescendant=""
         aria-autocomplete="list"
         aria-controls="downshift-0-menu"
         aria-describedby="field-combobox-input-:r0:-hint"
+        aria-expanded="false"
         aria-invalid="false"
         aria-labelledby="downshift-0-label"
         aria-required="false"
         autocomplete="off"
         class="css-1fv0ovm-ComboboxBase"
         id="combobox-input-:r0:"
+        role="combobox"
         type="text"
         value=""
       />
       <button
+        aria-controls="downshift-0-menu"
+        aria-expanded="false"
         aria-label="Toggle menu"
         class="css-16i21f4-BaseButton-ComboboxIconButton"
         id="downshift-0-toggle-button"
@@ -69,17 +70,13 @@ exports[`ComboboxAsync renders correctly 1`] = `
           />
         </svg>
       </button>
-      <div
-        class="css-15i2gz6-ComboboxBase"
+      <ul
+        aria-labelledby="downshift-0-label"
+        class="css-13zg723-boxStyles-ComboboxList"
+        id="downshift-0-menu"
+        role="listbox"
         style="position: absolute; left: 0px; top: 0px;"
-      >
-        <ul
-          aria-labelledby="downshift-0-label"
-          class="css-1bz7paq-boxStyles-ComboboxList"
-          id="downshift-0-menu"
-          role="listbox"
-        />
-      </div>
+      />
     </div>
   </div>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7110,10 +7110,10 @@ compression@^1.7.4:
     safe-buffer "5.1.2"
     vary "~1.1.2"
 
-compute-scroll-into-view@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz#6a88f18acd9d42e9cf4baa6bec7e0522607ab7ab"
-  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
+compute-scroll-into-view@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-2.0.4.tgz#2b444b2b9e4724819d2531efacb7ac094155fdf6"
+  integrity sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -7989,13 +7989,13 @@ dotenv@^8.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
-downshift@^6.1.7:
-  version "6.1.7"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-6.1.7.tgz#fdb4c4e4f1d11587985cd76e21e8b4b3fa72e44c"
-  integrity sha512-cVprZg/9Lvj/uhYRxELzlu1aezRcgPWBjTvspiGTVEU64gF5pRdSRKFVLcxqsZC637cLAGMbL40JavEfWnqgNg==
+downshift@^7.4.1:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.4.1.tgz#50114d4479e9bd5751a9fc3af72fb12b6178147f"
+  integrity sha512-HbzzY55YB/kbtnBQVds9fVPp9JBw913HAgGFlh4q5qNlzuwFJLyM7h0mkbBRAv3TmVaSPDdprM+sTMoQeIx04w==
   dependencies:
     "@babel/runtime" "^7.14.8"
-    compute-scroll-into-view "^1.0.17"
+    compute-scroll-into-view "^2.0.4"
     prop-types "^15.7.2"
     react-is "^17.0.2"
     tslib "^2.3.0"


### PR DESCRIPTION
## Describe your changes

Upgraded internal dependency of `downshift` to version 7 which was updated to support the ARIA 1.2 combobox pattern. This change effects both the `Autocomplete` and `Combobox` component.

[See release notes for `downshift` version 7](https://github.com/downshift-js/downshift/releases/tag/v7.0.0).

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).