### PR TITLE
docs: Add guidance about focusing the error summary and success messaging

### DIFF
--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -43,7 +43,7 @@ Instead, allow users to interact with buttons and receive feedback.
 
 ### Error messages
 
-A form should validate when a user attempts to submit. If there are errors, they should be listed in an error summary (or [PageAlert](/components/page-alert)) at the top of the page. The summary should link to each error and focus on the form field when clicked.
+A form should validate when a user attempts to submit. If there are errors, they should be listed in an error summary (or [PageAlert](/components/page-alert)), placed at the top of the page and immediately focused. The summary should link to each error and focus on the form field when clicked.
 
 If only one error is present, the error summary can be omitted and the invalid field can be focused.
 

--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -48,3 +48,7 @@ A form should validate when a user attempts to submit. If there are errors, they
 If only one error is present, the error summary can be omitted and the invalid field can be focused.
 
 An invalid field is highlighted with a red border and a red error message. They should never be covered by autocomplete menus and on-screen keyboards.
+
+### Success messaging
+
+When a form is successfully completed, return the user to the entry point of the form and display a [PageAlert](/components/page-alert) with the green 'success' tone and a clear message which communicates the successful submission. When possible provide, persistent methods for a user to return and see the status of the from submission - ie a reference number for the artifact.

--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -43,7 +43,7 @@ Instead, allow users to interact with buttons and receive feedback.
 
 ### Error messages
 
-A form should validate when a user attempts to submit. If there are errors, they should be listed in an error summary (or [PageAlert](/components/page-alert)), placed at the top of the page and immediately focused. The summary should link to each error and focus on the form field when clicked.
+A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [PageAlert](/components/page-alert)) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
 
 If only one error is present, the error summary can be omitted and the invalid field can be focused.
 
@@ -51,4 +51,4 @@ An invalid field is highlighted with a red border and a red error message. They 
 
 ### Success messaging
 
-When a form is successfully completed, return the user to the entry point of the form and display a [PageAlert](/components/page-alert) with the green 'success' tone and a clear message which communicates the successful submission. When possible provide, persistent methods for a user to return and see the status of the from submission - ie a reference number for the artifact.
+When a form is successfully completed, return the user to the entry point of the form and display a [PageAlert](/components/page-alert) with the 'success' tone and a clear message which communicates the successful submission. When possible, provide persistent methods for a user to return and see the status of the submitted artefact, for example a reference number.


### PR DESCRIPTION
Drafted in github.com editor