### PR TITLE
docs: Update `Field` documentation

### DIFF
--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -5,8 +5,6 @@ group: Forms
 storybookPath: /story/forms-field--basic
 ---
 
-## Default
-
 The field component connects the label, description and message to the input element.
 
 ```jsx live
@@ -81,7 +79,7 @@ The usage of `hideOptionalLabel` should be reserved for inputs that filter data 
 
 ## Hooks
 
-## `useScrollToField`
+### useScrollToField
 
 By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
 


### PR DESCRIPTION
## Describe your changes

In the following screenshot, the heading `useScrollToField` is the wrong heading type (level 2 instead of level 3). Also, as it's using a `<code />` component the associated heading ID is `object-object` and the font size is incorrect.

<img width="846" alt="Screen Shot 2023-03-23 at 3 52 33 pm" src="https://user-images.githubusercontent.com/6265154/227115691-14eeeb40-0f10-4d51-8195-18450318a331.png">

In the following screenshot, the heading "useScrollToField" contains the backticks.

<img width="902" alt="Screen Shot 2023-03-23 at 3 52 16 pm" src="https://user-images.githubusercontent.com/6265154/227115681-c6817c35-c702-4fef-b2f0-6100fccb108a.png">

## Preview

[Preview changes here](https://design-system.agriculture.gov.au/pr-preview/pr-1037/components/field)