### PR TITLE
field: Update `useScrollToField`

### DIFF
--- a/.changeset/heavy-apes-tickle.md
+++ b/.changeset/heavy-apes-tickle.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+field: Extended the function returned from from `useScrollToField` to accept either a mouse event or an ID of a form field element. This change makes it easier for consumers to scroll and focus a form field on the same page in situations such as when a form first renders.

--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -81,12 +81,17 @@ The usage of `hideOptionalLabel` should be reserved for inputs that filter data 
 
 ### useScrollToField
 
-By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
+`useScrollToField` is a hook that can be used to scroll and focus users to a form field on the same page.
 
-Please refer to the [example site single-page form example](https://design-system.agriculture.gov.au/example-site/single-page-form) to see an example of this hook in use.
+Because our labels or legends appear above the input, when using native browsers API's users will be presented with an input without any context, as the label or legend will be off the top of the screen. Manually handling the click event, scrolling the question into view and then focussing the element solves this.
+
+Please refer to the [example site single-page form example](/example-site/single-page-form) to see an example of this hook in use.
 
 ```jsx
-function ExampleForm() {
+/**
+ * Example usage when displaying a list of form validation errors
+ */
+function ExampleOne() {
 	const scrollToField = useScrollToField();
 	return (
 		<ul>
@@ -98,6 +103,25 @@ function ExampleForm() {
 				</li>
 			))}
 		</ul>
+	);
+}
+
+/**
+ * Example usage scrolling and focusing to a specific field on first mount
+ */
+function ExampleTwo() {
+	const targetId = 'last-name'; // This could potentially come from route query params
+	const scrollToField = useScrollToField();
+
+	React.useEffect(() => {
+		scrollToField('last-name');
+	}, [scrollToField]);
+
+	return (
+		<FormStack>
+			<TextInput label="First name" id="first-name" />
+			<TextInput label="Last name" id="last-name" />
+		</FormStack>
 	);
 }
 ```

--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -114,7 +114,7 @@ function ExampleTwo() {
 	const scrollToField = useScrollToField();
 
 	React.useEffect(() => {
-		scrollToField('last-name');
+		scrollToField(targetId);
 	}, [scrollToField]);
 
 	return (

--- a/packages/react/src/field/useScrollToField.ts
+++ b/packages/react/src/field/useScrollToField.ts
@@ -1,25 +1,42 @@
 import { useCallback, MouseEvent } from 'react';
 
 export function useScrollToField() {
-	return useCallback((event: MouseEvent<HTMLAnchorElement>) => {
-		if (focusTarget(event)) {
-			// Prevent default browser behaviour
-			event.preventDefault();
-		}
-	}, []);
+	return useCallback(
+		(eventOrTargetId: MouseEvent<HTMLAnchorElement> | string) => {
+			const targetId = getScrollTargetId(eventOrTargetId);
+			if (!targetId) return;
+
+			const targetEl = document.getElementById(targetId);
+			if (!targetEl) return;
+
+			scrollAndFocusTarget(targetId, targetEl);
+
+			// Prevent default browser behaviour if user clicked on a lin
+			if (typeof eventOrTargetId !== 'string') {
+				eventOrTargetId.preventDefault();
+			}
+		},
+		[]
+	);
 }
 
-function focusTarget(event: MouseEvent<HTMLAnchorElement>) {
-	const target = event.target;
-	if (!(target instanceof HTMLAnchorElement)) return false;
+function getScrollTargetId(
+	eventOrTargetId: MouseEvent<HTMLAnchorElement> | string
+) {
+	if (typeof eventOrTargetId === 'string') {
+		return eventOrTargetId;
+	}
+
 	// Attempt to the find target ID from the anchor tag href
-	const targetId = getTargetId(event);
-	if (!targetId) return false;
-	// Attempt to find the target element using the target Id
-	const targetEl = document.getElementById(targetId);
-	if (!targetEl) return false;
+	const target = eventOrTargetId.target;
+	if (!(target instanceof HTMLAnchorElement)) return;
+	return target.hash.substring(1);
+}
+
+function scrollAndFocusTarget(targetId: string, targetEl: HTMLElement) {
 	const targetLabel = document.querySelector("label[for='" + targetId + "']");
 	const targetLabelParent = targetLabel?.parentElement;
+
 	if (targetEl.tagName.toLowerCase() === 'div') {
 		// If the target element is a div (e.g. a `ControlGroup`), focus the first child input
 		targetEl.querySelector('input')?.focus();
@@ -33,11 +50,4 @@ function focusTarget(event: MouseEvent<HTMLAnchorElement>) {
 	} else {
 		targetEl.scrollIntoView();
 	}
-	return true;
-}
-
-function getTargetId(event: MouseEvent<HTMLAnchorElement>) {
-	const target = event.target;
-	if (!(target instanceof HTMLAnchorElement)) return;
-	return target.hash.substring(1);
 }


### PR DESCRIPTION
## Describe your changes

### Field

Extended the function returned from from `useScrollToField` to accept either a mouse event or an ID of a form field element. This change makes it easier for consumers to scroll and focus a form field on the same page in situations such as when a form first renders.

I've added an example of this use case to our documentation site, but we currently do not have any living examples of where this hook would be useful. It would have useful to have have had this in PR #980.

[Preview changes in single page form](https://design-system.agriculture.gov.au/pr-preview/pr-1038/example-site/category/subcategory/single-page-form).

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).