### PR TITLE
field: Update wrapping behaviour of label

### DIFF
--- a/.changeset/shy-bottles-float.md
+++ b/.changeset/shy-bottles-float.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+field: Update wrapping behaviour of label.

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Autocomplete renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`Autocomplete renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Combobox renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`Combobox renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ComboboxAsync renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`ComboboxAsync renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/control-input/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-input/__snapshots__/ControlGroup.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
       class="css-faxsk2-ControlGroup"
     >
       <legend
-        class="css-n7rdvo-boxStyles"
+        class="css-79i25n-boxStyles"
       >
         <span
           class="css-433uqb-boxStyles-Text"
@@ -20,6 +20,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
+           
           (optional)
         </span>
       </legend>
@@ -183,7 +184,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
       class="css-faxsk2-ControlGroup"
     >
       <legend
-        class="css-n7rdvo-boxStyles"
+        class="css-79i25n-boxStyles"
       >
         <span
           class="css-433uqb-boxStyles-Text"
@@ -193,6 +194,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
+           
           (optional)
         </span>
       </legend>
@@ -403,7 +405,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
       class="css-faxsk2-ControlGroup"
     >
       <legend
-        class="css-n7rdvo-boxStyles"
+        class="css-79i25n-boxStyles"
       >
         <span
           class="css-433uqb-boxStyles-Text"
@@ -413,6 +415,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
+           
           (optional)
         </span>
       </legend>
@@ -524,7 +527,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
       class="css-faxsk2-ControlGroup"
     >
       <legend
-        class="css-n7rdvo-boxStyles"
+        class="css-79i25n-boxStyles"
       >
         <span
           class="css-433uqb-boxStyles-Text"
@@ -534,6 +537,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
+           
           (optional)
         </span>
       </legend>

--- a/packages/react/src/date-picker/DateRangePicker.test.tsx
+++ b/packages/react/src/date-picker/DateRangePicker.test.tsx
@@ -269,7 +269,7 @@ describe('DateRangePicker', () => {
 			required: false,
 		});
 		expect(await await (await getLegend(defaultLegend)).textContent).toEqual(
-			`${defaultLegend}(optional)`
+			`${defaultLegend} (optional)`
 		);
 	});
 
@@ -295,7 +295,7 @@ describe('DateRangePicker', () => {
 			onChange: console.log,
 		});
 		expect(await (await getLegend(legend)).textContent).toEqual(
-			`${legend}(optional)`
+			`${legend} (optional)`
 		);
 	});
 
@@ -323,8 +323,8 @@ describe('DateRangePicker', () => {
 		const inputToId = await (await getToInput())?.id;
 		const labelTo = container.querySelector(`[for="${inputToId}"]`);
 
-		expect(labelFrom?.textContent).toEqual('Start date(dd/mm/yyyy)');
-		expect(labelTo?.textContent).toEqual('End date(dd/mm/yyyy)');
+		expect(labelFrom?.textContent).toEqual('Start date (dd/mm/yyyy)');
+		expect(labelTo?.textContent).toEqual('End date (dd/mm/yyyy)');
 	});
 
 	it('shows date format when no legend is supplied', async () => {
@@ -338,8 +338,10 @@ describe('DateRangePicker', () => {
 		const inputToId = await (await getToInput())?.id;
 		const labelTo = container.querySelector(`[for="${inputToId}"]`);
 
-		expect(labelFrom?.textContent).toEqual('Start date(dd/mm/yyyy) (optional)');
-		expect(labelTo?.textContent).toEqual('End date(dd/mm/yyyy) (optional)');
+		expect(labelFrom?.textContent).toEqual(
+			'Start date (dd/mm/yyyy) (optional)'
+		);
+		expect(labelTo?.textContent).toEqual('End date (dd/mm/yyyy) (optional)');
 	});
 
 	it('invalid: can render an invalid state when both fields are invalid', async () => {

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`DatePicker renders correctly 1`] = `
       class="css-1904cz9-boxStyles-FieldContainer"
     >
       <label
-        class="css-n7rdvo-boxStyles"
+        class="css-79i25n-boxStyles"
         for="field-:r0:"
       >
         <span
@@ -18,6 +18,7 @@ exports[`DatePicker renders correctly 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
+           
           (dd/mm/yyyy) (optional)
         </span>
       </label>

--- a/packages/react/src/date-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`DateRangePicker renders correctly 1`] = `
       class="css-1lbpzz2-DateRangePicker"
     >
       <legend
-        class="css-n4cl2w-boxStyles-DateRangePicker"
+        class="css-1r0k8hi-boxStyles-DateRangePicker"
       >
         <span
           class="css-433uqb-boxStyles-Text"
@@ -20,6 +20,7 @@ exports[`DateRangePicker renders correctly 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
+           
           (optional)
         </span>
       </legend>
@@ -33,7 +34,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             class="css-1904cz9-boxStyles-FieldContainer"
           >
             <label
-              class="css-n7rdvo-boxStyles"
+              class="css-79i25n-boxStyles"
               for="field-:r1:"
             >
               <span
@@ -44,6 +45,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               <span
                 class="css-1rpt3h8-boxStyles-Text"
               >
+                 
                 (dd/mm/yyyy) (optional)
               </span>
             </label>
@@ -107,7 +109,7 @@ exports[`DateRangePicker renders correctly 1`] = `
             class="css-1904cz9-boxStyles-FieldContainer"
           >
             <label
-              class="css-n7rdvo-boxStyles"
+              class="css-79i25n-boxStyles"
               for="field-:r2:"
             >
               <span
@@ -118,6 +120,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               <span
                 class="css-1rpt3h8-boxStyles-Text"
               >
+                 
                 (dd/mm/yyyy) (optional)
               </span>
             </label>

--- a/packages/react/src/field/Field.test.tsx
+++ b/packages/react/src/field/Field.test.tsx
@@ -140,7 +140,7 @@ describe('Field', () => {
 			it('renders correctly', () => {
 				renderField({ label, required: false });
 				const labelEl = getLabelElement();
-				expect(labelEl.textContent).toBe(`${label}(optional)`);
+				expect(labelEl.textContent).toBe(`${label} (optional)`);
 			});
 			it('renders correctly when optional label is hidden', () => {
 				renderField({
@@ -177,14 +177,14 @@ describe('Field', () => {
 				renderField({ label, secondaryLabel, required: false });
 				const labelEl = getLabelElement();
 				expect(labelEl.textContent).toBe(
-					`${label}${secondaryLabel} (optional)`
+					`${label} ${secondaryLabel} (optional)`
 				);
 			});
 
 			it('renders correctly when true', () => {
 				renderField({ label, secondaryLabel, required: true });
 				const labelEl = getLabelElement();
-				expect(labelEl.textContent).toBe(`${label}${secondaryLabel}`);
+				expect(labelEl.textContent).toBe(`${label} ${secondaryLabel}`);
 			});
 		});
 	});

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -1,6 +1,5 @@
 import { ElementType, PropsWithChildren, useMemo } from 'react';
 import { Box } from '../box';
-import { mapSpacing } from '../core';
 import { Text } from '../text';
 
 export type FieldLabelProps = PropsWithChildren<{

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -1,5 +1,6 @@
 import { ElementType, PropsWithChildren, useMemo } from 'react';
-import { Flex } from '../box';
+import { Box } from '../box';
+import { mapSpacing } from '../core';
 import { Text } from '../text';
 
 export type FieldLabelProps = PropsWithChildren<{
@@ -34,15 +35,16 @@ export const FieldLabel = ({
 			.join(' ');
 	}, [required, secondaryLabelProp, hideOptionalLabel]);
 	return (
-		<Flex as={as} htmlFor={htmlFor} gap={0.25} className={className}>
+		<Box as={as} htmlFor={htmlFor} className={className}>
 			<Text as="span" fontWeight="bold">
 				{children}
 			</Text>
 			{secondaryLabel ? (
 				<Text as="span" color="muted">
+					{' '}
 					{secondaryLabel}
 				</Text>
 			) : null}
-		</Flex>
+		</Box>
 	);
 };

--- a/packages/react/src/field/__snapshots__/Field.test.tsx.snap
+++ b/packages/react/src/field/__snapshots__/Field.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Field Basic renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`Field Basic renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -37,7 +38,7 @@ exports[`Field Invalid renders correctly 1`] = `
     class="css-1n67ua0-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r4:"
     >
       <span
@@ -48,6 +49,7 @@ exports[`Field Invalid renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -103,7 +105,7 @@ exports[`Field With hint renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r2:"
     >
       <span
@@ -114,6 +116,7 @@ exports[`Field With hint renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/packages/react/src/fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           class="css-1904cz9-boxStyles-FieldContainer"
         >
           <label
-            class="css-n7rdvo-boxStyles"
+            class="css-79i25n-boxStyles"
             for="field-:r1:"
           >
             <span
@@ -49,7 +49,7 @@ exports[`Fieldset Basic renders correctly 1`] = `
           class="css-1904cz9-boxStyles-FieldContainer"
         >
           <label
-            class="css-n7rdvo-boxStyles"
+            class="css-79i25n-boxStyles"
             for="field-:r2:"
           >
             <span
@@ -106,7 +106,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           class="css-1904cz9-boxStyles-FieldContainer"
         >
           <label
-            class="css-n7rdvo-boxStyles"
+            class="css-79i25n-boxStyles"
             for="field-:ra:"
           >
             <span
@@ -127,7 +127,7 @@ exports[`Fieldset Legend as page heading renders correctly 1`] = `
           class="css-1904cz9-boxStyles-FieldContainer"
         >
           <label
-            class="css-n7rdvo-boxStyles"
+            class="css-79i25n-boxStyles"
             for="field-:rb:"
           >
             <span

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FileInput renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`FileInput renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
+++ b/packages/react/src/search-input/__snapshots__/SearchInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SearchInput Basic renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`SearchInput Basic renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -66,7 +67,7 @@ exports[`SearchInput Invalid renders correctly 1`] = `
     class="css-1n67ua0-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r4:"
     >
       <span
@@ -77,6 +78,7 @@ exports[`SearchInput Invalid renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -161,7 +163,7 @@ exports[`SearchInput With hint renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r2:"
     >
       <span
@@ -172,6 +174,7 @@ exports[`SearchInput With hint renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/select/__snapshots__/Select.test.tsx.snap
+++ b/packages/react/src/select/__snapshots__/Select.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Select Basic renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`Select Basic renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -71,7 +72,7 @@ exports[`Select Grouped options renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r2:"
     >
       <span
@@ -82,6 +83,7 @@ exports[`Select Grouped options renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -159,7 +161,7 @@ exports[`Select Invalid renders correctly 1`] = `
     class="css-1n67ua0-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r6:"
     >
       <span
@@ -170,6 +172,7 @@ exports[`Select Invalid renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -259,7 +262,7 @@ exports[`Select With hint renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r4:"
     >
       <span
@@ -270,6 +273,7 @@ exports[`Select With hint renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
+++ b/packages/react/src/text-input/__snapshots__/TextInput.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TextInput Basic renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`TextInput Basic renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -37,7 +38,7 @@ exports[`TextInput Invalid renders correctly 1`] = `
     class="css-1n67ua0-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r4:"
     >
       <span
@@ -48,6 +49,7 @@ exports[`TextInput Invalid renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -103,7 +105,7 @@ exports[`TextInput With hint renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r2:"
     >
       <span
@@ -114,6 +116,7 @@ exports[`TextInput With hint renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>

--- a/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
+++ b/packages/react/src/textarea/__snapshots__/Textarea.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Textarea Basic renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r0:"
     >
       <span
@@ -17,6 +17,7 @@ exports[`Textarea Basic renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -36,7 +37,7 @@ exports[`Textarea Invalid renders correctly 1`] = `
     class="css-1n67ua0-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r4:"
     >
       <span
@@ -47,6 +48,7 @@ exports[`Textarea Invalid renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>
@@ -101,7 +103,7 @@ exports[`Textarea With hint renders correctly 1`] = `
     class="css-1904cz9-boxStyles-FieldContainer"
   >
     <label
-      class="css-n7rdvo-boxStyles"
+      class="css-79i25n-boxStyles"
       for="field-:r2:"
     >
       <span
@@ -112,6 +114,7 @@ exports[`Textarea With hint renders correctly 1`] = `
       <span
         class="css-1rpt3h8-boxStyles-Text"
       >
+         
         (optional)
       </span>
     </label>


### PR DESCRIPTION
## Describe your changes

This PR updates the wrapping behaviour of the `FieldLabel` component. Currently we use flexbox for our label component and the space between the primary and secondary label is added via a flex gap. But this has a few issues such as:

1. Labels that span multiple lines do not behave nicely
2. The text content of the node does not contain a space 

I have removed flexbox from the `FieldLabel` component and replaced that flex gap with a space character (`" "`).

### Screenshot

[Test in Playroom](https://design-system.agriculture.gov.au/pr-preview/pr-1041/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AxCAnAtgZQC4EMwBrAPgB0A7AAiqQBUYAPXASQoAcBXXKgG3wBGMXgF4yIOgAsAlgGcqcqviroY%2BXrwCefCBQDmVAO4ywkqrnTSY83BCqz2%2Bapk69c09rxh9pFa%2BbtYTF1ZC3xcb0N0fHZ2XwMhSXwAN2kITnRxKgB6cmpaABFwmAAFaWIYTPyafiFRcWxhGDAeZShio2lcM2Va4XMkngcneRc3Dy8fP1lxShoaZPVOGBFgP0MqIoiACgBKAF85%2Bd0AYST9FeA9qhESKmB9w-zcyiRstCw8QlJKEH2gA)

| Before      | After |
| ----------- | ----------- |
| <img width="318" alt="Screen Shot 2023-03-30 at 1 56 45 pm" src="https://user-images.githubusercontent.com/6265154/228725224-0874f47e-54a2-42e3-bead-cd3953c0661f.png">      | <img width="318" alt="Screen Shot 2023-03-30 at 1 58 15 pm" src="https://user-images.githubusercontent.com/6265154/228725466-b7750ee0-b7d7-4c9e-83da-ed5bf025dd80.png">  |

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
