### PR TITLE
docs: Add related components

### DIFF
--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -29,10 +29,11 @@ export async function getPkg(slug: string) {
 		storybookPath: (data.storybookPath ?? null) as string | null,
 		figmaGalleryNodeId: (data.figmaGalleryNodeId ?? null) as string | null,
 		subNavItems: subNavItems ?? null,
+		relatedComponents: (data.relatedComponents ?? null) as string[] | null,
 	};
 }
 
-export async function getPkgSubNavItems(slug: string) {
+async function getPkgSubNavItems(slug: string) {
 	return getMarkdownData(pkgReadmePath(slug)).then(({ data }) => {
 		const meta = pkgNavMetaData(slug, data);
 		return [

--- a/packages/react/src/a11y/docs/overview.mdx
+++ b/packages/react/src/a11y/docs/overview.mdx
@@ -3,6 +3,7 @@ title: A11y
 description: Utilities for improving accessibility.
 group: Foundations
 storybookPath: /story/foundations-a11y-visuallyhidden--basic
+relatedComponents: ['skip-link']
 ---
 
 ## VisuallyHidden

--- a/packages/react/src/accordion/docs/overview.mdx
+++ b/packages/react/src/accordion/docs/overview.mdx
@@ -4,6 +4,7 @@ description: An accordion hides sections of content users can choose to see if i
 group: Layout
 storybookPath: /story/layout-accordion--basic
 figmaGalleryNodeId: 11960%3A99742
+relatedComponents: ['details']
 ---
 
 ```jsx live

--- a/packages/react/src/autocomplete/docs/overview.mdx
+++ b/packages/react/src/autocomplete/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Autocomplete, also known as type-ahead, uses predictive text to com
 group: Forms
 storybookPath: /story/forms-autocomplete--basic
 figmaGalleryNodeId: 12911%3A103687
+relatedComponents: ['combobox', 'text-input']
 ---
 
 `Autocomplete` is a [controlled component](https://reactjs.org/docs/forms.html#controlled-components) which means consumers of this component need to manage the state of this component by using the `value` and `onChange` props.

--- a/packages/react/src/badge/docs/overview.mdx
+++ b/packages/react/src/badge/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Badges are decorative indicators used to either call attention to a
 group: Content
 storybookPath: /story/content-badge-statusbadge--basic
 figmaGalleryNodeId: 11981%3A101236
+relatedComponents: ['tags']
 ---
 
 ## StatusBadge

--- a/packages/react/src/call-to-action/docs/overview.mdx
+++ b/packages/react/src/call-to-action/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Call to action links are interactive UI cues that direct users to o
 group: Navigation
 storybookPath: /story/navigation-calltoaction--basic
 figmaGalleryNodeId: 11978%3A106349
+relatedComponents: ['direction-link', 'text-link']
 ---
 
 ```jsx live

--- a/packages/react/src/callout/docs/overview.mdx
+++ b/packages/react/src/callout/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Callouts are an excerpt of text used to draw attention to important
 group: Content
 storybookPath: /story/content-callout--basic
 figmaGalleryNodeId: 11981%3A101425
+relatedComponents: ['global-alert', 'page-alert']
 ---
 
 ```jsx live

--- a/packages/react/src/combobox/docs/overview.mdx
+++ b/packages/react/src/combobox/docs/overview.mdx
@@ -4,6 +4,7 @@ description: This component allows users to select from a list of options. It's 
 group: Forms
 storybookPath: /story/forms-combobox-combobox--basic
 figmaGalleryNodeId: 12925%3A104632
+relatedComponents: ['autocomplete', 'select', 'text-input']
 ---
 
 All Combobox components are [controlled components](https://reactjs.org/docs/forms.html#controlled-components) which means consumers of these components need to manage the state of these components by using the `value` and `onChange` props.

--- a/packages/react/src/control-input/docs/overview.mdx
+++ b/packages/react/src/control-input/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Control inputs helps users select one or more options from a list. 
 group: Forms
 storybookPath: /story/forms-checkbox--basic
 figmaGalleryNodeId: 12926%3A104981
+relatedComponents: ['switch']
 ---
 
 <DoHeading />

--- a/packages/react/src/details/docs/overview.mdx
+++ b/packages/react/src/details/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Detail areas guide users to links they can choose to open if the in
 group: Content
 storybookPath: /story/content-details--basic
 figmaGalleryNodeId: 14934%3A110986
+relatedComponents: ['accordion']
 ---
 
 ```jsx live

--- a/packages/react/src/direction-link/docs/overview.mdx
+++ b/packages/react/src/direction-link/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Direction links are links which communicate flow to other parts of 
 group: Navigation
 storybookPath: /story/navigation-directionlink--basic
 figmaGalleryNodeId: 11978%3A107081
+relatedComponents: ['call-to-action', 'text-link']
 ---
 
 ```jsx live

--- a/packages/react/src/field/docs/overview.mdx
+++ b/packages/react/src/field/docs/overview.mdx
@@ -3,6 +3,7 @@ title: Field
 description: The field package exposes the elements around form inputs, and an API to compose them.
 group: Forms
 storybookPath: /story/forms-field--basic
+relatedComponents: ['fieldset']
 ---
 
 The field component connects the label, description and message to the input element.

--- a/packages/react/src/fieldset/docs/overview.mdx
+++ b/packages/react/src/fieldset/docs/overview.mdx
@@ -3,6 +3,7 @@ title: Fieldset
 description: Use the fieldset component to group related form inputs.
 group: Forms
 storybookPath: /story/forms-fieldset--basic
+relatedComponents: ['field']
 ---
 
 Fieldset is used to associate a number of related form fields as well as labels within a form. The legend provides an association and caption for the form fields in the fieldset.

--- a/packages/react/src/file-input/docs/overview.mdx
+++ b/packages/react/src/file-input/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Allows a user to attach a file to a form.
 group: Forms
 storybookPath: /story/Forms-FileInput--basic
 figmaGalleryNodeId: 16180%3A41550
+relatedComponents: ['file-upload']
 ---
 
 A simple input for selecting files in a form. The `FileInput` component is a wrapper around the native `<input type="file" />` element. Use when you require multiple files in a form, which must be associated as seperate fields. If you only require a single file, use the [FileUpload](/components/file-upload) component instead.

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -4,6 +4,7 @@ description: This component allows users to select files to upload via drag-and-
 group: Forms
 storybookPath: /story/forms-fileupload--basic
 figmaGalleryNodeId: 12444%3A100384
+relatedComponents: ['file-input']
 ---
 
 ```jsx live

--- a/packages/react/src/global-alert/docs/overview.mdx
+++ b/packages/react/src/global-alert/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Global Alerts show pressing and high-signal messages, such as syste
 group: Content
 storybookPath: /story/content-globalalert--basic
 figmaGalleryNodeId: 15243%3A46718
+relatedComponents: ['callout', 'page-alert']
 ---
 
 ```jsx live

--- a/packages/react/src/header/docs/overview.mdx
+++ b/packages/react/src/header/docs/overview.mdx
@@ -4,6 +4,7 @@ group: Layout
 description: The Header is the masthead of our applications. it incorporates the AFF brand and provides a user context on where they are.
 storybookPath: /story/layout-header--body-background
 figmaGalleryNodeId: 11978%3A103772
+relatedComponents: ['main-nav']
 ---
 
 ```jsx live

--- a/packages/react/src/heading/docs/overview.mdx
+++ b/packages/react/src/heading/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Headings are a typographic component that support SEO and help stru
 group: Content
 storybookPath: /story/content-heading--basic
 figmaGalleryNodeId: 11981%3A101624
+relatedComponents: ['text']
 ---
 
 Headings use the `fontGrid` function to make the font-size and line-height snap to grid.

--- a/packages/react/src/inpage-nav/docs/overview.mdx
+++ b/packages/react/src/inpage-nav/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Also known as Page contents, Inpage nav links help users scan page 
 group: Navigation
 storybookPath: /story/navigation-inpagenav--basic
 figmaGalleryNodeId: 11978%3A107111
+relatedComponents: ['link-list', 'side-nav', 'sub-nav']
 ---
 
 ```jsx live

--- a/packages/react/src/link-list/docs/overview.mdx
+++ b/packages/react/src/link-list/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Link list is a simple set of vertical or horizontal links used for 
 group: Navigation
 storybookPath: /story/navigation-linklist--basic
 figmaGalleryNodeId: 11978%3A107123
+relatedComponents: ['inpage-nav', 'side-nav', 'sub-nav']
 ---
 
 ```jsx live

--- a/packages/react/src/loading/docs/overview.mdx
+++ b/packages/react/src/loading/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Loading indicators inform users their action is being processed.
 group: Content
 storybookPath: /story/content-loading-loadingblanket--basic
 figmaGalleryNodeId: 11981%3A101666
+relatedComponents: ['skeleton']
 ---
 
 ```jsx live

--- a/packages/react/src/main-nav/docs/overview.mdx
+++ b/packages/react/src/main-nav/docs/overview.mdx
@@ -4,6 +4,7 @@ description: The main nav is the primary way users navigate the UI. It is consis
 group: Navigation
 storybookPath: /story/navigation-mainnav--body
 figmaGalleryNodeId: 11978%3A107135
+relatedComponents: ['header']
 ---
 
 ```jsx live

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Page alerts are colour-coded, non-disruptive notifications that pro
 group: Content
 storybookPath: /story/content-pagealert--basic
 figmaGalleryNodeId: 11981%3A101690
+relatedComponents: ['callout', 'global-alert']
 ---
 
 Typically page alerts appear at the top of a page following a submit action.

--- a/packages/react/src/progress-indicator/docs/overview.mdx
+++ b/packages/react/src/progress-indicator/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Progress indicators show users the number of steps in a task, where
 group: Forms
 storybookPath: /story/forms-progressindicator--basic
 figmaGalleryNodeId: 12444%3A100448
+relatedComponents: ['task-list']
 ---
 
 ```jsx live

--- a/packages/react/src/search-box/docs/overview.mdx
+++ b/packages/react/src/search-box/docs/overview.mdx
@@ -4,6 +4,7 @@ description: An input that allows users to enter a keyword to search a website f
 group: Forms
 storybookPath: /story/forms-searchbox--basic
 figmaGalleryNodeId: 12444%3A100493
+relatedComponents: ['search-input']
 ---
 
 ```jsx live

--- a/packages/react/src/search-input/docs/overview.mdx
+++ b/packages/react/src/search-input/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Search input enables users to enter a word or phrase to find releva
 group: Forms
 storybookPath: /story/forms-searchinput--basic
 figmaGalleryNodeId: 15243%3A46806
+relatedComponents: ['search-box']
 ---
 
 ```jsx live

--- a/packages/react/src/select/docs/overview.mdx
+++ b/packages/react/src/select/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Select provides a way for users to choose one item from a collapsib
 group: Forms
 storybookPath: /story/forms-select--basic
 figmaGalleryNodeId: 12444%3A100538
+relatedComponents: ['combobox']
 ---
 
 ```jsx live

--- a/packages/react/src/side-nav/docs/overview.mdx
+++ b/packages/react/src/side-nav/docs/overview.mdx
@@ -4,6 +4,7 @@ description: A vertical list of links use for site navigation, typically placed 
 group: Navigation
 storybookPath: /story/navigation-sidenav--basic
 figmaGalleryNodeId: 11981%3A101095
+relatedComponents: ['inpage-nav', 'link-list', 'sub-nav']
 ---
 
 ```jsx live

--- a/packages/react/src/skeleton/docs/overview.mdx
+++ b/packages/react/src/skeleton/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Skeletons are visual placeholders for information while data is sti
 group: Content
 storybookPath: /story/content-skeleton-skeletonheading--basic
 figmaGalleryNodeId: 11981%3A101691
+relatedComponents: ['loading']
 ---
 
 <DoHeading />

--- a/packages/react/src/skip-link/docs/overview.mdx
+++ b/packages/react/src/skip-link/docs/overview.mdx
@@ -3,6 +3,7 @@ title: Skip link
 description: Skip links are internal page links that aid navigation around a page. They are detected by screen readers and help users quickly jump to and over content on the page.
 group: Navigation
 storybookPath: /story/navigation-skiplinks--basic
+relatedComponents: ['a11y']
 ---
 
 ```jsx

--- a/packages/react/src/sub-nav/docs/overview.mdx
+++ b/packages/react/src/sub-nav/docs/overview.mdx
@@ -4,6 +4,7 @@ description: A horizontal list of links typically placed between the main naviga
 group: Navigation
 storybookPath: /story/navigation-subnav--basic
 figmaGalleryNodeId: 11981%3A101155
+relatedComponents: ['inpage-nav', 'link-list', 'side-nav']
 ---
 
 ```jsx live

--- a/packages/react/src/summary-list/docs/overview.mdx
+++ b/packages/react/src/summary-list/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Summary list is used to summarise information such as a user’s re
 group: Content
 storybookPath: /story/Content-SummaryList--basic
 figmaGalleryNodeId: 12908%3A103687
+relatedComponents: ['table']
 ---
 
 ```jsx live

--- a/packages/react/src/switch/docs/overview.mdx
+++ b/packages/react/src/switch/docs/overview.mdx
@@ -4,6 +4,7 @@ description: A Switch allows a user to immediately update interface settings.
 group: Forms
 storybookPath: /story/forms-switch--switch
 figmaGalleryNodeId: 12444%3A100583
+relatedComponents: ['control-input']
 ---
 
 ```jsx live

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Tables help make complex information easier to scan and compare. Us
 group: Content
 storybookPath: /story/content-table--basic
 figmaGalleryNodeId: 11981%3A101727
+relatedComponents: ['summary-list']
 ---
 
 ```jsx live

--- a/packages/react/src/tags/docs/overview.mdx
+++ b/packages/react/src/tags/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Tags classify content using keywords or labels. They are added to a
 group: Content
 storybookPath: /story/content-tags--basic
 figmaGalleryNodeId: 11981%3A101715
+relatedComponents: ['badge']
 ---
 
 <DoHeading />

--- a/packages/react/src/task-list/docs/overview.mdx
+++ b/packages/react/src/task-list/docs/overview.mdx
@@ -4,6 +4,7 @@ description: Task list is a navigation tool that show users what input is requir
 group: Forms
 storybookPath: /story/forms-tasklist--unordered
 figmaGalleryNodeId: 12444%3A100628
+relatedComponents: ['progress-indicator']
 ---
 
 ```jsx live

--- a/packages/react/src/text-input/docs/overview.mdx
+++ b/packages/react/src/text-input/docs/overview.mdx
@@ -4,6 +4,7 @@ description: This component allows users to enter free-form text.
 group: Forms
 storybookPath: /story/forms-textinput--basic
 figmaGalleryNodeId: 12444%3A100673
+relatedComponents: ['autocomplete', 'combobox', 'textarea']
 ---
 
 ```jsx live

--- a/packages/react/src/text-link/docs/overview.mdx
+++ b/packages/react/src/text-link/docs/overview.mdx
@@ -4,6 +4,7 @@ description: A typographic component for creating hyperlinks.
 group: Navigation
 storybookPath: /story/navigation-textlink--basic
 figmaGalleryNodeId: 11981%3A101185
+relatedComponents: ['call-to-action', 'direction-link', 'text']
 ---
 
 ```jsx live

--- a/packages/react/src/text/docs/overview.mdx
+++ b/packages/react/src/text/docs/overview.mdx
@@ -3,6 +3,7 @@ title: Text
 description: A primitive typographic component for constrained text styles
 group: Foundations
 storybookPath: /story/foundations-text--basic
+relatedComponents: ['heading', 'text-link']
 ---
 
 `Text` uses the `fontGrid` function to make the font-size and line-height snap to grid.

--- a/packages/react/src/textarea/docs/overview.mdx
+++ b/packages/react/src/textarea/docs/overview.mdx
@@ -4,6 +4,7 @@ description: A text area lets users enter long-form plain text over multiple lin
 group: Forms
 storybookPath: /story/forms-textarea--basic
 figmaGalleryNodeId: 12444%3A100718
+relatedComponents: ['text-input']
 ---
 
 ```jsx live


### PR DESCRIPTION
## Describe your changes

Added a new section to the component documentation page which shows off "Related components".

Relationships between components have been created by adding array of component slugs to the frontmatter of components. Note: Not every component has related components.

[View preview here](https://design-system.agriculture.gov.au/pr-preview/pr-1065/components/text-input)

