### PR TITLE
progress-indicator: Add new status `started` status

### DIFF
--- a/.changeset/ninety-crabs-sniff.md
+++ b/.changeset/ninety-crabs-sniff.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+progress-indicator: Added new status `started` which can be used to indicate that the step has been partially completed but is not active or selected.

--- a/packages/react/src/progress-indicator/ProgressIndicator.stories.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicator.stories.tsx
@@ -1,64 +1,60 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { Box } from '../box';
-import {
-	ProgressIndicator,
-	ProgressIndicatorCollapseButton,
-	ProgressIndicatorHeading,
-	ProgressIndicatorItemButton,
-	ProgressIndicatorItemLink,
-	ProgressIndicatorList,
-} from './index';
+import { ProgressIndicator } from './index';
 
-export default {
+const meta: Meta<typeof ProgressIndicator> = {
 	title: 'forms/ProgressIndicator',
 	component: ProgressIndicator,
-	subcomponents: {
-		ProgressIndicatorCollapseButton,
-		ProgressIndicatorHeading,
-		ProgressIndicatorItemButton,
-		ProgressIndicatorItemLink,
-		ProgressIndicatorList,
-	},
-} as ComponentMeta<typeof ProgressIndicator>;
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
 
 const exampleLinkItems = [
 	{ href: '#', label: 'Introduction', status: 'done' as const },
-	{ href: '#', label: 'Business Contacts', status: 'doing' as const },
-	{ href: '#', label: 'Case Studies', status: 'todo' as const },
+	{ href: '#', label: 'Organisations', status: 'started' as const },
+	{ href: '#', label: 'Business contacts', status: 'doing' as const },
+	{ href: '#', label: 'Case studies', status: 'todo' as const },
 	{ href: '#', label: 'Attachments', status: 'blocked' as const },
 ];
 
 const exampleButtonItems = [
 	{ onClick: console.log, label: 'Introduction', status: 'done' as const },
+	{ onClick: console.log, label: 'Organisations', status: 'started' as const },
 	{
 		onClick: console.log,
-		label: 'Business Contacts',
+		label: 'Business contacts',
 		status: 'doing' as const,
 	},
-	{ onClick: console.log, label: 'Case Studies', status: 'todo' as const },
+	{ onClick: console.log, label: 'Case studies', status: 'todo' as const },
+	{ onClick: console.log, label: 'Attachments', status: 'blocked' as const },
 ];
 
-export const Basic: ComponentStory<typeof ProgressIndicator> = (args) => (
-	<ProgressIndicator {...args} />
-);
-Basic.args = {
-	items: exampleLinkItems,
+export const Basic: Story = {
+	args: {
+		items: exampleLinkItems,
+	},
 };
 
-export const OnBodyAlt: ComponentStory<typeof ProgressIndicator> = (args) => (
-	<Box background="bodyAlt" padding={1.5}>
-		<ProgressIndicator {...args} />
-	</Box>
-);
-OnBodyAlt.storyName = 'On bodyAlt background';
-OnBodyAlt.args = {
-	background: 'bodyAlt',
-	items: exampleLinkItems,
+export const OnBodyAlt: Story = {
+	name: 'On bodyAlt background',
+	args: {
+		background: 'bodyAlt',
+		items: exampleButtonItems,
+	},
+	parameters: {
+		layout: 'fullscreen',
+	},
+	render: (props) => (
+		<Box background="bodyAlt" padding={1.5}>
+			<ProgressIndicator {...props} />
+		</Box>
+	),
 };
 
-export const Button: ComponentStory<typeof ProgressIndicator> = (args) => (
-	<ProgressIndicator {...args} />
-);
-Button.args = {
-	items: exampleButtonItems,
+export const Buttons: Story = {
+	args: {
+		items: exampleButtonItems,
+	},
 };

--- a/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
@@ -220,6 +220,11 @@ const statusMap = {
 		icon: ProgressDoingIcon,
 		iconColor: 'action',
 	},
+	started: {
+		label: 'In progress',
+		icon: ProgressDoingIcon,
+		iconColor: 'border',
+	},
 	todo: {
 		label: 'Not started',
 		icon: ProgressTodoIcon,

--- a/packages/react/src/progress-indicator/docs/overview.mdx
+++ b/packages/react/src/progress-indicator/docs/overview.mdx
@@ -10,8 +10,9 @@ figmaGalleryNodeId: 12444%3A100448
 <ProgressIndicator
 	items={[
 		{ href: '#', label: 'Introduction', status: 'done' },
-		{ href: '#', label: 'Business Contacts', status: 'doing' },
-		{ href: '#', label: 'Case Studies', status: 'todo' },
+		{ href: '#', label: 'Organisations', status: 'started' },
+		{ href: '#', label: 'Business contacts', status: 'doing' },
+		{ href: '#', label: 'Case studies', status: 'todo' },
 		{ href: '#', label: 'Attachments', status: 'blocked' },
 	]}
 />
@@ -60,21 +61,30 @@ The `status` prop can be used to indicate the status of each item. The following
 				<code>todo</code>
 			</TableCell>
 			<TableCell>Not started</TableCell>
-			<TableCell>The task is available for the user to do</TableCell>
+			<TableCell>The step is available for the user to do</TableCell>
 		</tr>
 		<tr>
 			<TableCell>
 				<code>doing</code>
 			</TableCell>
 			<TableCell>In progress</TableCell>
-			<TableCell>The task is currently active or selected</TableCell>
+			<TableCell>The step is currently active or selected</TableCell>
+		</tr>
+		<tr>
+			<TableCell>
+				<code>started</code>
+			</TableCell>
+			<TableCell>In progress</TableCell>
+			<TableCell>
+				The step has been partially completed but is not active or selected
+			</TableCell>
 		</tr>
 		<tr>
 			<TableCell>
 				<code>done</code>
 			</TableCell>
 			<TableCell>Completed</TableCell>
-			<TableCell>The task has been completed</TableCell>
+			<TableCell>The step has been completed</TableCell>
 		</tr>
 		<tr>
 			<TableCell>
@@ -94,8 +104,9 @@ If an item does not specify a `href` attribute a `button` element will be render
 <ProgressIndicator
 	items={[
 		{ onClick: console.log, label: 'Introduction', status: 'done' },
-		{ onClick: console.log, label: 'Business Contacts', status: 'doing' },
-		{ onClick: console.log, label: 'Case Studies', status: 'todo' },
+		{ onClick: console.log, label: 'Organisations', status: 'started' },
+		{ onClick: console.log, label: 'Business contacts', status: 'doing' },
+		{ onClick: console.log, label: 'Case studies', status: 'todo' },
 		{ onClick: console.log, label: 'Attachments', status: 'blocked' },
 	]}
 />


### PR DESCRIPTION
## Describe your changes

Added new status `started` which can be used to indicate that the step has been partially completed but is not active or selected.

[View preview here](https://design-system.agriculture.gov.au/pr-preview/pr-1068/components/progress-indicator)

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).