### PR TITLE
Update eslintconfig for JS scripts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -58,5 +58,12 @@ module.exports = {
 				'import/no-anonymous-default-export': 'off',
 			},
 		},
+		// Scrips written in plain JS need to use require
+		{
+			files: ['*.js'],
+			rules: {
+				'@typescript-eslint/no-var-requires': 'off',
+			},
+		},
 	],
 };

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 const withPreconstruct = require('@preconstruct/next');
 
 // We use a github action for pull requests deploy preview

--- a/docs/scripts/generateComponentProps.js
+++ b/docs/scripts/generateComponentProps.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');

--- a/docs/scripts/generateGuideImages.js
+++ b/docs/scripts/generateGuideImages.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const puppeteer = require('puppeteer');
 const sharp = require('sharp');
 

--- a/docs/scripts/generateTemplateImages.js
+++ b/docs/scripts/generateTemplateImages.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 const { normalize } = require('path');
 const { readdir, readFile } = require('fs/promises');
 const puppeteer = require('puppeteer');

--- a/example-form/next.config.js
+++ b/example-form/next.config.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 const withPreconstruct = require('@preconstruct/next');
 
 const basePath = [process.env.BASE_PATH, '/example-form']

--- a/example-site/next.config.js
+++ b/example-site/next.config.js
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-
 const withPreconstruct = require('@preconstruct/next');
 
 const basePath = [process.env.BASE_PATH, '/example-site']


### PR DESCRIPTION
## Describe your changes

Updated our ESLint config to disable the `typescript-eslint/no-var-requires` rule in our plain Javascript files. This change means we can stop manually disabling this rule in every JS file.