### PR TITLE
main-nav: Remove custom icons

### DIFF
--- a/.changeset/chilly-fireants-move.md
+++ b/.changeset/chilly-fireants-move.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+main-nav: Replaced custom inline icons with design system icons `MenuIcon` and `CloseIcon`

--- a/packages/react/src/main-nav/MainNav.tsx
+++ b/packages/react/src/main-nav/MainNav.tsx
@@ -4,10 +4,15 @@ import { NavList, NavListItem } from './NavList';
 import { findBestMatch, MainNavBackground } from './utils';
 
 export type MainNavProps = PropsWithChildren<{
+	/** Used for highlighting the active navigation item. */
 	activePath?: string;
+	/** The background of the component. */
 	background?: MainNavBackground;
+	/** Defines an identifier (ID) which must be unique. */
 	id?: string;
+	/** List of navigation items to display. */
 	items?: NavListItem[];
+	/** Optional list of navigation items to display on the right of the component. */
 	secondaryItems?: NavListItem[];
 }>;
 

--- a/packages/react/src/main-nav/MenuButtons.tsx
+++ b/packages/react/src/main-nav/MenuButtons.tsx
@@ -2,6 +2,7 @@ import { MouseEventHandler, PropsWithChildren } from 'react';
 import { BaseButton } from '../button';
 import { Box, Flex } from '../box';
 import { boxPalette } from '../core';
+import { CloseIcon, MenuIcon } from '../icon';
 import { localPalette } from './utils';
 
 export type MainNavButtonProps = PropsWithChildren<{
@@ -46,19 +47,7 @@ export function OpenButton({ onClick }: MainNavButtonProps) {
 			aria-expanded="false"
 			aria-label="Open main menu"
 		>
-			<svg
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="currentcolor"
-				xmlns="http://www.w3.org/2000/svg"
-				aria-hidden="true"
-				focusable="false"
-			>
-				<rect x="4" y="16" width="16" height="2" />
-				<rect x="4" y="11" width="16" height="2" />
-				<rect x="4" y="6" width="16" height="2" />
-			</svg>
+			<MenuIcon />
 			Menu
 		</MainNavButton>
 	);
@@ -72,30 +61,7 @@ export function CloseButton({ onClick }: MainNavButtonProps) {
 			aria-expanded="true"
 			aria-label="Close main menu"
 		>
-			<svg
-				width="24"
-				height="24"
-				viewBox="0 0 24 24"
-				fill="currentcolor"
-				xmlns="http://www.w3.org/2000/svg"
-				aria-hidden="true"
-				focusable="false"
-			>
-				<rect
-					x="6"
-					y="17.3137"
-					width="16"
-					height="2"
-					transform="rotate(-45 6 17.3137)"
-				/>
-				<rect
-					x="7.41406"
-					y="6"
-					width="16"
-					height="2"
-					transform="rotate(45 7.41406 6)"
-				/>
-			</svg>
+			<CloseIcon />
 			Close
 		</MainNavButton>
 	);

--- a/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
@@ -27,30 +27,23 @@ exports[`MainNav renders correctly 1`] = `
           >
             <svg
               aria-hidden="true"
-              fill="currentcolor"
+              class="css-9s3cfn-Icon"
+              clip-rule="evenodd"
               focusable="false"
               height="24"
+              role="img"
               viewBox="0 0 24 24"
               width="24"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <rect
-                height="2"
-                width="16"
-                x="4"
-                y="16"
+              <path
+                d="M3 6H21"
               />
-              <rect
-                height="2"
-                width="16"
-                x="4"
-                y="11"
+              <path
+                d="M3 12H21"
               />
-              <rect
-                height="2"
-                width="16"
-                x="4"
-                y="6"
+              <path
+                d="M3 18H21"
               />
             </svg>
             Menu
@@ -80,26 +73,20 @@ exports[`MainNav renders correctly 1`] = `
               >
                 <svg
                   aria-hidden="true"
-                  fill="currentcolor"
+                  class="css-9s3cfn-Icon"
+                  clip-rule="evenodd"
                   focusable="false"
                   height="24"
+                  role="img"
                   viewBox="0 0 24 24"
                   width="24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
-                  <rect
-                    height="2"
-                    transform="rotate(-45 6 17.3137)"
-                    width="16"
-                    x="6"
-                    y="17.3137"
+                  <path
+                    d="M5 19L19 5"
                   />
-                  <rect
-                    height="2"
-                    transform="rotate(45 7.41406 6)"
-                    width="16"
-                    x="7.41406"
-                    y="6"
+                  <path
+                    d="M19 19L5 5"
                   />
                 </svg>
                 Close


### PR DESCRIPTION
## Describe your changes

Replaced custom inline icons with design system icons `MenuIcon` and `CloseIcon`. I noticed these while doing the App shell work.

I believe this happened because this component was one of the first that was built, before the icon library began to take shape. When `MenuIcon` and `CloseIcon` were added - we didn't update this component.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1080/) (ust shrink your browser until you see the main nav mobile version appear)

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).