### PR TITLE
docs: Add base path to images

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -31,12 +31,13 @@ import {
 	ChevronDownIcon,
 	ChevronUpIcon,
 } from '@ag.ds-next/react/icon';
+import { withBasePath } from '../lib/img';
 import * as designSystemComponents from './designSystemComponents';
 import { prismTheme } from './prism-theme';
 
 const PlaceholderImage = () => (
 	<img
-		src="/img/placeholder/600X260.png"
+		src={withBasePath('/img/placeholder/600X260.png')}
 		alt="Grey placeholder image"
 		css={{ width: '100%' }}
 	/>

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -4,6 +4,7 @@ import {
 	isValidElement,
 	HTMLAttributes,
 	AnchorHTMLAttributes,
+	ImgHTMLAttributes,
 } from 'react';
 import type { MDXRemoteProps } from 'next-mdx-remote';
 import Link from 'next/link';
@@ -21,6 +22,7 @@ import {
 	TableWrapper,
 } from '@ag.ds-next/react/table';
 import { slugify } from '../lib/slugify';
+import { withBasePath } from '../lib/img';
 import generatedComponentPropsData from '../__generated__/componentProps.json';
 import { Code } from './Code';
 import { ComponentPropsTable } from './ComponentPropsTable';
@@ -42,6 +44,9 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 			</Fragment>
 		);
 	},
+	img: ({ alt, src, ...props }: ImgHTMLAttributes<HTMLImageElement>) => (
+		<img alt={alt} src={withBasePath(src)} {...props} />
+	),
 	ButtonLink,
 	FigmaEmbed: ({ src }: { src: string }) => (
 		<Box

--- a/docs/lib/img.ts
+++ b/docs/lib/img.ts
@@ -4,5 +4,8 @@
  * See next.config.js
  */
 export function withBasePath(src: string | undefined) {
+	if (!src) return;
+	// Don't replace external images
+	if (/^(https?:\/\/|\/\/)/i.test(src)) return src;
 	return [process.env.NEXT_PUBLIC_BASE_PATH, src].filter(Boolean).join('');
 }

--- a/docs/lib/img.ts
+++ b/docs/lib/img.ts
@@ -1,0 +1,8 @@
+/**
+ * We use a github action for pull requests deploy preview
+ * As they get published on a subpath, we need to also set the base path of images
+ * See next.config.js
+ */
+export function withBasePath(src: string | undefined) {
+	return [process.env.NEXT_PUBLIC_BASE_PATH, src].filter(Boolean).join('');
+}

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -9,6 +9,9 @@ const basePath = process.env.BASE_PATH ?? undefined;
 const nextConfig = {
 	reactStrictMode: true,
 	basePath,
+	env: {
+		NEXT_PUBLIC_BASE_PATH: basePath,
+	},
 };
 
 module.exports = withPreconstruct(nextConfig);

--- a/docs/pages/foundations/tokens/colour.tsx
+++ b/docs/pages/foundations/tokens/colour.tsx
@@ -9,6 +9,7 @@ import { ColorTable } from '../../../components/TokenColorTable';
 import { TokenLayout } from '../../../components/TokenLayout';
 import { LinkComponent } from '../../../components/LinkComponent';
 import { getTokensBreadcrumbs, TOKEN_PAGES } from '../../../content/tokens';
+import { withBasePath } from '../../../lib/img';
 
 export default function TokensColorPage() {
 	const [isDarkMode, setDarkMode] = useState(false);
@@ -95,7 +96,7 @@ export default function TokensColorPage() {
 
 						<Box paddingTop={[1, 0]}>
 							<img
-								src="/img/guides/home.webp"
+								src={withBasePath('/img/guides/home.webp')}
 								alt="Screenshot of a successful usage of palettes"
 							/>
 						</Box>

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -13,6 +13,7 @@ import { ButtonLink } from '@ag.ds-next/react/button';
 import { AppLayout } from '../components/AppLayout';
 import { PictogramCard } from '../components/PictogramCard';
 import { DocumentTitle } from '../components/DocumentTitle';
+import { withBasePath } from '../lib/img';
 
 const description =
 	'AgDS is a suite of tools and guidelines to help designers and developers build the steel threads of the Export Service with efficiency and consistency.';
@@ -23,7 +24,13 @@ export default function Homepage() {
 			<DocumentTitle description={description} />
 			<AppLayout>
 				<HeroBanner
-					image={<img src="/img/agds-hero.webp" role="presentation" alt="" />}
+					image={
+						<img
+							src={withBasePath('/img/agds-hero.webp')}
+							role="presentation"
+							alt=""
+						/>
+					}
 				>
 					<HeroBannerTitleContainer>
 						<HeroBannerTitle>

--- a/docs/pages/patterns/[slug]/index.tsx
+++ b/docs/pages/patterns/[slug]/index.tsx
@@ -9,6 +9,7 @@ import {
 	getPatternSlugs,
 	Pattern,
 } from '../../../lib/mdx/patterns';
+import { withBasePath } from '../../../lib/img';
 import { PatternLayout } from '../../../components/PatternLayout';
 import { mdxComponents } from '../../../components/mdxComponents';
 import { DocumentTitle } from '../../../components/DocumentTitle';
@@ -34,7 +35,7 @@ export default function PatternOverviewPage({
 					{pattern.group === 'templates' ? (
 						<Box border borderColor="muted" css={{ img: { display: 'block' } }}>
 							<img
-								src={`/img/templates/${pattern.slug}.webp`}
+								src={withBasePath(`//img/templates/${pattern.slug}.webp`)}
 								role="presentation"
 								alt=""
 							/>

--- a/docs/pages/patterns/index.tsx
+++ b/docs/pages/patterns/index.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../lib/mdx/patterns';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { CategoryPageTemplate } from '../../components/CategoryPageTemplate';
+import { withBasePath } from '../../lib/img';
 
 type StaticProps = Awaited<ReturnType<typeof getStaticProps>>['props'];
 
@@ -74,7 +75,7 @@ function PatternCard({
 				</CardInner>
 				{group === 'templates' ? (
 					<img
-						src={`/img/templates/${slug}.webp`}
+						src={withBasePath(`/img/templates/${slug}.webp`)}
 						role="presentation"
 						alt=""
 						height="auto"


### PR DESCRIPTION
## Describe your changes

We use a Github action for pull requests deploy preview. As the deploy previews get published on a sub-path, we need to prefix the paths of links and images with this sub-path. 

NextJS automatically prefixes links for us but our images do not contain the prefix. This means that at the moment any new images that are added in PR are not available to preview in the PR is merged.

This PR fixes this issue by ensuring local image paths are prefixed with the base path.

