### PR TITLE
app-layout: Use `bodyAlt` for AppLayoutSidebar

### DIFF
--- a/packages/react/src/app-layout/AppLayoutSidebar.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.tsx
@@ -20,7 +20,7 @@ export function AppLayoutSidebar({ activePath, items }: AppLayoutSidebarProps) {
 			<Stack
 				as="aside"
 				gap={1}
-				background="shade"
+				background="bodyAlt"
 				borderRight
 				borderColor="muted"
 				flexGrow={1}

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -128,7 +128,7 @@ function AppLayoutSidebarNavItemInner({
 					...(isActive && {
 						position: 'relative',
 						fontWeight: tokens.fontWeight.bold,
-						background: boxPalette.backgroundBody,
+						background: boxPalette.backgroundShadeAlt,
 						color: boxPalette.foregroundText,
 						'&:before': {
 							content: "''",
@@ -149,7 +149,7 @@ function AppLayoutSidebarNavItemInner({
 					}),
 
 					'&:hover': {
-						background: boxPalette.backgroundBody,
+						background: boxPalette.backgroundShadeAlt,
 						color: boxPalette.foregroundText,
 						'& span:first-of-type': {
 							textDecoration: 'underline',

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -147,7 +147,7 @@ exports[`AppLayout renders correctly 1`] = `
       </div>
     </header>
     <aside
-      class="css-qmgybk-boxStyles-AppLayoutSidebar"
+      class="css-1r9ioti-boxStyles-AppLayoutSidebar"
     >
       <nav
         aria-label="main"
@@ -157,7 +157,7 @@ exports[`AppLayout renders correctly 1`] = `
           class="css-o80hmi-boxStyles"
         >
           <li
-            class="css-1dlv8vn-AppLayoutSidebarNavItemInner"
+            class="css-1y1qeh5-AppLayoutSidebarNavItemInner"
           >
             <a
               aria-current="page"
@@ -187,7 +187,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-172k8w9-AppLayoutSidebarNavItemInner"
+            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
           >
             <a
               href="#establishments"
@@ -226,7 +226,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-172k8w9-AppLayoutSidebarNavItemInner"
+            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
           >
             <a
               href="#intelligence"
@@ -252,7 +252,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-172k8w9-AppLayoutSidebarNavItemInner"
+            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
           >
             <a
               href="#compliance"
@@ -291,7 +291,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-5xtwjg-AppLayoutSidebarNavItemInner"
+            class="css-1c7lu52-AppLayoutSidebarNavItemInner"
           >
             <a
               href="#account/messages"
@@ -322,7 +322,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-172k8w9-AppLayoutSidebarNavItemInner"
+            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
           >
             <a
               href="#account/settings"
@@ -353,7 +353,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-172k8w9-AppLayoutSidebarNavItemInner"
+            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
           >
             <a
               href="#help"
@@ -387,7 +387,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-172k8w9-AppLayoutSidebarNavItemInner"
+            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
           >
             <button
               class="css-6e6ykx-BaseButton"


### PR DESCRIPTION
Change on-top of AppLayout PR to propose a change in component usage.

- AppLayoutSidebar now uses 'bodyAlt' background as it should be considered a body area for content
- the active/hover state should use 'shadeAlt' as we use shades to tint content. shadeAlt sits within a bodyAlt area.

<img width="2036" alt="image" src="https://user-images.githubusercontent.com/12689383/235593242-965b82f1-a62a-4665-b605-d2ae1d255281.png">
