### PR TITLE
core: Update `transition` token

### DIFF
--- a/packages/react/src/accordion/AccordionTitle.tsx
+++ b/packages/react/src/accordion/AccordionTitle.tsx
@@ -53,7 +53,7 @@ export const AccordionTitle = ({
 					weight="bold"
 					size="sm"
 					css={{
-						transition: `transform ${tokens.transition.duration} ${tokens.transition.timingFunction}`,
+						transition: `transform ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 						transform: `rotate(${isOpen ? 180 : 0}deg)`,
 					}}
 				/>

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -114,8 +114,8 @@ const borderWidth = {
 export type BorderWidth = keyof typeof borderWidth;
 
 const transition = {
-	duration: '250ms',
-	timingFunction: 'ease',
+	duration: 250, // in milliseconds (ms)
+	timingFunction: 'ease', // https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function
 };
 
 export const tokens = {

--- a/packages/react/src/modal/ModalCover.tsx
+++ b/packages/react/src/modal/ModalCover.tsx
@@ -18,7 +18,7 @@ export const ModalCover = forwardRef<HTMLDivElement, ModalCoverProps>(
 					backgroundColor: `rgba(0, 0, 0, 0.8)`,
 					zIndex: 100,
 					overflowY: 'auto',
-					animation: `${animateFadeInOut} ${tokens.transition.duration} ${tokens.transition.timingFunction}`,
+					animation: `${animateFadeInOut} ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 				}}
 			>
 				{children}

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -41,7 +41,7 @@ export const ModalDialog = ({
 					position: 'relative',
 					margin: '0 auto',
 					minHeight: '100vh',
-					animation: `${animateSlideInUp} ${tokens.transition.duration}  ${tokens.transition.timingFunction}`,
+					animation: `${animateSlideInUp} ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 					[tokens.mediaQuery.min.sm]: {
 						margin: `${mapSpacing(6)} auto ${mapSpacing(1)}`,
 						minHeight: 'auto',

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Modal renders correctly 1`] = `
       <div
         aria-labelledby="modal-:r0:-title"
         aria-modal="true"
-        class="css-1vaislj-boxStyles-ModalDialog"
+        class="css-2sldpu-boxStyles-ModalDialog"
         role="dialog"
       >
         <h2

--- a/packages/react/src/progress-indicator/ProgressIndicatorCollapseButton.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicatorCollapseButton.tsx
@@ -53,7 +53,7 @@ export const ProgressIndicatorCollapseButton = ({
 				size="sm"
 				weight="bold"
 				css={{
-					transition: `transform ${tokens.transition.duration} ${tokens.transition.timingFunction}`,
+					transition: `transform ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 					transform: `rotate(${isOpen ? 180 : 0}deg)`,
 				}}
 			/>

--- a/packages/react/src/side-nav/SideNavCollapseButton.tsx
+++ b/packages/react/src/side-nav/SideNavCollapseButton.tsx
@@ -51,7 +51,7 @@ export const SideNavCollapseButton = ({
 				size="sm"
 				weight="bold"
 				css={{
-					transition: `transform ${tokens.transition.duration} ${tokens.transition.timingFunction}`,
+					transition: `transform ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 					transform: `rotate(${isOpen ? 180 : 0}deg)`,
 				}}
 			/>

--- a/packages/react/src/switch/SwitchTrack.tsx
+++ b/packages/react/src/switch/SwitchTrack.tsx
@@ -75,7 +75,7 @@ export const SwitchThumb = ({ checked, size }: SwitchThumbProps) => {
 				borderStyle: 'solid',
 				borderColor: boxPalette.foregroundAction,
 				position: 'absolute',
-				transition: `left ${tokens.transition.duration} ${tokens.transition.timingFunction}`,
+				transition: `left ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 				left: checked ? thumbCheckedPos : '0rem',
 			}}
 		>


### PR DESCRIPTION
## Describe your changes

Follow up to https://github.com/steelthreads/agds-next/pull/1088

This PR updates our `transition.duration` token to be a number which is more consistent with our other tokens. For example, we define `borderRadius` as `4`, not `4px` and we define `fontSize` as `16`, not `16rem`,

This change means we can also use this token in Javascript easily, for example with react-spring:

```
useSpring({ ..., config: { duration: tokens.transition.duration })
```