### PR TITLE
docs: Update mismatched documentation for background tokens

### DIFF
--- a/docs/components/TokenColorTable.tsx
+++ b/docs/components/TokenColorTable.tsx
@@ -52,12 +52,12 @@ const colourTokens = {
 		bodyAlt: {
 			light: theme.lightBackgroundBodyAlt,
 			dark: theme.darkBackgroundBodyAlt,
-			desc: 'Used to help differentiate or highlight interface components that sit on `body` background. For example, hover states for interactive components, callouts, and Zebra stripes on tables.',
+			desc: 'Used as an alternative background.',
 		},
 		shade: {
 			light: theme.lightBackgroundShade,
 			dark: theme.darkBackgroundShade,
-			desc: 'Used as an alternative background.',
+			desc: 'Used to help differentiate or highlight interface components that sit on `body` background. For example, hover states for interactive components, callouts, and Zebra stripes on tables.',
 		},
 		shadeAlt: {
 			light: theme.lightBackgroundShadeAlt,


### PR DESCRIPTION
I think I got these values around the wrong way when I initially developed this page.

This change accurately documents the purpose of the shade and shadeAlt tokens