### PR TITLE
tokens: Add `xxl` border token

### DIFF
--- a/.changeset/many-knives-confess.md
+++ b/.changeset/many-knives-confess.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: Added new border token `xxl` which has a value of 8px.

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -109,6 +109,7 @@ const borderWidth = {
 	md: 2,
 	lg: 3,
 	xl: 4,
+	xxl: 8,
 } as const;
 
 export type BorderWidth = keyof typeof borderWidth;

--- a/packages/react/src/main-nav/MainNav.stories.tsx
+++ b/packages/react/src/main-nav/MainNav.stories.tsx
@@ -1,107 +1,100 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { AvatarIcon } from '../icon';
 import { NotificationBadge } from '../badge';
 import { MainNav } from './MainNav';
 import { MainNavBottomBar } from './MainNavBottomBar';
 
-export default {
+const meta: Meta<typeof MainNav> = {
 	title: 'navigation/MainNav',
 	component: MainNav,
-	subcomponents: { MainNavBottomBar },
-} as ComponentMeta<typeof MainNav>;
-
-const NAV_ITEMS = [
-	{ href: '#home', label: 'Home' },
-	{ href: '#content', label: 'Content page' },
-	{ href: '#form', label: 'Form page' },
-	{ href: '#simple', label: 'Simple page' },
-];
-
-const defaultArgs = {
-	items: NAV_ITEMS,
-	activePath: '#content',
-	background: 'body',
-} as const;
-
-const Template: ComponentStory<typeof MainNav> = (args) => (
-	<MainNav {...args} />
-);
-
-export const Body = Template.bind({});
-Body.args = {
-	...defaultArgs,
-	background: 'body',
-};
-Body.storyName = 'Body background';
-
-export const BodyAlt = Template.bind({});
-BodyAlt.args = {
-	...defaultArgs,
-	background: 'bodyAlt',
-};
-BodyAlt.storyName = 'BodyAlt background';
-
-export const HeaderRightLinks = Template.bind({});
-HeaderRightLinks.args = {
-	...defaultArgs,
-	activePath: '#messages',
-	secondaryItems: [
-		{
-			href: '#messages',
-			label: 'Messages',
-			endElement: <NotificationBadge tone="action" value={5} />,
-		},
-		{
-			href: '#sign-in',
-			label: 'Sign in',
-			endElement: <AvatarIcon color="action" />,
-		},
-	],
+	args: {
+		items: [
+			{ href: '#home', label: 'Home' },
+			{ href: '#content', label: 'Content page' },
+			{ href: '#form', label: 'Form page' },
+			{ href: '#simple', label: 'Simple page' },
+		],
+		activePath: '#content',
+	},
 };
 
-export const HeaderRightButton = Template.bind({});
-HeaderRightButton.args = {
-	...defaultArgs,
-	secondaryItems: [
-		{
-			onClick: console.log,
-			label: 'Sign in',
-			endElement: <AvatarIcon color="action" />,
-		},
-	],
+export default meta;
+
+type Story = StoryObj<typeof MainNav>;
+
+export const Body: Story = {
+	storyName: 'Body background',
+	args: {
+		background: 'body',
+	},
 };
 
-export const NoLinks = Template.bind({});
-NoLinks.args = {
-	...defaultArgs,
-	items: undefined,
-	secondaryItems: [
-		{
-			onClick: console.log,
-			label: 'Sign in',
-			endElement: <AvatarIcon color="action" />,
-		},
-	],
+export const BodyAlt: Story = {
+	storyName: 'BodyAlt background',
+	args: {
+		background: 'bodyAlt',
+	},
 };
 
-export const EndElement = Template.bind({});
-EndElement.args = {
-	...defaultArgs,
-	activePath: '#issues',
-	items: [
-		{ href: '#home', label: 'Home' },
-		{ href: '#code', label: 'Code' },
-		{
-			href: '#issues',
-			label: 'Issues',
-			endElement: <NotificationBadge tone="action" value={5} />,
-		},
-		{ href: '#pull-requests', label: 'Pull requests' },
-		{ href: '#security', label: 'Security' },
-		{ href: '#settings', label: 'Settings' },
-	],
+export const SecondaryLinks: Story = {
+	args: {
+		activePath: '#messages',
+		secondaryItems: [
+			{
+				href: '#messages',
+				label: 'Messages',
+				endElement: <NotificationBadge tone="action" value={5} />,
+			},
+			{
+				href: '#sign-in',
+				label: 'Sign in',
+				endElement: <AvatarIcon color="action" />,
+			},
+		],
+	},
 };
 
-export const BottomBar: ComponentStory<typeof MainNavBottomBar> = () => (
-	<MainNavBottomBar />
-);
+export const SecondaryButtons: Story = {
+	args: {
+		secondaryItems: [
+			{
+				onClick: console.log,
+				label: 'Sign in',
+				endElement: <AvatarIcon color="action" />,
+			},
+		],
+	},
+};
+
+export const NoItems: Story = {
+	args: {
+		items: undefined,
+		secondaryItems: [
+			{
+				onClick: console.log,
+				label: 'Sign in',
+				endElement: <AvatarIcon color="action" />,
+			},
+		],
+	},
+};
+
+export const EndElement: Story = {
+	args: {
+		activePath: '#issues',
+		items: [
+			{ href: '#home', label: 'Home' },
+			{ href: '#code', label: 'Code' },
+			{
+				href: '#issues',
+				label: 'Issues',
+				endElement: <NotificationBadge tone="action" value={5} />,
+			},
+			{ href: '#pull-requests', label: 'Pull requests' },
+			{ href: '#security', label: 'Security' },
+			{ href: '#settings', label: 'Settings' },
+		],
+	},
+};
+
+export const BottomBar = () => <MainNavBottomBar />;

--- a/packages/react/src/main-nav/MainNavBottomBar.tsx
+++ b/packages/react/src/main-nav/MainNavBottomBar.tsx
@@ -1,12 +1,12 @@
 import { boxPalette } from '../core';
 import { Box } from '../box';
-import { bottomBarPadding } from './utils';
 
 export function MainNavBottomBar() {
 	return (
 		<Box
-			paddingTop={bottomBarPadding}
-			css={{ backgroundColor: boxPalette.accent }}
+			borderBottom
+			borderBottomWidth="xxl"
+			css={{ borderBottomColor: boxPalette.accent }}
 		/>
 	);
 }

--- a/packages/react/src/main-nav/NavContainer.tsx
+++ b/packages/react/src/main-nav/NavContainer.tsx
@@ -24,7 +24,6 @@ import {
 	MainNavBackground,
 	localPalette,
 	localPaletteVars,
-	bottomBarPadding,
 } from './utils';
 import { CloseButton, OpenButton } from './MenuButtons';
 
@@ -222,13 +221,14 @@ function Overlay({ onClick }: { onClick: MouseEventHandler<HTMLDivElement> }) {
 function BottomBar() {
 	return (
 		<Box
-			paddingTop={bottomBarPadding}
+			borderBottom
+			borderBottomWidth="xxl"
 			css={{
 				position: 'absolute',
 				bottom: 0,
 				left: 0,
 				right: 0,
-				backgroundColor: localPalette.bottomBar,
+				borderBottomColor: localPalette.bottomBar,
 			}}
 		/>
 	);

--- a/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`MainNav renders correctly 1`] = `
     tabindex="-1"
   >
     <div
-      class="css-51kibj-boxStyles-BottomBar"
+      class="css-1jzbc50-boxStyles-BottomBar"
     />
     <div
       class="css-zlf9wg-boxStyles-NavContainer"

--- a/packages/react/src/main-nav/utils.ts
+++ b/packages/react/src/main-nav/utils.ts
@@ -1,7 +1,5 @@
 import { NavListLink, NavListItem } from './NavList';
 
-export const bottomBarPadding = 0.5;
-
 export const hoverMap = {
 	body: 'shade',
 	bodyAlt: 'shadeAlt',


### PR DESCRIPTION
## Describe your changes

Currently we have 4 border tokens: `sm (1px)`, `md (2px)`, `lg (3px)` and `xl (4px)`.

However, in the Main nav component we have a custom border value of 8px. I think this has been fine, but we have re-used this custom border in the App layout header component, so I feel like this is the right time to "tokenise" this new border value.

In the following PR, I have added a new `xxl` border token of `8px` so that it can be used across Main nav and App layout Header.