### PR TITLE
docs: fix typo in single page form template

### DIFF
--- a/docs/content/patterns/single-page-form/index.mdx
+++ b/docs/content/patterns/single-page-form/index.mdx
@@ -44,7 +44,7 @@ Instead, allow users to interact with buttons and receive feedback.
 
 ### Error messages
 
-A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [PageAlert](/components/page-alert) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
+A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [Page alert](/components/page-alert) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
 
 If only one error is present, the error summary can be omitted and the invalid field can be focused.
 
@@ -52,4 +52,4 @@ An invalid field is highlighted with a red border and a red error message. They 
 
 ### Success messaging
 
-When a form is successfully completed, return the user to the entry point of the form and display a [PageAlert](/components/page-alert) with the 'success' tone and a clear message which communicates the successful submission. When possible, provide persistent methods for a user to return and see the status of the submitted artefact, for example a reference number.
+When a form is successfully completed, return the user to the entry point of the form and display a [Page alert](/components/page-alert) with the 'success' tone and a clear message which communicates the successful submission. When possible, provide persistent methods for a user to return and see the status of the submitted artefact, for example a reference number.

--- a/docs/content/patterns/single-page-form/index.mdx
+++ b/docs/content/patterns/single-page-form/index.mdx
@@ -44,7 +44,7 @@ Instead, allow users to interact with buttons and receive feedback.
 
 ### Error messages
 
-A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [PageAlert](/components/page-alert)) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
+A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [PageAlert](/components/page-alert) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
 
 If only one error is present, the error summary can be omitted and the invalid field can be focused.
 


### PR DESCRIPTION
- Fixed small typo
- Renamed `PageAlert` to `Page alert`