### PR TITLE
app-layout: Update  header branding hover state

### DIFF
--- a/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
@@ -41,7 +41,7 @@ export const FocusMode: Story = {
 	),
 };
 
-export const WithouSubline: Story = {
+export const WithoutSubline: Story = {
 	args: {
 		subLine: undefined,
 	},

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -1,5 +1,11 @@
 import { Flex } from '../box';
-import { boxPalette, mapSpacing, tokens, useLinkComponent } from '../core';
+import {
+	boxPalette,
+	mapSpacing,
+	packs,
+	tokens,
+	useLinkComponent,
+} from '../core';
 import { Text } from '../text';
 
 export type AppLayoutHeaderBrandProps = {
@@ -27,6 +33,7 @@ export function AppLayoutHeaderBrand({
 			color="text"
 			css={{
 				textDecoration: 'none',
+				'&:hover': packs.underline,
 				// Logo styles
 				svg: { display: 'block', height: '3.75rem' },
 			}}

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`AppLayout renders correctly 1`] = `
         class="css-1aywuo5-boxStyles"
       >
         <a
-          class="css-1i04zgw-boxStyles-AppLayoutHeaderBrand"
+          class="css-2ixix2-boxStyles-AppLayoutHeaderBrand"
           href="#"
         >
           <svg


### PR DESCRIPTION
## Describe your changes

Update hover state of our `AppLayoutHeader` component to match `Header`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1098/storybook/index.html?path=/story/layout-applayout--basic)

### Example screenshot

<img width="1208" alt="Screenshot 2023-05-08 at 10 11 44 am" src="https://user-images.githubusercontent.com/6265154/236709536-2ed85c98-65a2-4022-a6ed-5ed93b5dcede.png">
