### PR TITLE
app-layout: Fix shrinking/wrapping in `AppLayoutHeader`

### DIFF
--- a/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
@@ -61,3 +61,13 @@ export const WithoutUserSecondaryText: Story = {
 		},
 	},
 };
+
+export const WithLongUserName: Story = {
+	args: {
+		accountDetails: {
+			href: '#account',
+			name: 'Mobutu Sese Seko Kuku Ngbendu Wa Za Banga',
+			secondaryText: 'Orange Meat Works',
+		},
+	},
+};

--- a/packages/react/src/app-layout/AppLayoutHeaderAccount.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderAccount.tsx
@@ -23,6 +23,7 @@ export function AppLayoutHeaderAccount({
 			href={href}
 			alignItems="center"
 			focus
+			flexShrink={0}
 			gap={1}
 			css={{
 				textDecoration: 'none',
@@ -34,7 +35,13 @@ export function AppLayoutHeaderAccount({
 				},
 			}}
 		>
-			<Flex flexDirection="column">
+			<Flex
+				flexDirection="column"
+				css={{
+					// Wrap long names at a sensible width
+					maxWidth: '16rem',
+				}}
+			>
 				<Text color="action" fontWeight="bold" fontSize="xs">
 					{name}
 				</Text>

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -35,7 +35,7 @@ export function AppLayoutHeaderBrand({
 				textDecoration: 'none',
 				'&:hover': packs.underline,
 				// Logo styles
-				svg: { display: 'block', height: '3.75rem' },
+				svg: { display: 'block', height: '3.75rem', flexShrink: 0 },
 			}}
 		>
 			{logo}

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`AppLayout renders correctly 1`] = `
         class="css-1aywuo5-boxStyles"
       >
         <a
-          class="css-2ixix2-boxStyles-AppLayoutHeaderBrand"
+          class="css-10e1rls-boxStyles-AppLayoutHeaderBrand"
           href="#"
         >
           <svg
@@ -62,11 +62,11 @@ exports[`AppLayout renders correctly 1`] = `
           </div>
         </a>
         <a
-          class="css-a3q8q0-boxStyles-AppLayoutHeaderAccount"
+          class="css-gsfq1r-boxStyles-AppLayoutHeaderAccount"
           href="/account/preferences"
         >
           <div
-            class="css-o80hmi-boxStyles"
+            class="css-1bv5hke-boxStyles-AppLayoutHeaderAccount"
           >
             <span
               class="css-19uuw7q-boxStyles-Text"
@@ -120,11 +120,11 @@ exports[`AppLayout renders correctly 1`] = `
           </span>
         </button>
         <a
-          class="css-1v957my-boxStyles-AppLayoutHeaderAccount"
+          class="css-wk4htx-boxStyles-AppLayoutHeaderAccount"
           href="/account/preferences"
         >
           <div
-            class="css-o80hmi-boxStyles"
+            class="css-1bv5hke-boxStyles-AppLayoutHeaderAccount"
           >
             <span
               class="css-19uuw7q-boxStyles-Text"


### PR DESCRIPTION
## Describe your changes

Follow up to PR #1098  and PR #1059.

- Prevent coat of arms logo from shrinking when title or sub line is really long
- Prevent user account avatar from shrinking when title or sub line is really long
- Added max-width of `16rem` to user account which will wrap long names at a sensible width.
  -  Added story to show what a really long name could look like. [Preview here ](https://design-system.agriculture.gov.au/pr-preview/pr-1100/storybook/index.html?path=/story/layout-applayout-applayoutheader--with-long-user-name)
