### PR TITLE
app-layout: Add max-width to header title and subline

### DIFF
--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -43,6 +43,7 @@ export function AppLayoutHeaderBrand({
 				flexDirection="column"
 				justifyContent="center"
 				alignItems="flex-start"
+				maxWidth={tokens.maxWidth.bodyText}
 				css={{
 					// Border between logo and heading/subLine
 					[tokens.mediaQuery.min.md]: {

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </svg>
           <div
-            class="css-tq3w1z-boxStyles-AppLayoutHeaderBrand"
+            class="css-1l41q-boxStyles-AppLayoutHeaderBrand"
           >
             <span
               class="css-1lv1g9v-boxStyles-Text"


### PR DESCRIPTION
## Describe your changes

### Examples screenshots

With long subline

<img width="1701" alt="Screenshot 2023-05-09 at 9 42 40 am" src="https://user-images.githubusercontent.com/6265154/236960134-59eae518-5219-4ca1-8521-765326fd03ec.png">

With long title and subline

<img width="1699" alt="Screenshot 2023-05-09 at 9 42 56 am" src="https://user-images.githubusercontent.com/6265154/236960136-357f19fe-cc25-4718-b8f0-e551738653b5.png">
