### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -55,7 +55,7 @@ export default function AboutPage() {
 								</TextLink>
 							</li>
 							<li>
-								A suite of <TextLink href="/templates">page templates</TextLink>{' '}
+								A suite of <TextLink href="/patterns">page templates</TextLink>{' '}
 								and interaction patterns
 							</li>
 							<li>Comprehensive documentation</li>

--- a/docs/pages/components/[slug]/accessibility.tsx
+++ b/docs/pages/components/[slug]/accessibility.tsx
@@ -35,7 +35,7 @@ export default function PackagesAccessibility({
 						href: '#pkg-content',
 					},
 				]}
-				editPath={`/packages/${pkg.slug}/docs/accessibility.mdx`}
+				editPath={`/packages/react/src/${pkg.slug}/docs/accessibility.mdx`}
 			>
 				{toc?.length > 1 ? (
 					<InpageNav

--- a/docs/pages/components/[slug]/code.tsx
+++ b/docs/pages/components/[slug]/code.tsx
@@ -35,7 +35,7 @@ export default function PackagesCode({
 						href: '#pkg-content',
 					},
 				]}
-				editPath={`/packages/${pkg.slug}/docs/code.mdx`}
+				editPath={`/packages/react/src/${pkg.slug}/docs/code.mdx`}
 			>
 				<InpageNav
 					title="On this page"

--- a/docs/pages/components/[slug]/content.tsx
+++ b/docs/pages/components/[slug]/content.tsx
@@ -35,7 +35,7 @@ export default function PackagesContent({
 						href: '#pkg-content',
 					},
 				]}
-				editPath={`/packages/${pkg.slug}/docs/content.mdx`}
+				editPath={`/packages/react/src/${pkg.slug}/docs/content.mdx`}
 			>
 				{toc?.length > 1 ? (
 					<InpageNav

--- a/docs/pages/components/[slug]/rationale.tsx
+++ b/docs/pages/components/[slug]/rationale.tsx
@@ -35,7 +35,7 @@ export default function PackagesRationale({
 						href: '#pkg-content',
 					},
 				]}
-				editPath={`/packages/${pkg.slug}/docs/rationale.mdx`}
+				editPath={`/packages/react/src/${pkg.slug}/docs/rationale.mdx`}
 			>
 				{toc?.length > 1 ? (
 					<InpageNav


### PR DESCRIPTION
## Describe your changes

- Fixes "Edit this page" broken link on the components page
- Fixes link  "/templates" section which has been moved to "/patterns"