### PR TITLE
Improve active filter tag formatting in medium table filtering example

### DIFF
--- a/.storybook/stories/DataFiltering/components/ActiveFilters.tsx
+++ b/.storybook/stories/DataFiltering/components/ActiveFilters.tsx
@@ -95,9 +95,9 @@ export const ActiveFilters = ({
 	removeFilter: (filter: keyof GetDataFilters) => void;
 	resetFilters: () => void;
 }) => {
-	const items = getTagsFromFilters({ filters, removeFilter });
+	const tags = getTagsFromFilters({ filters, removeFilter });
 
-	if (items.length === 0) {
+	if (tags.length === 0) {
 		return null;
 	}
 
@@ -105,7 +105,7 @@ export const ActiveFilters = ({
 		<Flex alignItems="flex-end">
 			<Tags
 				heading={<Text fontWeight="bold">Active filters</Text>}
-				items={items}
+				items={tags}
 			/>
 			<Button
 				size="sm"

--- a/.storybook/stories/DataFiltering/components/ActiveFilters.tsx
+++ b/.storybook/stories/DataFiltering/components/ActiveFilters.tsx
@@ -5,6 +5,8 @@ import { Button } from '@ag.ds-next/react/button';
 import { CloseIcon } from '@ag.ds-next/react/icon';
 import { Tags } from '@ag.ds-next/react/tags';
 import { GetDataFilters } from '../lib/getData';
+import { STATUS_MAP } from './DashboardTable';
+import { STATE_OPTIONS } from './FilterStateSelect';
 
 const formatDate = (date: Date | undefined) => {
 	if (!date) return;
@@ -30,7 +32,28 @@ const getTagsFromFilters = ({
 	}[] = [];
 
 	for (const [key, value] of filterEntries) {
+		if (!value) continue;
 		const formattedKey = formatFilterKey(key);
+		const onRemove = () => removeFilter(key);
+
+		if (key === 'state') {
+			const option = STATE_OPTIONS.find((o) => o.value === value);
+			if (!option) continue;
+			tags.push({
+				label: `${formattedKey}: ${option.label}`,
+				onRemove,
+			});
+			continue;
+		}
+
+		if (key === 'status') {
+			tags.push({
+				label: `${formattedKey}: ${STATUS_MAP[value].label}`,
+				onRemove,
+			});
+			continue;
+		}
+
 		if (key === 'requestDate') {
 			const fromDate =
 				value.from && typeof value.from !== 'string' ? value.from : undefined;
@@ -42,15 +65,12 @@ const getTagsFromFilters = ({
 				label: `${formattedKey}: ${[formatDate(fromDate), formatDate(toDate)]
 					.filter(Boolean)
 					.join(' - ')}`,
-				onRemove: () => removeFilter(key),
+				onRemove,
 			});
-		} else {
-			if (!value) continue;
-			tags.push({
-				label: `${formattedKey}: ${value}`,
-				onRemove: () => removeFilter(key),
-			});
+			continue;
 		}
+
+		tags.push({ label: `${formattedKey}: ${value}`, onRemove });
 	}
 
 	return tags;

--- a/.storybook/stories/DataFiltering/components/DashboardTable.tsx
+++ b/.storybook/stories/DataFiltering/components/DashboardTable.tsx
@@ -216,7 +216,7 @@ export const DashboardTable = forwardRef<HTMLTableElement, DashboardTableProps>(
 	}
 );
 
-const STATUS_MAP = {
+export const STATUS_MAP = {
 	notBooked: {
 		label: 'Not booked',
 		tone: 'neutral',

--- a/.storybook/stories/DataFiltering/components/FilterStateSelect.tsx
+++ b/.storybook/stories/DataFiltering/components/FilterStateSelect.tsx
@@ -14,16 +14,7 @@ export const FilterStateSelect = ({
 			label="State"
 			placeholder="All"
 			hideOptionalLabel
-			options={[
-				{ value: 'act', label: 'ACT' },
-				{ value: 'nsw', label: 'NSW' },
-				{ value: 'nt', label: 'NT' },
-				{ value: 'qld', label: 'QLD' },
-				{ value: 'sa', label: 'SA' },
-				{ value: 'tas', label: 'TAS' },
-				{ value: 'vic', label: 'VIC' },
-				{ value: 'wa', label: 'WA' },
-			]}
+			options={STATE_OPTIONS}
 			value={filters.state || ''}
 			aria-controls={tableId}
 			onChange={(e) => {
@@ -36,3 +27,14 @@ export const FilterStateSelect = ({
 		/>
 	);
 };
+
+export const STATE_OPTIONS = [
+	{ value: 'act', label: 'ACT' },
+	{ value: 'nsw', label: 'NSW' },
+	{ value: 'nt', label: 'NT' },
+	{ value: 'qld', label: 'QLD' },
+	{ value: 'sa', label: 'SA' },
+	{ value: 'tas', label: 'TAS' },
+	{ value: 'vic', label: 'VIC' },
+	{ value: 'wa', label: 'WA' },
+];


### PR DESCRIPTION
## Describe your changes

In the medium table filtering example, the value displayed in the tag has incorrect formatting. Some examples of this incorrect formatting are `Status: notBooked` and `State: act`.

In the following screenshot, you can see the formatting of the tags underneath "Active filters" has been fixed.

<img width="1240" alt="Screenshot 2023-05-15 at 2 53 14 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/37c3e5e7-21a4-4a23-9aba-5d74d28f9817">

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
