### PR TITLE
tags: Update wrapping behaviour

### DIFF
--- a/.changeset/metal-rivers-dance.md
+++ b/.changeset/metal-rivers-dance.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-tags: Updated wrapping behaviour the flowing of tags across multiple lines.
+tags: Enabled wrapping behaviour to allow tags to flow across multiple lines.

--- a/.changeset/metal-rivers-dance.md
+++ b/.changeset/metal-rivers-dance.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+tags: Updated wrapping behaviour the flowing of tags across multiple lines.

--- a/packages/react/src/tags/Tags.stories.tsx
+++ b/packages/react/src/tags/Tags.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Box } from '../box';
 import { Text } from '../text';
 import { Tags, TagsContainer, TagsList, Tag } from './index';
 
@@ -55,9 +56,9 @@ export const Modular = () => (
 		</Text>
 		<TagsList>
 			{exampleLinks.map(({ href, label }, idx) => (
-				<Tag key={idx} href={href}>
-					{label}
-				</Tag>
+				<Box key={idx} as="li">
+					<Tag href={href}>{label}</Tag>
+				</Box>
 			))}
 		</TagsList>
 	</TagsContainer>

--- a/packages/react/src/tags/Tags.stories.tsx
+++ b/packages/react/src/tags/Tags.stories.tsx
@@ -5,6 +5,13 @@ import { Tags, TagsContainer, TagsList, Tag } from './index';
 const meta: Meta<typeof Tags> = {
 	title: 'content/Tags',
 	component: Tags,
+	args: {
+		heading: (
+			<Text as="h2" fontWeight="bold">
+				Tags:
+			</Text>
+		),
+	},
 };
 
 export default meta;
@@ -21,33 +28,18 @@ type Story = StoryObj<typeof Tags>;
 
 export const Basic: Story = {
 	args: {
-		heading: (
-			<Text as="h2" fontWeight="bold">
-				Tags:
-			</Text>
-		),
 		items: exampleItems,
 	},
 };
 
 export const Links: Story = {
 	args: {
-		heading: (
-			<Text as="h2" fontWeight="bold">
-				Tags:
-			</Text>
-		),
 		items: exampleLinks,
 	},
 };
 
 export const Removable: Story = {
 	args: {
-		heading: (
-			<Text as="h2" fontWeight="bold">
-				Tags:
-			</Text>
-		),
 		items: [
 			{ label: 'Foo', onRemove: console.log },
 			{ label: 'Bar', onRemove: console.log },

--- a/packages/react/src/tags/Tags.stories.tsx
+++ b/packages/react/src/tags/Tags.stories.tsx
@@ -1,12 +1,13 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { Text } from '../text';
 import { Tags, TagsContainer, TagsList, Tag } from './index';
 
-export default {
+const meta: Meta<typeof Tags> = {
 	title: 'content/Tags',
 	component: Tags,
-	subcomponents: { TagsContainer, TagsList, Tag },
-} as ComponentMeta<typeof Tags>;
+};
+
+export default meta;
 
 const exampleItems = [{ label: 'Foo' }, { label: 'Bar' }, { label: 'Baz' }];
 
@@ -16,40 +17,43 @@ const exampleLinks = [
 	{ href: '#', label: 'Baz' },
 ];
 
-const Template: ComponentStory<typeof Tags> = (args) => <Tags {...args} />;
+type Story = StoryObj<typeof Tags>;
 
-export const Basic = Template.bind({});
-Basic.args = {
-	heading: (
-		<Text as="h2" fontWeight="bold">
-			Tags:
-		</Text>
-	),
-	items: exampleItems,
+export const Basic: Story = {
+	args: {
+		heading: (
+			<Text as="h2" fontWeight="bold">
+				Tags:
+			</Text>
+		),
+		items: exampleItems,
+	},
 };
 
-export const Links = Template.bind({});
-Links.args = {
-	heading: (
-		<Text as="h2" fontWeight="bold">
-			Tags:
-		</Text>
-	),
-	items: exampleLinks,
+export const Links: Story = {
+	args: {
+		heading: (
+			<Text as="h2" fontWeight="bold">
+				Tags:
+			</Text>
+		),
+		items: exampleLinks,
+	},
 };
 
-export const Removable = Template.bind({});
-Removable.args = {
-	heading: (
-		<Text as="h2" fontWeight="bold">
-			Tags:
-		</Text>
-	),
-	items: [
-		{ label: 'Foo', onRemove: console.log },
-		{ label: 'Bar', onRemove: console.log },
-		{ label: 'Baz', onRemove: console.log },
-	],
+export const Removable: Story = {
+	args: {
+		heading: (
+			<Text as="h2" fontWeight="bold">
+				Tags:
+			</Text>
+		),
+		items: [
+			{ label: 'Foo', onRemove: console.log },
+			{ label: 'Bar', onRemove: console.log },
+			{ label: 'Baz', onRemove: console.log },
+		],
+	},
 };
 
 export const Modular = () => (
@@ -58,9 +62,11 @@ export const Modular = () => (
 			Tags:
 		</Text>
 		<TagsList>
-			<Tag href="#">Foo</Tag>
-			<Tag href="#">Bar</Tag>
-			<Tag href="#">Baz</Tag>
+			{exampleLinks.map(({ href, label }, idx) => (
+				<Tag key={idx} href={href}>
+					{label}
+				</Tag>
+			))}
 		</TagsList>
 	</TagsContainer>
 );

--- a/packages/react/src/tags/TagsList.tsx
+++ b/packages/react/src/tags/TagsList.tsx
@@ -4,7 +4,7 @@ import { Flex } from '../box';
 export type TagsListProps = { children: ReactNode };
 
 export const TagsList = ({ children }: TagsListProps) => (
-	<Flex as="ul" gap={0.5} alignItems="center">
+	<Flex as="ul" gap={0.5} alignItems="center" flexWrap="wrap">
 		{children}
 	</Flex>
 );

--- a/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
+++ b/packages/react/src/tags/__snapshots__/Tags.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Tags With links renders correctly 1`] = `
       Tags:
     </h2>
     <ul
-      class="css-1xkbxzi-boxStyles"
+      class="css-15pioji-boxStyles"
     >
       <li
         class="css-79i25n-boxStyles"
@@ -71,7 +71,7 @@ exports[`Tags With onRemove renders correctly 1`] = `
       Tags:
     </h2>
     <ul
-      class="css-1xkbxzi-boxStyles"
+      class="css-15pioji-boxStyles"
     >
       <li
         class="css-79i25n-boxStyles"
@@ -203,7 +203,7 @@ exports[`Tags Without links renders correctly 1`] = `
       Tags:
     </h2>
     <ul
-      class="css-1xkbxzi-boxStyles"
+      class="css-15pioji-boxStyles"
     >
       <li
         class="css-79i25n-boxStyles"


### PR DESCRIPTION
## Describe your changes

Updated wrapping behaviour the flowing of tags across multiple lines.

In this [this playroom example](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AVAhgcwM4B0B2ABAQBYxpQCWeGAvMPkUajAB4AuBaWNOIxATLwIAzCHjYB1GBQzE2PEACMIAGyi8AfA0ZF02eNqYB6FKzZbCBAL7aKbGAFtuwANqGCwEgCcYw%2BAV4AYl4AGgIVNEUYFX9eADEICCErEPdPYh8-AJBgkDCIqJjsgCE0L2TUyyJ0zNic0PDI6LrSgC8KtO9fOtz8pqL4xI6qjy6soIaC5pKy4Z0a7uzexsKWtHaQa0r5sZ7J-rqEpM2UzozFibyV6d5S8pPtxgXx%2BqupgZA2uYIAXRs8IwWPIgADuFCgbGIWAQLj%2BQA), you can see how tags currently do not wrap correctly.

Using our deploy preview, you can see the new behaviour in [this playroom example](https://design-system.agriculture.gov.au/pr-preview/pr-1116/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AVAhgcwM4B0B2ABAQBYxpQCWeGAvMPkUajAB4AuBaWNOIxATLwIAzCHjYB1GBQzE2PEACMIAGyi8AfA0ZF02eNqYB6FKzZbCBAL7aKbGAFtuwANqGCwEgCcYw%2BAV4AYl4AGgIVNEUYFX9eADEICCErEPdPYh8-AJBgkDCIqJjsgCE0L2TUyyJ0zNic0PDI6LrSgC8KtO9fOtz8pqL4xI6qjy6soIaC5pKy4Z0a7uzexsKWtHaQa0r5sZ7J-rqEpM2UzozFibyV6d5S8pPtxgXx%2BqupgZA2uYIAXRs8IwWEBWIA).

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
