### PR TITLE
core: Create new hook `useAriaModalPolyfill`

### DIFF
--- a/.changeset/orange-vans-tap.md
+++ b/.changeset/orange-vans-tap.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: Created new hook `useAriaModalPolyfill` which adds `aria-hidden="true"` to every direct child of the `body` element when a modal is opened. This hook consolidates code that was previously copied/pasted across Modal, App layout and Main nav.

--- a/.changeset/sharp-pigs-shave.md
+++ b/.changeset/sharp-pigs-shave.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Adding missing aria dialog tags to mobile version of App layout sidebar. 

--- a/packages/react/src/core/utils/index.ts
+++ b/packages/react/src/core/utils/index.ts
@@ -5,6 +5,7 @@ export { useElementSize } from './useElementSize';
 export { usePrefersReducedMotion } from './usePrefersReducedMotion';
 export { useWindowSize } from './useWindowSize';
 export { useClickOutside } from './useClickOutside';
+export { useAriaModalPolyfill } from './useAriaModalPolyfill';
 export { forwardRefWithAs } from './forwardRefWithAs';
 export { mergeRefs } from './mergeRefs';
 export { fontGrid } from './fontGrid';

--- a/packages/react/src/core/utils/useAriaModalPolyfill.ts
+++ b/packages/react/src/core/utils/useAriaModalPolyfill.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * The following hook will add `aria-hidden="true"` to every direct child of the `body` element when a modal is opened.
+ * This is because `aria-modal` is not yet supported by all browsers (https://a11ysupport.io/tech/aria/aria-modal_attribute).
+ * This fixes a bug in certain devices where focus is not trapped correctly such as VoiceOver on iOS.
+ * This has been inspired by Reach UI (https://github.com/reach/reach-ui/blob/main/packages/dialog/src/index.tsx)
+ */
+export function useAriaModalPolyfill(isOpen: boolean) {
+	const modalContainerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!isOpen || !modalContainerRef.current) return;
+
+		const rootNodes: Element[] = [];
+		const originalAttrs: (string | null)[] = [];
+		document.querySelectorAll('body > *').forEach(function (node) {
+			if (node === modalContainerRef.current) return;
+			const attr = node.getAttribute('aria-hidden');
+			const alreadyHidden = attr !== null && attr !== 'false';
+			if (alreadyHidden) return;
+			rootNodes.push(node);
+			originalAttrs.push(attr);
+			node.setAttribute('aria-hidden', 'true');
+		});
+		return () => {
+			rootNodes.forEach((node, index) => {
+				const originalValue = originalAttrs[index];
+				if (originalValue === null) {
+					node.removeAttribute('aria-hidden');
+				} else {
+					node.setAttribute('aria-hidden', originalValue);
+				}
+			});
+		};
+	}, [isOpen]);
+
+	return { modalContainerRef };
+}

--- a/packages/react/src/main-nav/NavContainer.tsx
+++ b/packages/react/src/main-nav/NavContainer.tsx
@@ -15,6 +15,7 @@ import {
 	mapSpacing,
 	tokens,
 	useWindowSize,
+	useAriaModalPolyfill,
 	packs,
 	useBoxPalette,
 	BoxPalette,
@@ -107,8 +108,6 @@ function NavContainerDialog({
 	menuVisiblyOpen,
 	palette,
 }: NavContainerDialogProps) {
-	const dialogRef = useRef<HTMLDivElement>(null);
-
 	// Close the component when the user presses the escape key
 	useEffect(() => {
 		const handleKeyDown = (e: KeyboardEvent) => {
@@ -122,42 +121,13 @@ function NavContainerDialog({
 		return () => window.removeEventListener('keydown', handleKeyDown);
 	}, [close]);
 
-	// The following `useEffect` will add `aria-hidden="true"` to every direct child of the `body` element when the modal is opened.
-	// This is because `aria-modal` is not yet supported by all browsers (https://a11ysupport.io/tech/aria/aria-modal_attribute).
-	// This fixes a bug in certain devices where focus is not trapped correctly such as VoiceOver on iOS.
-	// This has been inspired by Reach UI (https://github.com/reach/reach-ui/blob/main/packages/dialog/src/index.tsx)
-	useEffect(() => {
-		if (!menuVisiblyOpen || !dialogRef.current) return;
-
-		const rootNodes: Element[] = [];
-		const originalAttrs: (string | null)[] = [];
-
-		document.querySelectorAll('body > *').forEach(function (node) {
-			if (node === dialogRef.current) return;
-			const attr = node.getAttribute('aria-hidden');
-			const alreadyHidden = attr !== null && attr !== 'false';
-			if (alreadyHidden) return;
-			rootNodes.push(node);
-			originalAttrs.push(attr);
-			node.setAttribute('aria-hidden', 'true');
-		});
-
-		return () => {
-			rootNodes.forEach((node, index) => {
-				const originalValue = originalAttrs[index];
-				if (originalValue === null) {
-					node.removeAttribute('aria-hidden');
-				} else {
-					node.setAttribute('aria-hidden', originalValue);
-				}
-			});
-		};
-	}, [menuVisiblyOpen]);
+	// Polyfill usage of `aria-modal`
+	const { modalContainerRef } = useAriaModalPolyfill(menuVisiblyOpen);
 
 	const element = (
 		<Box
+			ref={modalContainerRef}
 			palette={palette}
-			ref={dialogRef}
 			{...(menuVisiblyOpen
 				? {
 						role: 'dialog',


### PR DESCRIPTION
## Describe your changes

### Core

Created new hook `useAriaModalPolyfill` which adds `aria-hidden="true"` to every direct child of the `body` element when a modal is opened. This hook consolidates code that was previously copied/pasted across Modal, App layout and Main nav.

- [View app layout preview in storybook](https://design-system.agriculture.gov.au/pr-preview/pr-1119/storybook/index.html?path=/story/layout-applayout--basic)
- [View modal preview in storybook](https://design-system.agriculture.gov.au/pr-preview/pr-1119/storybook/index.html?path=/story/content-modal--basic)
- [View main nav preview in storybook](https://design-system.agriculture.gov.au/pr-preview/pr-1119/storybook/index.html?path=/story/navigation-mainnav--body)

### App layout

Adding missing aria dialog tags to mobile version of App layout sidebar. I noticed this was broken when implementing the `useAriaModalPolyfill` hook.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).