### PR TITLE
Improve mobile experience of table filtering examples

### DIFF
--- a/.storybook/stories/DataFiltering/components/ActiveFilters.tsx
+++ b/.storybook/stories/DataFiltering/components/ActiveFilters.tsx
@@ -102,14 +102,14 @@ export const ActiveFilters = ({
 	}
 
 	return (
-		<Flex alignItems="flex-end">
+		<Flex flexWrap="wrap" gap={0.75} alignItems="flex-end">
 			<Tags
 				heading={<Text fontWeight="bold">Active filters</Text>}
 				items={tags}
 			/>
 			<Button
 				size="sm"
-				variant="tertiary"
+				variant="text"
 				onClick={resetFilters}
 				iconAfter={CloseIcon}
 			>

--- a/.storybook/stories/DataFiltering/components/FilterBar.tsx
+++ b/.storybook/stories/DataFiltering/components/FilterBar.tsx
@@ -35,6 +35,7 @@ export const FilterBar = ({ children }: { children: ReactNode }) => {
 export const FilterBarGroup = ({ children }: { children: ReactNode }) => {
 	return (
 		<Flex
+			flexWrap="wrap"
 			columnGap={1}
 			rowGap={1.5}
 			flexDirection={{ xs: 'column', md: 'row' }}

--- a/.storybook/stories/DataFiltering/components/FilterSearchInput.tsx
+++ b/.storybook/stories/DataFiltering/components/FilterSearchInput.tsx
@@ -17,7 +17,7 @@ export const FilterSearchInput = ({
 			hideOptionalLabel
 			value={filters.businessName}
 			onChange={(searchString) => {
-				// debounce
+				// TODO debounce
 				setFilters({
 					...filters,
 					businessName: searchString,


### PR DESCRIPTION
## Describe your changes

Updated wrapping behaviour of two elements in the "medium" table filtering example.

| Before | After |
|--------|--------|
| <img width="670" alt="Screenshot 2023-05-17 at 10 33 10 am" src="https://github.com/steelthreads/agds-next/assets/6265154/44ee3bb4-d7cd-48a0-93d6-93c7f657113f"> | <img width="670" alt="Screenshot 2023-05-17 at 10 32 56 am" src="https://github.com/steelthreads/agds-next/assets/6265154/2e4df144-5535-412c-841e-116a6ded8fc8"> | 
| <img width="794" alt="Screenshot 2023-05-17 at 10 35 15 am" src="https://github.com/steelthreads/agds-next/assets/6265154/4959f42b-df47-4669-8191-2679a46b9b96">| <img width="792" alt="Screenshot 2023-05-17 at 10 35 09 am" src="https://github.com/steelthreads/agds-next/assets/6265154/79c1a2ce-b8ea-4a8c-bc66-5b12818faf69"> |








