### PR TITLE
combobox: Remove use-debounce dependency

### DIFF
--- a/.changeset/honest-ties-develop.md
+++ b/.changeset/honest-ties-develop.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+combobox: Remove use-debounce dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,8 +13,7 @@
 		"react-day-picker": "^8.3.5",
 		"react-dropzone": "^12.0.5",
 		"react-focus-lock": "^2.8.1",
-		"react-popper": "^2.2.5",
-		"use-debounce": "^9.0.2"
+		"react-popper": "^2.2.5"
 	},
 	"devDependencies": {
 		"@emotion/react": "^11.7.0",

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -1,8 +1,8 @@
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
-import { useDebounce } from 'use-debounce';
 import { useCombobox } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxBase } from './ComboboxBase';
+import { useDebounceValue } from './useDebounceValue';
 import {
 	DefaultComboboxOption,
 	filterOptions,
@@ -106,7 +106,7 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 	});
 
 	// Keep track of the debounced input value to prevent unnecessary network requests
-	const [debouncedInputValue] = useDebounce(combobox.inputValue, 300);
+	const debouncedInputValue = useDebounceValue(combobox.inputValue, 300);
 
 	const shouldLoadOptions = useMemo(() => {
 		// Do load options when...

--- a/packages/react/src/combobox/ComboboxAsyncMulti.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.tsx
@@ -7,8 +7,8 @@ import {
 	useState,
 } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
-import { useDebounce } from 'use-debounce';
 import { FieldMaxWidth } from '../core';
+import { useDebounceValue } from './useDebounceValue';
 import { ComboboxMultiBase } from './ComboboxBase';
 import {
 	DefaultComboboxOption,
@@ -149,7 +149,7 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 	});
 
 	// Keep track of the debounced input value to prevent unnecessary network requests
-	const [debouncedInputValue] = useDebounce(combobox.inputValue, 300);
+	const debouncedInputValue = useDebounceValue(combobox.inputValue, 300);
 
 	const shouldLoadOptions = useMemo(() => {
 		// Do load options when...

--- a/packages/react/src/combobox/useDebounceValue.test.ts
+++ b/packages/react/src/combobox/useDebounceValue.test.ts
@@ -1,0 +1,80 @@
+import { act, renderHook } from '@testing-library/react';
+import { useDebounceValue } from './useDebounceValue';
+
+jest.useFakeTimers();
+
+describe('useDebounceValue', () => {
+	test('Immediately returns the initial value', () => {
+		const { result } = renderHook(() => useDebounceValue('initial', 300));
+		expect(result.current).toBe('initial');
+	});
+	test('Updates no sooner than waitMS', () => {
+		const waitMS = 300;
+		const { result, rerender } = renderHook((value = 'initial') =>
+			useDebounceValue(value, waitMS)
+		);
+
+		// re-render with an updated value
+		rerender('updated-value');
+		expect(result.current).toBe('initial');
+
+		// Wait for some time (less than the timeout)
+		act(() => {
+			jest.advanceTimersByTime(waitMS - 1);
+		});
+		expect(result.current).toBe('initial');
+
+		// Complete the timeout
+		act(() => {
+			jest.advanceTimersByTime(1);
+		});
+		expect(result.current).toBe('updated-value');
+	});
+
+	test('updates to the last provided value', () => {
+		const waitMS = 300;
+		const { result, rerender } = renderHook((value = 'initial') =>
+			useDebounceValue(value, waitMS)
+		);
+
+		// Re-render with a new value
+		rerender('first-update');
+
+		// Some time passes, but not the full timer
+		act(() => {
+			jest.advanceTimersByTime(waitMS / 2);
+		});
+		// Still showing the initial value
+		expect(result.current).toBe('initial');
+
+		// Re-render with another new value
+		rerender('second-update');
+		expect(result.current).toBe('initial');
+
+		// Allow the timer to complete
+		act(() => {
+			jest.runAllTimers();
+		});
+		expect(result.current).toBe('second-update');
+	});
+
+	test('Does not update after unmounting', () => {
+		const { unmount, result, rerender } = renderHook((value = 'initial') =>
+			useDebounceValue(value, 300)
+		);
+
+		// Set a new value
+		rerender('updated-value');
+
+		// The component unmounts ...
+		unmount();
+
+		// ... before the timer has run
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		// The result should not be updated.
+		expect(result.current).toBe('initial');
+	});
+});

--- a/packages/react/src/combobox/useDebounceValue.ts
+++ b/packages/react/src/combobox/useDebounceValue.ts
@@ -1,0 +1,17 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useDebounceValue<T>(value: T, waitMS: number): T {
+	const [internalState, setInternalState] = useState<T>(value);
+	const storedValue = useRef<T>(value);
+
+	useEffect(() => {
+		if (value !== storedValue.current) {
+			const t = setTimeout(() => {
+				setInternalState(value);
+			}, waitMS);
+			return () => clearTimeout(t);
+		}
+	}, [value, waitMS]);
+
+	return internalState;
+}


### PR DESCRIPTION
## Describe your changes

As a general rule we always want to reduce our reliance on 3rd party code where possible. The `use-debounce` package is only being used within the `ComboboxAsync` and `ComboboxAsyncMulti` components.

This library was being used to prevent "thrashing" network requests while a user is typing in a combobox. No library options or functionality were exposed as public API.

## Changes
- removed the dependency `use-debounce`
- created a replacement hook targeted to our use case `useDebounceValue`
- added unit tests
- updated usage in `ComboboxAsync` and `ComboboxAsyncMulti`

> **Note** This is a less sophisticated method of debounce but is one which I believe is appropriate for this use case.
> Specifically this debounce does not support a "maximum wait time". The component will always wait at least 300ms before updating and will wait longer if more input is given.
