### PR TITLE
docs/example sites: Rename AppLayout to SiteLayout

### DIFF
--- a/docs/components/CategoryPageTemplate.tsx
+++ b/docs/components/CategoryPageTemplate.tsx
@@ -6,7 +6,7 @@ import {
 	HeroCategoryBannerTitle,
 } from '@ag.ds-next/react/hero-banner';
 import { Flex, Stack } from '@ag.ds-next/react/box';
-import { AppLayout } from './AppLayout';
+import { SiteLayout } from './SiteLayout';
 import { EditPage } from './EditPage';
 
 export const CategoryPageTemplate = ({
@@ -21,7 +21,7 @@ export const CategoryPageTemplate = ({
 	editPath?: string;
 }) => {
 	return (
-		<AppLayout>
+		<SiteLayout>
 			<HeroCategoryBanner>
 				<HeroCategoryBannerTitle>{title}</HeroCategoryBannerTitle>
 				<HeroCategoryBannerSubtitle>{description}</HeroCategoryBannerSubtitle>
@@ -36,6 +36,6 @@ export const CategoryPageTemplate = ({
 					)}
 				</Stack>
 			</SectionContent>
-		</AppLayout>
+		</SiteLayout>
 	);
 };

--- a/docs/components/PatternLayout.tsx
+++ b/docs/components/PatternLayout.tsx
@@ -4,7 +4,7 @@ import { SideNavProps } from '@ag.ds-next/react/side-nav';
 import { ButtonLink } from '@ag.ds-next/react/button';
 import { CallToActionLink } from '@ag.ds-next/react/call-to-action';
 import type { Pattern, getPatternBreadcrumbs } from '../lib/mdx/patterns';
-import { AppLayout } from './AppLayout';
+import { SiteLayout } from './SiteLayout';
 import { PageLayout } from './PageLayout';
 import { PageTitle } from './PageTitle';
 import { FigmaLogo } from './FigmaLogo';
@@ -26,7 +26,7 @@ export function PatternLayout({
 	pattern,
 }: PatternLayoutProps) {
 	return (
-		<AppLayout applyMainElement={false}>
+		<SiteLayout applyMainElement={false}>
 			<PageLayout
 				applyMainElement={true}
 				sideNav={{
@@ -89,6 +89,6 @@ export function PatternLayout({
 				)}
 				{children}
 			</PageLayout>
-		</AppLayout>
+		</SiteLayout>
 	);
 }

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -11,7 +11,7 @@ import { PageLayout } from './PageLayout';
 import { FigmaLogo } from './FigmaLogo';
 import { StorybookLogo } from './StorybookLogo';
 import { GithubLogo } from './GithubLogo';
-import { AppLayout } from './AppLayout';
+import { SiteLayout } from './SiteLayout';
 
 export function PkgLayout({
 	children,
@@ -29,7 +29,7 @@ export function PkgLayout({
 }>) {
 	const { asPath } = useRouter();
 	return (
-		<AppLayout applyMainElement={false}>
+		<SiteLayout applyMainElement={false}>
 			<PageLayout
 				applyMainElement={true}
 				sideNav={{
@@ -99,6 +99,6 @@ export function PkgLayout({
 				) : null}
 				{children}
 			</PageLayout>
-		</AppLayout>
+		</SiteLayout>
 	);
 }

--- a/docs/components/SiteLayout.tsx
+++ b/docs/components/SiteLayout.tsx
@@ -4,15 +4,15 @@ import { SkipLinks } from '@ag.ds-next/react/skip-link';
 import { SiteHeader } from './SiteHeader';
 import { SiteFooter } from './SiteFooter';
 
-type AppLayoutProps = PropsWithChildren<{
+type SiteLayoutProps = PropsWithChildren<{
 	/** If true, the area between the header and footer will be a 'main' element with the ID of 'main-content' applied (used for skip links). */
 	applyMainElement?: boolean;
 }>;
 
-export const AppLayout = ({
+export const SiteLayout = ({
 	applyMainElement = true,
 	children,
-}: AppLayoutProps) => {
+}: SiteLayoutProps) => {
 	return (
 		<>
 			<SkipLinks

--- a/docs/components/SubcategoryPageTemplate.tsx
+++ b/docs/components/SubcategoryPageTemplate.tsx
@@ -6,7 +6,7 @@ import {
 } from '@ag.ds-next/react/hero-banner';
 import { Flex, Stack } from '@ag.ds-next/react/box';
 import { Breadcrumbs, BreadcrumbsProps } from '@ag.ds-next/react/breadcrumbs';
-import { AppLayout } from './AppLayout';
+import { SiteLayout } from './SiteLayout';
 import { EditPage } from './EditPage';
 
 export const SubcategoryPageTemplate = ({
@@ -21,7 +21,7 @@ export const SubcategoryPageTemplate = ({
 	editPath?: string;
 }) => {
 	return (
-		<AppLayout>
+		<SiteLayout>
 			<HeroSubcategoryBanner>
 				{breadcrumbs?.length ? <Breadcrumbs links={breadcrumbs} /> : null}
 				<HeroSubcategoryBannerTitle>{title}</HeroSubcategoryBannerTitle>
@@ -36,6 +36,6 @@ export const SubcategoryPageTemplate = ({
 					)}
 				</Stack>
 			</SectionContent>
-		</AppLayout>
+		</SiteLayout>
 	);
 };

--- a/docs/components/TokenLayout.tsx
+++ b/docs/components/TokenLayout.tsx
@@ -1,7 +1,7 @@
 import { PropsWithChildren } from 'react';
 import { BreadcrumbsProps } from '@ag.ds-next/react/breadcrumbs';
 import { TOKEN_NAV_LINKS } from '../content/tokens';
-import { AppLayout } from './AppLayout';
+import { SiteLayout } from './SiteLayout';
 import { PageLayout } from './PageLayout';
 import { PageTitle } from './PageTitle';
 
@@ -20,7 +20,7 @@ export const TokenLayout = ({
 	description,
 }: TokenLayoutProps) => {
 	return (
-		<AppLayout applyMainElement={false}>
+		<SiteLayout applyMainElement={false}>
 			<PageLayout
 				applyMainElement={true}
 				sideNav={{
@@ -37,6 +37,6 @@ export const TokenLayout = ({
 				<PageTitle title={title} introduction={description} />
 				{children}
 			</PageLayout>
-		</AppLayout>
+		</SiteLayout>
 	);
 };

--- a/docs/pages/404.tsx
+++ b/docs/pages/404.tsx
@@ -3,14 +3,14 @@ import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 import { PageContent } from '@ag.ds-next/react/content';
 import { Stack } from '@ag.ds-next/react/box';
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 
 export default function NotFoundPage() {
 	return (
 		<>
 			<DocumentTitle title="Error 404" />
-			<AppLayout>
+			<SiteLayout>
 				<PageContent>
 					<Stack gap={1.5}>
 						<H1>Page not found</H1>
@@ -21,7 +21,7 @@ export default function NotFoundPage() {
 						<Text>Error code: 404</Text>
 					</Stack>
 				</PageContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -1,6 +1,6 @@
 import { Prose } from '@ag.ds-next/react/prose';
 import { TextLink } from '@ag.ds-next/react/text-link';
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { PageLayout } from '../components/PageLayout';
 import { PageTitle } from '../components/PageTitle';
@@ -9,7 +9,7 @@ export default function AboutPage() {
 	return (
 		<>
 			<DocumentTitle title="About AgDS" />
-			<AppLayout applyMainElement={false}>
+			<SiteLayout applyMainElement={false}>
 				<PageLayout
 					breadcrumbs={[
 						{
@@ -99,7 +99,7 @@ export default function AboutPage() {
 						</p>
 					</Prose>
 				</PageLayout>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/docs/pages/foundations/[slug].tsx
+++ b/docs/pages/foundations/[slug].tsx
@@ -3,7 +3,7 @@ import { MDXRemote } from 'next-mdx-remote';
 import { InpageNav } from '@ag.ds-next/react/inpage-nav';
 import { Prose } from '@ag.ds-next/react/prose';
 import { mdxComponents } from '../../components/mdxComponents';
-import { AppLayout } from '../../components/AppLayout';
+import { SiteLayout } from '../../components/SiteLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { PageLayout } from '../../components/PageLayout';
 import { PageTitle } from '../../components/PageTitle';
@@ -26,7 +26,7 @@ export default function FoundationsPage({
 				title={foundation.title}
 				description={foundation.description}
 			/>
-			<AppLayout>
+			<SiteLayout>
 				<PageLayout
 					editPath={`/docs/content/foundations/${foundation.slug}.mdx`}
 					breadcrumbs={breadcrumbs}
@@ -45,7 +45,7 @@ export default function FoundationsPage({
 						<MDXRemote {...foundation.source} components={mdxComponents} />
 					</Prose>
 				</PageLayout>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/docs/pages/guides/[slug].tsx
+++ b/docs/pages/guides/[slug].tsx
@@ -9,7 +9,7 @@ import {
 	Guide,
 } from '../../lib/mdx/guides';
 import { mdxComponents } from '../../components/mdxComponents';
-import { AppLayout } from '../../components/AppLayout';
+import { SiteLayout } from '../../components/SiteLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { PageLayout } from '../../components/PageLayout';
 import { PageTitle } from '../../components/PageTitle';
@@ -23,7 +23,7 @@ export default function Guides({
 	return (
 		<>
 			<DocumentTitle title={guide.title} description={guide.opener} />
-			<AppLayout applyMainElement={false}>
+			<SiteLayout applyMainElement={false}>
 				<PageLayout
 					applyMainElement={true}
 					editPath={`/docs/content/guides/${guide.slug}.mdx`}
@@ -40,7 +40,7 @@ export default function Guides({
 						<MDXRemote {...guide.source} components={mdxComponents} />
 					</Prose>
 				</PageLayout>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -10,7 +10,7 @@ import {
 	HeroBannerSubtitle,
 } from '@ag.ds-next/react/hero-banner';
 import { ButtonLink } from '@ag.ds-next/react/button';
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { PictogramCard } from '../components/PictogramCard';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { withBasePath } from '../lib/img';
@@ -22,7 +22,7 @@ export default function Homepage() {
 	return (
 		<>
 			<DocumentTitle description={description} />
-			<AppLayout>
+			<SiteLayout>
 				<HeroBanner
 					image={
 						<img
@@ -92,7 +92,7 @@ export default function Homepage() {
 						</Prose>
 					</Stack>
 				</SectionContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/docs/pages/roadmap.tsx
+++ b/docs/pages/roadmap.tsx
@@ -1,6 +1,6 @@
 import { Prose } from '@ag.ds-next/react/prose';
 import { TextLink } from '@ag.ds-next/react/text-link';
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { PageLayout } from '../components/PageLayout';
 import { PageTitle } from '../components/PageTitle';
@@ -9,7 +9,7 @@ export default function RoadmapPage() {
 	return (
 		<>
 			<DocumentTitle title="AgDS Roadmap" />
-			<AppLayout applyMainElement={false}>
+			<SiteLayout applyMainElement={false}>
 				<PageLayout
 					breadcrumbs={[
 						{
@@ -79,7 +79,7 @@ export default function RoadmapPage() {
 						<p>Last updated April 19th 2023.</p>
 					</Prose>
 				</PageLayout>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/docs/pages/updates/[slug].tsx
+++ b/docs/pages/updates/[slug].tsx
@@ -8,7 +8,7 @@ import {
 	Update,
 } from '../../lib/mdx/updates';
 import { mdxComponents } from '../../components/mdxComponents';
-import { AppLayout } from '../../components/AppLayout';
+import { SiteLayout } from '../../components/SiteLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { PageLayout } from '../../components/PageLayout';
 import { PageTitle } from '../../components/PageTitle';
@@ -20,7 +20,7 @@ export default function Updates({
 	return (
 		<>
 			<DocumentTitle title={update.title} description={update.description} />
-			<AppLayout>
+			<SiteLayout>
 				<PageLayout
 					editPath={`/docs/content/updates/${update.slug}.mdx`}
 					breadcrumbs={breadcrumbs}
@@ -34,7 +34,7 @@ export default function Updates({
 						<MDXRemote {...update.source} components={mdxComponents} />
 					</Prose>
 				</PageLayout>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
+++ b/example-form/components/FormRegisterPetDetails/FormRegisterPetDetails.tsx
@@ -13,7 +13,7 @@ import { PageContent, ContentBleed } from '@ag.ds-next/react/content';
 import { ProgressIndicator } from '@ag.ds-next/react/progress-indicator';
 import { Stack } from '@ag.ds-next/react/box';
 import { DirectionButton } from '@ag.ds-next/react/direction-link';
-import { AppLayout } from '../AppLayout';
+import { SiteLayout } from '../SiteLayout';
 import { useFormRegisterPet } from '../FormRegisterPetContext';
 import {
 	FormRegisterPetDetailsStep0,
@@ -213,7 +213,7 @@ export const FormRegisterPetDetails = () => {
 	};
 
 	return (
-		<AppLayout focusMode>
+		<SiteLayout focusMode>
 			<PageContent>
 				<context.Provider value={contextValue}>
 					<Columns>
@@ -239,7 +239,7 @@ export const FormRegisterPetDetails = () => {
 					</Columns>
 				</context.Provider>
 			</PageContent>
-		</AppLayout>
+		</SiteLayout>
 	);
 };
 

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetails.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetails.tsx
@@ -13,7 +13,7 @@ import { PageContent, ContentBleed } from '@ag.ds-next/react/content';
 import { ProgressIndicator } from '@ag.ds-next/react/progress-indicator';
 import { Stack } from '@ag.ds-next/react/box';
 import { DirectionButton } from '@ag.ds-next/react/direction-link';
-import { AppLayout } from '../AppLayout';
+import { SiteLayout } from '../SiteLayout';
 import { useFormRegisterPet } from '../FormRegisterPetContext';
 import {
 	FormRegisterPetPersonalDetailsStep0,
@@ -200,7 +200,7 @@ export const FormRegisterPetPersonalDetails = () => {
 	};
 
 	return (
-		<AppLayout focusMode>
+		<SiteLayout focusMode>
 			<PageContent>
 				<context.Provider value={contextValue}>
 					<Columns>
@@ -226,7 +226,7 @@ export const FormRegisterPetPersonalDetails = () => {
 					</Columns>
 				</context.Provider>
 			</PageContent>
-		</AppLayout>
+		</SiteLayout>
 	);
 };
 

--- a/example-form/components/SiteLayout.tsx
+++ b/example-form/components/SiteLayout.tsx
@@ -4,7 +4,7 @@ import { SkipLinks } from '@ag.ds-next/react/skip-link';
 import { SiteHeader } from './SiteHeader';
 import { SiteFooter } from './SiteFooter';
 
-export const AppLayout = ({
+export const SiteLayout = ({
 	children,
 	focusMode = false,
 }: PropsWithChildren<{

--- a/example-form/pages/index.tsx
+++ b/example-form/pages/index.tsx
@@ -8,7 +8,7 @@ import {
 	HeroBannerTitleContainer,
 } from '@ag.ds-next/react/hero-banner';
 import { CallToActionLink } from '@ag.ds-next/react/call-to-action';
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { ServicesRecentlyViewedCardList } from '../components/ServicesRecentlyViewedCardList';
 
@@ -16,7 +16,7 @@ export default function HomePage() {
 	return (
 		<>
 			<DocumentTitle title="Home" />
-			<AppLayout>
+			<SiteLayout>
 				<HeroBanner background="bodyAlt">
 					<HeroBannerTitleContainer>
 						<HeroBannerTitle>My Government services account</HeroBannerTitle>
@@ -35,7 +35,7 @@ export default function HomePage() {
 						</CallToActionLink>
 					</Stack>
 				</SectionContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/pages/not-found.tsx
+++ b/example-form/pages/not-found.tsx
@@ -4,14 +4,14 @@ import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 import { tokens } from '@ag.ds-next/react/core';
 import { PageContent } from '@ag.ds-next/react/content';
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 
 export default function NotFoundPage() {
 	return (
 		<>
 			<DocumentTitle title="Page not found" />
-			<AppLayout>
+			<SiteLayout>
 				<PageContent>
 					<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
 						<H1>Oops! This page does not exist.</H1>
@@ -24,7 +24,7 @@ export default function NotFoundPage() {
 						</Text>
 					</Stack>
 				</PageContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/pages/services/index.tsx
+++ b/example-form/pages/services/index.tsx
@@ -4,7 +4,7 @@ import {
 	HeroCategoryBannerTitle,
 	HeroCategoryBannerSubtitle,
 } from '@ag.ds-next/react/hero-banner';
-import { AppLayout } from '../../components/AppLayout';
+import { SiteLayout } from '../../components/SiteLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { ServicesCardList } from '../../components/ServicesCardList';
 
@@ -12,7 +12,7 @@ export default function ServicesPage() {
 	return (
 		<>
 			<DocumentTitle title="Services" />
-			<AppLayout>
+			<SiteLayout>
 				<HeroCategoryBanner>
 					<HeroCategoryBannerTitle>Services</HeroCategoryBannerTitle>
 					<HeroCategoryBannerSubtitle>
@@ -23,7 +23,7 @@ export default function ServicesPage() {
 				<SectionContent>
 					<ServicesCardList />
 				</SectionContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/pages/services/registrations/index.tsx
+++ b/example-form/pages/services/registrations/index.tsx
@@ -9,7 +9,7 @@ import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { Text } from '@ag.ds-next/react/text';
 import { Breadcrumbs } from '@ag.ds-next/react/breadcrumbs';
 import { Stack } from '@ag.ds-next/react/box';
-import { AppLayout } from '../../../components/AppLayout';
+import { SiteLayout } from '../../../components/SiteLayout';
 import { DocumentTitle } from '../../../components/DocumentTitle';
 import { RegistrationsCardList } from '../../../components/RegistrationsCardList';
 
@@ -30,7 +30,7 @@ export default function RegistrationsPage() {
 					registrationId ? 'Successfully registered pet ' : 'Registrations'
 				}
 			/>
-			<AppLayout>
+			<SiteLayout>
 				<HeroSubcategoryBanner>
 					<Breadcrumbs
 						links={[
@@ -58,7 +58,7 @@ export default function RegistrationsPage() {
 						<RegistrationsCardList />
 					</Stack>
 				</SectionContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/pages/services/registrations/pet/index.tsx
+++ b/example-form/pages/services/registrations/pet/index.tsx
@@ -6,7 +6,7 @@ import { Stack } from '@ag.ds-next/react/box';
 import { TaskList } from '@ag.ds-next/react/task-list';
 import { Text } from '@ag.ds-next/react/text';
 import { Breadcrumbs } from '@ag.ds-next/react/breadcrumbs';
-import { AppLayout } from '../../../../components/AppLayout';
+import { SiteLayout } from '../../../../components/SiteLayout';
 import { DocumentTitle } from '../../../../components/DocumentTitle';
 import { FormHelpCallout } from '../../../../components/FormHelpCallout';
 import { PageTitle } from '../../../../components/PageTitle';
@@ -30,7 +30,7 @@ export default function FormRegisterPetHomePage() {
 	return (
 		<>
 			<DocumentTitle title="Register a pet" />
-			<AppLayout>
+			<SiteLayout>
 				<PageContent>
 					<Columns>
 						<Column columnSpan={{ xs: 12, md: 8 }}>
@@ -76,7 +76,7 @@ export default function FormRegisterPetHomePage() {
 						</Column>
 					</Columns>
 				</PageContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/pages/services/registrations/pet/task-1/index.tsx
+++ b/example-form/pages/services/registrations/pet/task-1/index.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@ag.ds-next/react/box';
 import { H2 } from '@ag.ds-next/react/heading';
 import { DirectionLink } from '@ag.ds-next/react/direction-link';
 import { ButtonLink } from '@ag.ds-next/react/button';
-import { AppLayout } from '../../../../../components/AppLayout';
+import { SiteLayout } from '../../../../../components/SiteLayout';
 import { DocumentTitle } from '../../../../../components/DocumentTitle';
 import { FormHelpCallout } from '../../../../../components/FormHelpCallout';
 import { PageTitle } from '../../../../../components/PageTitle';
@@ -15,7 +15,7 @@ export default function FormRegisterPetTask1HomePage() {
 	return (
 		<>
 			<DocumentTitle title="Your personal details | Register a pet" />
-			<AppLayout focusMode>
+			<SiteLayout focusMode>
 				<PageContent>
 					<Columns>
 						<Column columnSpan={{ xs: 12, md: 8 }}>
@@ -55,7 +55,7 @@ export default function FormRegisterPetTask1HomePage() {
 						</Column>
 					</Columns>
 				</PageContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-form/pages/services/registrations/pet/task-2/index.tsx
+++ b/example-form/pages/services/registrations/pet/task-2/index.tsx
@@ -5,7 +5,7 @@ import { Stack } from '@ag.ds-next/react/box';
 import { H2 } from '@ag.ds-next/react/heading';
 import { DirectionLink } from '@ag.ds-next/react/direction-link';
 import { ButtonLink } from '@ag.ds-next/react/button';
-import { AppLayout } from '../../../../../components/AppLayout';
+import { SiteLayout } from '../../../../../components/SiteLayout';
 import { DocumentTitle } from '../../../../../components/DocumentTitle';
 import { FormHelpCallout } from '../../../../../components/FormHelpCallout';
 import { PageTitle } from '../../../../../components/PageTitle';
@@ -15,7 +15,7 @@ export default function FormRegisterPetTask2HomePage() {
 	return (
 		<>
 			<DocumentTitle title="Your pet's details | Register a pet" />
-			<AppLayout focusMode>
+			<SiteLayout focusMode>
 				<PageContent>
 					<Columns>
 						<Column columnSpan={{ xs: 12, md: 8 }}>
@@ -75,7 +75,7 @@ export default function FormRegisterPetTask2HomePage() {
 						</Column>
 					</Columns>
 				</PageContent>
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/components/SiteLayout.tsx
+++ b/example-site/components/SiteLayout.tsx
@@ -5,7 +5,7 @@ import { PatternBanner } from './PatternBanner';
 import { SiteHeader } from './SiteHeader';
 import { SiteFooter } from './SiteFooter';
 
-type AppLayoutProps = PropsWithChildren<{
+type SiteLayoutProps = PropsWithChildren<{
 	/** If true, the area between the header and footer will be a 'main' element with the ID of 'main-content' applied (used for skip links). */
 	applyMainElement?: boolean;
 	/** If true, the `MainNav` component will not be rendered. Used on pages with focused tasks such as multi-page forms. */
@@ -14,12 +14,12 @@ type AppLayoutProps = PropsWithChildren<{
 	template?: { name: string; slug: string };
 }>;
 
-export const AppLayout = ({
+export const SiteLayout = ({
 	children,
 	applyMainElement = true,
 	focusMode = false,
 	template,
-}: AppLayoutProps) => {
+}: SiteLayoutProps) => {
 	const skipLinks = useMemo(() => {
 		const items = [{ href: '#main-content', label: 'Skip to main content' }];
 		if (!focusMode) {

--- a/example-site/pages/404.tsx
+++ b/example-site/pages/404.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { NotFound } from '../components/templates/NotFound';
 
@@ -6,9 +6,9 @@ export default function NotFoundPage() {
 	return (
 		<>
 			<DocumentTitle title="Error 404" />
-			<AppLayout template={{ name: '404', slug: '404' }}>
+			<SiteLayout template={{ name: '404', slug: '404' }}>
 				<NotFound />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/index.tsx
+++ b/example-site/pages/category/index.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../components/AppLayout';
+import { SiteLayout } from '../../components/SiteLayout';
 import { DocumentTitle } from '../../components/DocumentTitle';
 import { Category } from '../../components/templates/Category';
 
@@ -6,9 +6,9 @@ export default function CategoryPage() {
 	return (
 		<>
 			<DocumentTitle title="Category" />
-			<AppLayout template={{ name: 'Category', slug: 'category' }}>
+			<SiteLayout template={{ name: 'Category', slug: 'category' }}>
 				<Category />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/content.tsx
+++ b/example-site/pages/category/subcategory/content.tsx
@@ -1,17 +1,17 @@
 import { DocumentTitle } from '../../../components/DocumentTitle';
-import { AppLayout } from '../../../components/AppLayout';
+import { SiteLayout } from '../../../components/SiteLayout';
 import { Content } from '../../../components/templates/Content';
 
 export default function ContentPage() {
 	return (
 		<>
 			<DocumentTitle title="Content page example" />
-			<AppLayout
+			<SiteLayout
 				template={{ name: 'Content', slug: 'content' }}
 				applyMainElement={false}
 			>
 				<Content />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/index.tsx
+++ b/example-site/pages/category/subcategory/index.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../../components/AppLayout';
+import { SiteLayout } from '../../../components/SiteLayout';
 import { DocumentTitle } from '../../../components/DocumentTitle';
 import { Subcategory } from '../../../components/templates/Subcategory';
 
@@ -6,9 +6,9 @@ export default function SubcategoryPage() {
 	return (
 		<>
 			<DocumentTitle title="Subcategory" />
-			<AppLayout template={{ name: 'Subcategory', slug: 'subcategory' }}>
+			<SiteLayout template={{ name: 'Subcategory', slug: 'subcategory' }}>
 				<Subcategory />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/multi-page-form/form.tsx
+++ b/example-site/pages/category/subcategory/multi-page-form/form.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../../../components/AppLayout';
+import { SiteLayout } from '../../../../components/SiteLayout';
 import { DocumentTitle } from '../../../../components/DocumentTitle';
 import { FormExampleMultiStep } from '../../../../components/FormExampleMultiStep/FormExampleMultiStep';
 
@@ -6,12 +6,12 @@ export default function FormMultiPageFormPage() {
 	return (
 		<>
 			<DocumentTitle title="Multi-page form example" />
-			<AppLayout
+			<SiteLayout
 				template={{ name: 'Multi-page form', slug: 'multi-page-form' }}
 				focusMode
 			>
 				<FormExampleMultiStep />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/multi-page-form/index.tsx
+++ b/example-site/pages/category/subcategory/multi-page-form/index.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../../../components/AppLayout';
+import { SiteLayout } from '../../../../components/SiteLayout';
 import { DocumentTitle } from '../../../../components/DocumentTitle';
 import { MultiPageFormIntro } from '../../../../components/templates/MultiPageFormIntro';
 
@@ -6,11 +6,11 @@ export default function FormMultiPageHomePage() {
 	return (
 		<>
 			<DocumentTitle title="Multi-page form example" />
-			<AppLayout
+			<SiteLayout
 				template={{ name: 'Multi-page form', slug: 'multi-page-form' }}
 			>
 				<MultiPageFormIntro />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/multi-page-form/success.tsx
+++ b/example-site/pages/category/subcategory/multi-page-form/success.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../../../components/AppLayout';
+import { SiteLayout } from '../../../../components/SiteLayout';
 import { DocumentTitle } from '../../../../components/DocumentTitle';
 import { MultiPageFormSuccess } from '../../../../components/templates/MultiPageFormSuccess';
 
@@ -6,11 +6,11 @@ export default function FormMultiPageFormPage() {
 	return (
 		<>
 			<DocumentTitle title="Success | Multi-page form example" />
-			<AppLayout
+			<SiteLayout
 				template={{ name: 'Multi-page form', slug: 'multi-page-form' }}
 			>
 				<MultiPageFormSuccess />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/single-page-form-success.tsx
+++ b/example-site/pages/category/subcategory/single-page-form-success.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../../components/AppLayout';
+import { SiteLayout } from '../../../components/SiteLayout';
 import { DocumentTitle } from '../../../components/DocumentTitle';
 import { SinglePageFormSuccess } from '../../../components/templates/SinglePageFormSuccess';
 
@@ -6,11 +6,11 @@ export default function SinglePageFormSuccessPage() {
 	return (
 		<>
 			<DocumentTitle title="Success | Single-page form example" />
-			<AppLayout
+			<SiteLayout
 				template={{ name: 'Single-page form', slug: 'single-page-form' }}
 			>
 				<SinglePageFormSuccess />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/category/subcategory/single-page-form.tsx
+++ b/example-site/pages/category/subcategory/single-page-form.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../../../components/AppLayout';
+import { SiteLayout } from '../../../components/SiteLayout';
 import { DocumentTitle } from '../../../components/DocumentTitle';
 import { SinglePageFormPage } from '../../../components/templates/SinglePageForm';
 
@@ -6,11 +6,11 @@ export default function SinglePageForm() {
 	return (
 		<>
 			<DocumentTitle title="Single-page form example" />
-			<AppLayout
+			<SiteLayout
 				template={{ name: 'Single-page form', slug: 'single-page-form' }}
 			>
 				<SinglePageFormPage />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/index.tsx
+++ b/example-site/pages/index.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { Home } from '../components/templates/Home';
 
@@ -6,9 +6,9 @@ export default function HomePage() {
 	return (
 		<>
 			<DocumentTitle title="Home" />
-			<AppLayout template={{ name: 'Home', slug: 'home' }}>
+			<SiteLayout template={{ name: 'Home', slug: 'home' }}>
 				<Home />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }

--- a/example-site/pages/sign-in-form.tsx
+++ b/example-site/pages/sign-in-form.tsx
@@ -1,4 +1,4 @@
-import { AppLayout } from '../components/AppLayout';
+import { SiteLayout } from '../components/SiteLayout';
 import { DocumentTitle } from '../components/DocumentTitle';
 import { SignInFormPage } from '../components/templates/SignInForm';
 
@@ -6,9 +6,9 @@ export default function SignInForm() {
 	return (
 		<>
 			<DocumentTitle title="Sign in" />
-			<AppLayout template={{ name: 'Sign-in form', slug: 'sign-in' }}>
+			<SiteLayout template={{ name: 'Sign-in form', slug: 'sign-in' }}>
 				<SignInFormPage />
-			</AppLayout>
+			</SiteLayout>
 		</>
 	);
 }


### PR DESCRIPTION
## Describe your changes

This PR renames the main layout components used by the docs and example sites from `AppLayout` to `SiteLayout`.

### Context

- We now have a component called `AppLayout` which is different to the layout (`SiteHeader` and `SiteFooter`) used in the docs and example sites.
- We want to start documenting and showing examples using the new `AppLayout`.

### Naming
The new name `SiteLayout` was chosen because it maintains the existing namespace of `SiteHeader` and `SiteFooter`. The previous name of `AppLayout` was chosen because it aligned with the underlying naming conventions of next.js.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
