### PR TITLE
badge: Re-export and deprecate types

### DIFF
--- a/packages/react/src/badge/index.ts
+++ b/packages/react/src/badge/index.ts
@@ -1,6 +1,15 @@
-import { IndicatorDot as _IndicatorDot } from '../indicator-dot';
-import { NotificationBadge as _NotificationBadge } from '../notification-badge';
-import { StatusBadge as _StatusBadge } from '../status-badge';
+import {
+	IndicatorDot as _IndicatorDot,
+	IndicatorDotProps as _IndicatorDotProps,
+} from '../indicator-dot';
+import {
+	NotificationBadge as _NotificationBadge,
+	NotificationBadgeProps as _NotificationBadgeProps,
+} from '../notification-badge';
+import {
+	StatusBadge as _StatusBadge,
+	StatusBadgeProps as _StatusBadgeProps,
+} from '../status-badge';
 
 /**
  * @deprecated This component has been moved.
@@ -11,6 +20,14 @@ import { StatusBadge as _StatusBadge } from '../status-badge';
 export const IndicatorDot = _IndicatorDot;
 
 /**
+ * @deprecated This type has been moved.
+ * Use `IndicatorDotProps` from the `indicator-dot` entrypoint instead.
+ * Example: `import { IndicatorDotProps } from '@ag.ds-next/react/indicator-dot'`".
+ * This will be removed in the next major version.
+ */
+export type IndicatorDotProps = _IndicatorDotProps;
+
+/**
  * @deprecated This component has been moved.
  * Use `NotificationBadge` from the `notification-badge` entrypoint instead.
  * Example: `import { NotificationBadge } from '@ag.ds-next/react/notification-badge'`".
@@ -19,9 +36,25 @@ export const IndicatorDot = _IndicatorDot;
 export const NotificationBadge = _NotificationBadge;
 
 /**
+ * @deprecated This type has been moved.
+ * Use `NotificationBadgeProps` from the `indicator-dot` entrypoint instead.
+ * Example: `import { NotificationBadgeProps } from '@ag.ds-next/react/indicator-dot'`".
+ * This will be removed in the next major version.
+ */
+export type NotificationBadgeProps = _NotificationBadgeProps;
+
+/**
  * @deprecated This component has been moved.
  * Use `StatusBadge` from the `status-badge` entrypoint instead.
  * Example: `import { StatusBadge } from '@ag.ds-next/react/status-badge'`".
  * This will be removed in the next major version.
  */
 export const StatusBadge = _StatusBadge;
+
+/**
+ * @deprecated This type has been moved.
+ * Use `StatusBadgeProps` from the `status-badge` entrypoint instead.
+ * Example: `import { StatusBadgeProps } from '@ag.ds-next/react/status-badge'`".
+ * This will be removed in the next major version.
+ */
+export type StatusBadgeProps = _StatusBadgeProps;


### PR DESCRIPTION
## Describe your changes

This PR is a follow up up to #1162. 

As well as re-exporting and marking components as deprecated, we should also do this for the component prop type definitions.

No changeset required as PR #1162 contains that.