### PR TITLE
control-input: Move conditional field container

### DIFF
--- a/.changeset/slimy-drinks-rest.md
+++ b/.changeset/slimy-drinks-rest.md
@@ -1,5 +1,0 @@
----
-'@ag.ds-next/react': minor
----
-
-control-input: Created new component `ConditionalFieldContainer` which can be used when conditionally revealing a related question.

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -34,6 +34,7 @@ import {
 } from '@ag.ds-next/react/icon';
 import { withBasePath } from '../lib/img';
 import * as designSystemComponents from './designSystemComponents';
+import { ConditionalFieldContainer } from './ConditionalFieldContainer';
 import { prismTheme } from './prism-theme';
 
 const PlaceholderImage = () => (
@@ -257,6 +258,7 @@ const StaticCode = ({
 
 const LIVE_SCOPE = {
 	...designSystemComponents,
+	ConditionalFieldContainer,
 	PlaceholderImage,
 	useState,
 	Fragment,

--- a/docs/components/ConditionalFieldContainer.tsx
+++ b/docs/components/ConditionalFieldContainer.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren } from 'react';
-import { Box } from '../box';
-import { mapSpacing, tokens } from '../core';
+import { Box } from '@ag.ds-next/react/box';
+import { mapSpacing, tokens } from '@ag.ds-next/react/core';
 
 export type ConditionalFieldContainerProps = PropsWithChildren<{}>;
 

--- a/docs/components/designSystemComponents.tsx
+++ b/docs/components/designSystemComponents.tsx
@@ -122,12 +122,7 @@ export {
 export { ProgressIndicator } from '@ag.ds-next/react/progress-indicator';
 export { PageAlert, PageAlertTitle } from '@ag.ds-next/react/page-alert';
 export { GlobalAlert } from '@ag.ds-next/react/global-alert';
-export {
-	ControlGroup,
-	Checkbox,
-	Radio,
-	ConditionalFieldContainer,
-} from '@ag.ds-next/react/control-input';
+export { ControlGroup, Checkbox, Radio } from '@ag.ds-next/react/control-input';
 export {
 	SearchBox,
 	SearchBoxInput,

--- a/example-form/components/ConditionalFieldContainer.tsx
+++ b/example-form/components/ConditionalFieldContainer.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from 'react';
+import { Box } from '@ag.ds-next/react/box';
+import { mapSpacing, tokens } from '@ag.ds-next/react/core';
+
+export type ConditionalFieldContainerProps = PropsWithChildren<{}>;
+
+export function ConditionalFieldContainer({
+	children,
+}: ConditionalFieldContainerProps) {
+	return (
+		<Box
+			borderLeft
+			borderLeftWidth="xl"
+			paddingLeft={1.5}
+			css={{
+				marginLeft: `calc(${mapSpacing(1)} - ${tokens.borderWidth.xl / 2}px)`,
+			}}
+		>
+			{children}
+		</Box>
+	);
+}

--- a/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep2.tsx
+++ b/example-form/components/FormRegisterPetPersonalDetails/FormRegisterPetPersonalDetailsStep2.tsx
@@ -4,15 +4,12 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { Prose } from '@ag.ds-next/react/prose';
 import { Stack } from '@ag.ds-next/react/box';
-import {
-	ControlGroup,
-	ConditionalFieldContainer,
-	Radio,
-} from '@ag.ds-next/react/control-input';
+import { ControlGroup, Radio } from '@ag.ds-next/react/control-input';
 import { FormStack } from '@ag.ds-next/react/form-stack';
 import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { TextInput } from '@ag.ds-next/react/text-input';
 import { useScrollToField } from '@ag.ds-next/react/field';
+import { ConditionalFieldContainer } from '../ConditionalFieldContainer';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
 import { useFormRegisterPetPersonalDetails } from './FormRegisterPetPersonalDetails';
 import { FormRegisterPetPersonalDetailsActions } from './FormRegisterPetPersonalDetailsActions';

--- a/example-site/components/ConditionalFieldContainer.tsx
+++ b/example-site/components/ConditionalFieldContainer.tsx
@@ -1,0 +1,22 @@
+import { PropsWithChildren } from 'react';
+import { Box } from '@ag.ds-next/react/box';
+import { mapSpacing, tokens } from '@ag.ds-next/react/core';
+
+export type ConditionalFieldContainerProps = PropsWithChildren<{}>;
+
+export function ConditionalFieldContainer({
+	children,
+}: ConditionalFieldContainerProps) {
+	return (
+		<Box
+			borderLeft
+			borderLeftWidth="xl"
+			paddingLeft={1.5}
+			css={{
+				marginLeft: `calc(${mapSpacing(1)} - ${tokens.borderWidth.xl / 2}px)`,
+			}}
+		>
+			{children}
+		</Box>
+	);
+}

--- a/example-site/components/FormExampleMultiStep/FormExampleMultiStep3.tsx
+++ b/example-site/components/FormExampleMultiStep/FormExampleMultiStep3.tsx
@@ -4,15 +4,12 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { Prose } from '@ag.ds-next/react/prose';
 import { Stack } from '@ag.ds-next/react/box';
-import {
-	Checkbox,
-	ControlGroup,
-	ConditionalFieldContainer,
-} from '@ag.ds-next/react/control-input';
+import { Checkbox, ControlGroup } from '@ag.ds-next/react/control-input';
 import { FormStack } from '@ag.ds-next/react/form-stack';
 import { PageAlert } from '@ag.ds-next/react/page-alert';
 import { TextInput } from '@ag.ds-next/react/text-input';
 import { useScrollToField } from '@ag.ds-next/react/field';
+import { ConditionalFieldContainer } from '../ConditionalFieldContainer';
 import { FormRequiredFieldsMessage } from '../FormRequiredFieldsMessage';
 import { useFormExampleMultiStep } from './FormExampleMultiStep';
 import { FormExampleMultiStepActions } from './FormExampleMultiStepActions';

--- a/packages/react/src/control-input/docs/code.mdx
+++ b/packages/react/src/control-input/docs/code.mdx
@@ -5,5 +5,3 @@
 <ComponentPropsTable name="Checkbox" />
 
 <ComponentPropsTable name="Radio" />
-
-<ComponentPropsTable name="ConditionalFieldContainer" />

--- a/packages/react/src/control-input/index.ts
+++ b/packages/react/src/control-input/index.ts
@@ -1,4 +1,3 @@
 export * from './ControlGroup';
 export * from './Checkbox';
 export * from './Radio';
-export * from './ConditionalFieldContainer';


### PR DESCRIPTION
## Describe your changes

Follow up to #1148.

In this PR, I have moved the `ConditionalFieldContainer` component from the `control-input` entrypoint into the docs, example site and example form components directory.

It has also been added to the Live code editor context, so it can be used in the "conditionally revealed questions" pattern, which can be previewed here https://design-system.agriculture.gov.au/pr-preview/pr-1165/patterns/conditional-reveal.

The reason for this change is that we are most likely going to split up control-input into several small components. Until that work has been resolved, it doesn't make any sense to be altering that package right now.


