### PR TITLE
 date-range-picker: Add flex wrapping

### DIFF
--- a/.changeset/hip-maps-breathe.md
+++ b/.changeset/hip-maps-breathe.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+date-range-picker: Updated container wrapping behaviour to allow the component to be placed in tight areas such as sidebars.

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -9,7 +9,8 @@ import {
 } from 'react';
 import { usePopper } from 'react-popper';
 import { SelectRangeEventHandler } from 'react-day-picker';
-import { Flex, Stack } from '../box';
+import { Flex } from '../flex';
+import { Stack } from '../stack';
 import {
 	mapSpacing,
 	tokens,
@@ -306,12 +307,7 @@ export const DateRangePicker = ({
 					{message && invalid ? (
 						<FieldMessage id={messageId}>{message}</FieldMessage>
 					) : null}
-					<Flex
-						ref={setRefEl}
-						flexDirection={{ xs: 'column', sm: 'row' }}
-						inline
-						gap={1}
-					>
+					<Flex ref={setRefEl} flexWrap="wrap" inline gap={1}>
 						<DateInput
 							ref={fromInputRef}
 							label={fromLabel}

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`DateRangePicker renders correctly 1`] = `
         class="css-1fqlpl4-boxStyles-DateRangePicker"
       >
         <div
-          class="css-ns3arw-boxStyles"
+          class="css-72257o-boxStyles"
         >
           <div
             class="css-1904cz9-boxStyles-FieldContainer"


### PR DESCRIPTION
## Describe your changes

Updated container wrapping behaviour to allow the component to be placed in tight areas such as sidebars.

### Before

The grey box represents a parent container changing it's width. You can see clearly in this video, that the date range picker doesn't respond well when placed in a tight area.

https://github.com/steelthreads/agds-next/assets/6265154/8fd1b095-360e-4d82-9638-db8c68a9061c

### After

After flex wrapping has been added, the two inputs flow nicely in tight areas.

https://github.com/steelthreads/agds-next/assets/6265154/78dd90ee-c66c-42e9-9422-f51e71b8023e

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).