### PR TITLE
docs: Fix pagination storybook link

### DIFF
--- a/packages/react/src/pagination/docs/overview.mdx
+++ b/packages/react/src/pagination/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Pagination
 description: Pagination separates large amounts of content into separate pages, which helps reduce cognitive load.
 group: Navigation
-storybookPath: /story/navigation--basic
+storybookPath: /story/navigation-pagination--on-light
 figmaGalleryNodeId: 11978%3A107147
 ---
 


### PR DESCRIPTION
## Describe your changes

Storybook link for pagination was broken. Updated to the first pagination story.
