### PR TITLE
page-alert: Add support for React element in title

### DIFF
--- a/.changeset/shaggy-waves-exercise.md
+++ b/.changeset/shaggy-waves-exercise.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+Page alert: Added support for element in title prop

--- a/.changeset/shaggy-waves-exercise.md
+++ b/.changeset/shaggy-waves-exercise.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-Page alert: Added support for element in title prop
+page-alert: Added support for a react element in the `title` prop

--- a/example-site/components/templates/MultiPageFormSuccess.tsx
+++ b/example-site/components/templates/MultiPageFormSuccess.tsx
@@ -37,10 +37,16 @@ export function MultiPageFormSuccess() {
 							pretext="Title of multi-page form"
 							title="Multi-page form title (H1)"
 						/>
-						<PageAlert ref={successPageAlertRef} tabIndex={-1} tone="success">
-							<PageAlertTitle as="h2">
-								Descriptive success message (H2)
-							</PageAlertTitle>
+						<PageAlert
+							ref={successPageAlertRef}
+							tabIndex={-1}
+							tone="success"
+							title={
+								<PageAlertTitle as="h2">
+									Descriptive success message (H2)
+								</PageAlertTitle>
+							}
+						>
 							<Prose>
 								<p>Supporting paragraph for the success message</p>
 								<p>

--- a/example-site/components/templates/SinglePageFormSuccess.tsx
+++ b/example-site/components/templates/SinglePageFormSuccess.tsx
@@ -34,10 +34,16 @@ export function SinglePageFormSuccess() {
 							]}
 						/>
 						<PageTitle title="Single-page form (multi-question) xxl/display (H1)" />
-						<PageAlert ref={successPageAlertRef} tabIndex={-1} tone="success">
-							<PageAlertTitle as="h2">
-								Descriptive success message (H2)
-							</PageAlertTitle>
+						<PageAlert
+							ref={successPageAlertRef}
+							tabIndex={-1}
+							tone="success"
+							title={
+								<PageAlertTitle as="h2">
+									Descriptive success message (H2)
+								</PageAlertTitle>
+							}
+						>
 							<Prose>
 								<p>Supporting paragraph for the success message</p>
 								<p>

--- a/packages/react/src/page-alert/PageAlert.stories.tsx
+++ b/packages/react/src/page-alert/PageAlert.stories.tsx
@@ -12,17 +12,18 @@ const meta: Meta<typeof PageAlert> = {
 			<Text as="p">This is a Page alert component.</Text>
 		</PageAlert>
 	),
-	args: {
-		title: 'Page alert',
-		tone: 'success',
-	},
 };
 
 export default meta;
 
 type Story = StoryObj<typeof PageAlert>;
 
-export const Basic: Story = {};
+export const Basic: Story = {
+	args: {
+		title: 'Page alert',
+		tone: 'success',
+	},
+};
 
 export const WithProse: Story = {
 	render: (args) => (
@@ -47,6 +48,7 @@ export const WithProse: Story = {
 
 export const WithTitleElement: Story = {
 	args: {
+		tone: 'success',
 		title: (
 			<PageAlertTitle as="h2">Descriptive success message (H2)</PageAlertTitle>
 		),

--- a/packages/react/src/page-alert/PageAlert.stories.tsx
+++ b/packages/react/src/page-alert/PageAlert.stories.tsx
@@ -1,38 +1,54 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { Text } from '../text';
 import { Prose } from '../prose';
 import { PageAlert } from './PageAlert';
+import { PageAlertTitle } from './PageAlertTitle';
 
-export default {
+const meta: Meta<typeof PageAlert> = {
 	title: 'content/PageAlert',
 	component: PageAlert,
-} as ComponentMeta<typeof PageAlert>;
-
-export const Basic: ComponentStory<typeof PageAlert> = (args) => (
-	<PageAlert {...args}>
-		<Text as="p">This is a Page alert component.</Text>
-	</PageAlert>
-);
-Basic.args = {
-	title: 'Page alert',
-	tone: 'success',
+	render: (args) => (
+		<PageAlert {...args}>
+			<Text as="p">This is a Page alert component.</Text>
+		</PageAlert>
+	),
+	args: {
+		title: 'Page alert',
+		tone: 'success',
+	},
 };
 
-export const WithProse: ComponentStory<typeof PageAlert> = (args) => (
-	<PageAlert {...args}>
-		<Prose>
-			<ul>
-				<li>
-					<a href="#">Full name must not be empty</a>
-				</li>
-				<li>
-					<a href="#">Phone number must not be empty</a>
-				</li>
-			</ul>
-		</Prose>
-	</PageAlert>
-);
-WithProse.args = {
-	title: 'Page alert',
-	tone: 'error',
+export default meta;
+
+type Story = StoryObj<typeof PageAlert>;
+
+export const Basic: Story = {};
+
+export const WithProse: Story = {
+	render: (args) => (
+		<PageAlert {...args}>
+			<Prose>
+				<ul>
+					<li>
+						<a href="#">Full name must not be empty</a>
+					</li>
+					<li>
+						<a href="#">Phone number must not be empty</a>
+					</li>
+				</ul>
+			</Prose>
+		</PageAlert>
+	),
+	args: {
+		title: 'Page alert',
+		tone: 'error',
+	},
+};
+
+export const WithTitleElement: Story = {
+	args: {
+		title: (
+			<PageAlertTitle as="h2">Descriptive success message (H2)</PageAlertTitle>
+		),
+	},
 };

--- a/packages/react/src/page-alert/PageAlert.test.tsx
+++ b/packages/react/src/page-alert/PageAlert.test.tsx
@@ -70,7 +70,7 @@ describe('PageAlert', () => {
 	it('can render a different heading level', () => {
 		renderPageAlert({
 			tone: 'info',
-			children: <PageAlertTitle as="h2">Title</PageAlertTitle>,
+			title: <PageAlertTitle as="h2">Title</PageAlertTitle>,
 		});
 		const el = screen.getByText('Title');
 		expect(el).toBeInTheDocument();

--- a/packages/react/src/page-alert/PageAlert.tsx
+++ b/packages/react/src/page-alert/PageAlert.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, HTMLAttributes, PropsWithChildren } from 'react';
+import {
+	forwardRef,
+	HTMLAttributes,
+	PropsWithChildren,
+	ReactNode,
+	isValidElement,
+} from 'react';
 import { Flex } from '../box';
 import { boxPalette, tokens } from '../core';
 import {
@@ -17,7 +23,7 @@ export type PageAlertProps = PropsWithChildren<{
 	id?: string;
 	role?: DivProps['role'];
 	tabIndex?: number;
-	title?: string;
+	title?: ReactNode;
 	tone: PageAlertTone;
 }>;
 
@@ -48,7 +54,13 @@ export const PageAlert = forwardRef<HTMLDivElement, PageAlertProps>(
 					{icon}
 				</Flex>
 				<Flex padding={1.5} gap={1} flexDirection="column" flexGrow={1}>
-					{title ? <PageAlertTitle>{title}</PageAlertTitle> : null}
+					{title ? (
+						isValidElement(title) ? (
+							title
+						) : (
+							<PageAlertTitle>{title}</PageAlertTitle>
+						)
+					) : null}
 					{children}
 				</Flex>
 			</Flex>

--- a/packages/react/src/page-alert/PageAlertTitle.tsx
+++ b/packages/react/src/page-alert/PageAlertTitle.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { Text } from '../text';
 
 export type PageAlertTitleProps = PropsWithChildren<{
-	as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5';
+	as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }>;
 
 export const PageAlertTitle = ({

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -102,3 +102,14 @@ You can take advantage of our `Prose` component to ensure consistant spacing bet
 	</Prose>
 </PageAlert>
 ```
+
+You can also use the `PageAlertTitle` component in the title prop, to change the element used for the title.
+
+```jsx live
+<PageAlert
+	tone="success"
+	title={<PageAlertTitle as="h2">Submission successful</PageAlertTitle>}
+>
+	<Text as="p">Your application has been successfully submitted.</Text>
+</PageAlert>
+```


### PR DESCRIPTION
## Describe your changes

This PR adds support for placing a PageAlertTitle component in the PageAlert's `title` prop, as opposed to a string. This is to support an upcoming change which will introduce a Dismiss button to PageAlert.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).