### PR TITLE
box: Fix circular dependency 

### DIFF
--- a/packages/react/src/flex/Flex.tsx
+++ b/packages/react/src/flex/Flex.tsx
@@ -1,5 +1,6 @@
 import { forwardRefWithAs } from '../core';
-import { Box, BoxProps } from '../box';
+import { Box } from '../box/Box';
+import { BoxProps } from '../box/styles';
 
 export type FlexProps = BoxProps & { inline?: boolean };
 

--- a/packages/react/src/stack/Stack.tsx
+++ b/packages/react/src/stack/Stack.tsx
@@ -1,5 +1,6 @@
 import { forwardRefWithAs } from '../core';
-import { Box, BoxProps } from '../box';
+import { Box } from '../box/Box';
+import { BoxProps } from '../box/styles';
 
 export type StackProps = Omit<BoxProps, 'display'>;
 


### PR DESCRIPTION
## Describe your changes

This PR is a follow up to #1168 

This fixes up a circular dependency issue we have with the `Box`, `Flex` and `Stack` component.


