### PR TITLE
file-upload: Make internal types available to consumers

### DIFF
--- a/.changeset/wild-turtles-develop.md
+++ b/.changeset/wild-turtles-develop.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+FileUpload
+
+- Makes the internal FileUpload types available to consumers.

--- a/.changeset/wild-turtles-develop.md
+++ b/.changeset/wild-turtles-develop.md
@@ -2,6 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-FileUpload
-
-- Makes the internal FileUpload types available to consumers.
+file-upload: Made internal types available to consumers.

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, InputHTMLAttributes, useEffect, useState } from 'react';
 import { useDropzone, DropzoneOptions } from 'react-dropzone';
-import { Flex, Stack } from '../box';
+import { Flex } from '../flex';
+import { Stack } from '../stack';
 import { Button } from '../button';
 import { packs, boxPalette, tokens, mergeRefs } from '../core';
 import { Field } from '../field';
@@ -9,16 +10,21 @@ import { Text } from '../text';
 import { visuallyHiddenStyles } from '../a11y';
 import { FileUploadRejectedFileList } from './FileUploadRejectedFileList';
 import {
-	getAcceptedFilesSummary,
 	AcceptedFileMimeTypes,
-	getFileRejectionErrorMessage,
-	getErrorSummary,
-	formatFileSize,
 	FileWithStatus,
-	RejectedFile,
+	formatFileSize,
+	getAcceptedFilesSummary,
+	getErrorSummary,
+	getFileRejectionErrorMessage,
 	getFilesTotal,
+	RejectedFile,
 } from './utils';
 import { FileUploadFileList } from './FileUploadFileList';
+export type {
+	AcceptedFileMimeTypes,
+	FileWithStatus,
+	RejectedFile,
+} from './utils';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
 

--- a/packages/react/src/file-upload/FileUploadFile.tsx
+++ b/packages/react/src/file-upload/FileUploadFile.tsx
@@ -1,5 +1,6 @@
 import { MouseEventHandler } from 'react';
-import { Box, Flex } from '../box';
+import { Box } from '../box';
+import { Flex } from '../flex';
 import { boxPalette } from '../core';
 import { Text } from '../text';
 import { Button } from '../button';

--- a/packages/react/src/file-upload/FileUploadFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadFileList.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '../box';
+import { Stack } from '../stack';
 import { FileUploadFile } from './FileUploadFile';
 import { FileWithStatus } from './utils';
 

--- a/packages/react/src/file-upload/FileUploadRejectedFile.tsx
+++ b/packages/react/src/file-upload/FileUploadRejectedFile.tsx
@@ -1,5 +1,7 @@
 import { MouseEventHandler } from 'react';
-import { Box, Flex, Stack } from '../box';
+import { Box } from '../box';
+import { Flex } from '../flex';
+import { Stack } from '../stack';
 import { Button } from '../button';
 import { boxPalette } from '../core';
 import { AlertFilledIcon } from '../icon';

--- a/packages/react/src/file-upload/FileUploadRejectedFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadRejectedFileList.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '../box';
+import { Stack } from '../stack';
 import { FileUploadRejectedFile } from './FileUploadRejectedFile';
 import type { RejectedFile } from './utils';
 


### PR DESCRIPTION
## Describe your changes

Make the internal types of `FileUpload` available to Design System consumers.

Example:
```tsx
import type {
	AcceptedFileMimeTypes,
	FileWithStatus,
	RejectedFile,
} from '@ag.ds-next/react/file-upload';
```


## Checklist

### Updating existing component

- [ ] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

### Creating new component

- [ ] Describe the changes clearly in the PR description
- [ ] Preconstruct entrypoint has been created
- [ ] Changeset file includes a minor
- [ ] Export components for docs site and Playroom (`docs/components/designSystemComponents.tsx`)
- [ ] Add snippets to Playroom (`docs/playroom/snippets.ts`)
- [ ] Add component to Kitchen Sink (`.storybook/stories/KitchenSink.tsx`)
- [ ] Add pictogram to Docs (`docs/components/pictograms/index.tsx`)
