### PR TITLE
docs: Remove version number from components, patterns and templates

### DIFF
--- a/docs/components/PatternLayout.tsx
+++ b/docs/components/PatternLayout.tsx
@@ -36,11 +36,7 @@ export function PatternLayout({
 				editPath={editPath}
 				breadcrumbs={breadcrumbs}
 			>
-				<PageTitle
-					pretext={`v${pattern.version}`}
-					title={pattern.title}
-					introduction={pattern.description}
-				/>
+				<PageTitle title={pattern.title} introduction={pattern.description} />
 				{(pattern.figmaTemplateNodeId ||
 					pattern.githubTemplatePath ||
 					pattern.storybookPath) && (

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -42,7 +42,6 @@ export function PkgLayout({
 				skipLinks={skipLinks}
 			>
 				<PageTitle
-					pretext={`v${pkg.version}`}
 					title={pkg.title}
 					introduction={pkg.description}
 					callToAction={

--- a/docs/components/TemplateLayout.tsx
+++ b/docs/components/TemplateLayout.tsx
@@ -38,7 +38,6 @@ export function TemplateLayout({
 				breadcrumbs={breadcrumbs}
 			>
 				<PageTitle
-					pretext={`v${template.version}`}
 					title={template.title}
 					introduction={template.description}
 					callToAction={

--- a/docs/content/patterns/conditional-reveal/index.mdx
+++ b/docs/content/patterns/conditional-reveal/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Conditionally revealed questions
 description: Conditionally reveal a related question when a user selects a specific radio or checkbox option. This ensures that users only encounter questions when it is applicable to their selection.
-version: 1.0.0
 ---
 
 <DoHeading />

--- a/docs/content/patterns/filtering-a-dataset/index.mdx
+++ b/docs/content/patterns/filtering-a-dataset/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Filtering a dataset
 description: Filters allows a user to refine the data they want to display in a large dataset by removing any items that do not match their criteria.
-version: 1.0.0
 figmaTemplateNodeId: 18586-56265
 githubTemplatePath: /.storybook/stories/DataFiltering
 storybookPath: /story/patterns-data-filtering-and-sorting--small

--- a/docs/content/patterns/selecting-multiple-options/index.mdx
+++ b/docs/content/patterns/selecting-multiple-options/index.mdx
@@ -1,7 +1,6 @@
 ---
 title: Selecting multiple options
 description: Multi-select is a commonly used design pattern that allows users to select multiple options from a list. This pattern is used in various contexts such as search filters, form fields, and more.
-version: 1.0.0
 ---
 
 ## Usage guidelines

--- a/docs/content/templates/category/index.mdx
+++ b/docs/content/templates/category/index.mdx
@@ -2,7 +2,6 @@
 order: 2
 title: Category page
 description: Our category page example.
-version: 1.0.0
 previewPath: /category
 figmaTemplateNodeId: 8410%3A85360
 githubTemplatePath: /example-site/pages/category/index.tsx

--- a/docs/content/templates/content/index.mdx
+++ b/docs/content/templates/content/index.mdx
@@ -2,7 +2,6 @@
 order: 4
 title: Content page
 description: The content template is used to deliver long-form informational content.
-version: 1.0.0
 previewPath: /category/subcategory/content
 figmaTemplateNodeId: 8410%3A83580
 githubTemplatePath: /example-site/pages/category/subcategory/content.tsx

--- a/docs/content/templates/error-page/index.mdx
+++ b/docs/content/templates/error-page/index.mdx
@@ -2,7 +2,6 @@
 order: 8
 title: Error page
 description: A standard error screen page template.
-version: 1.0.0
 previewPath: /404
 githubTemplatePath: /example-site/pages/404.tsx
 storybookPath: /story/templates-error-page--not-found

--- a/docs/content/templates/home/index.mdx
+++ b/docs/content/templates/home/index.mdx
@@ -2,7 +2,6 @@
 order: 1
 title: Home page
 description: Provide a strong first impression.
-version: 1.0.0
 previewPath: /
 figmaTemplateNodeId: 8410%3A83756
 githubTemplatePath: /example-site/pages/index.tsx

--- a/docs/content/templates/multi-page-form/index.mdx
+++ b/docs/content/templates/multi-page-form/index.mdx
@@ -2,7 +2,6 @@
 order: 6
 title: Multi-page form
 description: Use this template to break up large forms into multiple smaller steps to decrease cognitive load.
-version: 1.0.0
 previewPath: /category/subcategory/multi-page-form
 figmaTemplateNodeId: 8410%3A83825
 githubTemplatePath: /example-site/pages/category/subcategory/multi-page-form/index.tsx

--- a/docs/content/templates/sign-in/index.mdx
+++ b/docs/content/templates/sign-in/index.mdx
@@ -2,7 +2,6 @@
 order: 7
 title: Sign-in form page
 description: An example of a sign-in form.
-version: 1.0.0
 previewPath: /sign-in-form
 githubTemplatePath: /example-site/pages/sign-in-form.tsx
 storybookPath: /story/templates-sign-in-form-page--sign-in-form

--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -2,7 +2,6 @@
 order: 5
 title: Single-page form
 description: An example of a single-page multi-question form.
-version: 1.0.0
 previewPath: /category/subcategory/single-page-form
 figmaTemplateNodeId: 8410%3A83912
 githubTemplatePath: /example-site/pages/category/subcategory/single-page-form.tsx

--- a/docs/content/templates/subcategory/index.mdx
+++ b/docs/content/templates/subcategory/index.mdx
@@ -2,7 +2,6 @@
 order: 3
 title: Subcategory page
 description: Our subcategory page example.
-version: 1.0.0
 previewPath: /category/subcategory
 figmaTemplateNodeId: 8410%3A85311
 githubTemplatePath: /example-site/pages/category/subcategory/index.tsx

--- a/docs/lib/mdx/packages.ts
+++ b/docs/lib/mdx/packages.ts
@@ -5,7 +5,6 @@ import {
 	getMarkdownData,
 	serializeMarkdown,
 	stripMdxExtension,
-	getJSONData,
 } from '../mdxUtils';
 import { slugify } from '../slugify';
 
@@ -18,12 +17,10 @@ const pkgDocsPath = (slug: string) => normalize(`${PKG_PATH}/${slug}/docs`);
 
 export async function getPkg(slug: string) {
 	const { data } = await getMarkdownData(pkgReadmePath(slug));
-	const { version } = await getJSONData(`${REACT_PKG_PATH}/package.json`);
 	const subNavItems = await getPkgSubNavItems(slug);
 	return {
 		slug,
 		name: slug,
-		version,
 		title: (data.title ?? slug) as string,
 		description: (data.description ?? null) as string | null,
 		storybookPath: (data.storybookPath ?? null) as string | null,

--- a/docs/lib/mdx/patterns.ts
+++ b/docs/lib/mdx/patterns.ts
@@ -23,7 +23,6 @@ export async function getPattern(slug: string) {
 		content,
 		data,
 		title: (data.title ?? slug) as string,
-		version: data.version as string,
 		description: (data.description ?? null) as string | null,
 		figmaTemplateNodeId: (data.figmaTemplateNodeId ?? null) as string | null,
 		githubTemplatePath: (data.githubTemplatePath ?? null) as string | null,

--- a/docs/lib/mdx/templates.ts
+++ b/docs/lib/mdx/templates.ts
@@ -24,7 +24,6 @@ export async function getTemplate(slug: string) {
 		content,
 		data,
 		title: (data.title ?? slug) as string,
-		version: data.version as string,
 		description: (data.description ?? null) as string | null,
 		previewPath: (data.previewPath ?? null) as string | null,
 		figmaTemplateNodeId: (data.figmaTemplateNodeId ?? null) as string | null,


### PR DESCRIPTION
## Describe your changes

Remove version number from components, patterns and templates.

- [View components preview](https://design-system.agriculture.gov.au/pr-preview/pr-1186/components/avatar)
- [View patterns preview](https://design-system.agriculture.gov.au/pr-preview/pr-1186/patterns/conditional-reveal)
- [View templates preview](https://design-system.agriculture.gov.au/pr-preview/pr-1186/templates/category)