### PR TITLE
docs: Add table of contents to patterns

### DIFF
--- a/docs/content/patterns/selecting-multiple-options/index.mdx
+++ b/docs/content/patterns/selecting-multiple-options/index.mdx
@@ -4,9 +4,7 @@ description: Multi-select is a commonly used design pattern that allows users to
 version: 1.0.0
 ---
 
-## Usage guidelines
-
-### Small list
+## Small list
 
 A simple list of [Checkboxes](/components/checkbox) should always be preferred. This is the most accessible solution as it provides users with a clear understanding of all the available options. It also eliminates the need for additional interactions such as opening a dropdown menu.
 
@@ -18,7 +16,7 @@ A simple list of [Checkboxes](/components/checkbox) should always be preferred. 
 </ControlGroup>
 ```
 
-### Large list
+## Large list
 
 The [ComboboxMulti](/components/combobox) component can be used when there are a large number of options or vertical space is limited. It allows users to search and select options from a dropdown menu. However, this approach requires additional interaction and may not be as clear as a simple list of checkboxes.
 

--- a/docs/pages/patterns/[slug].tsx
+++ b/docs/pages/patterns/[slug].tsx
@@ -1,6 +1,7 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
 import { Prose } from '@ag.ds-next/react/prose';
+import { InpageNav } from '@ag.ds-next/react/inpage-nav';
 import {
 	getPattern,
 	getPatternSlugs,
@@ -8,6 +9,7 @@ import {
 	getPatternNavLinks,
 	Pattern,
 } from '../../lib/mdx/patterns';
+import { generateToc } from '../../lib/generateToc';
 import { PatternLayout } from '../../components/PatternLayout';
 import { mdxComponents } from '../../components/mdxComponents';
 import { DocumentTitle } from '../../components/DocumentTitle';
@@ -16,6 +18,7 @@ export default function PatternPage({
 	breadcrumbs,
 	pattern,
 	navLinks,
+	toc,
 }: InferGetStaticPropsType<typeof getStaticProps>) {
 	return (
 		<>
@@ -29,6 +32,12 @@ export default function PatternPage({
 				editPath={`/docs/content/patterns/${pattern.slug}/index.mdx`}
 				navLinks={navLinks}
 			>
+				{toc?.length > 1 ? (
+					<InpageNav
+						title="On this page"
+						links={toc.map((i) => ({ label: i.title, href: `#${i.slug}` }))}
+					/>
+				) : null}
 				<Prose id="page-content">
 					<MDXRemote {...pattern.source} components={mdxComponents} />
 				</Prose>
@@ -42,6 +51,7 @@ export const getStaticProps: GetStaticProps<
 		pattern: Pattern;
 		navLinks: Awaited<ReturnType<typeof getPatternNavLinks>>;
 		breadcrumbs: Awaited<ReturnType<typeof getPatternBreadcrumbs>>;
+		toc: Awaited<ReturnType<typeof generateToc>>;
 	},
 	{ slug: string }
 > = async ({ params }) => {
@@ -54,13 +64,14 @@ export const getStaticProps: GetStaticProps<
 	}
 
 	const breadcrumbs = await getPatternBreadcrumbs(slug);
+	const toc = await generateToc(pattern.content);
 
 	return {
 		props: {
-			pattern,
-			navLinks,
 			breadcrumbs,
-			slug,
+			navLinks,
+			pattern,
+			toc,
 		},
 	};
 };


### PR DESCRIPTION
## Describe your changes

In this PR I have added our table of contents to the "Patterns" section of the docs website. We do this in other parts of the website, but we never added to Patterns section.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1187/patterns/filtering-a-dataset)

