### PR TITLE
file-input: Removed red tint background from invalid state

### DIFF
--- a/.changeset/two-icons-joke.md
+++ b/.changeset/two-icons-joke.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+file-input: Removed red tint background from invalid state

--- a/packages/react/src/file-input/FileInput.test.tsx
+++ b/packages/react/src/file-input/FileInput.test.tsx
@@ -23,4 +23,25 @@ describe('FileInput', () => {
 			rules: { 'valid-id': 'off' },
 		});
 	});
+
+	describe('invalid', () => {
+		it('renders correctly', () => {
+			const { container } = renderFileInput({
+				invalid: true,
+				message: 'This file is not valid',
+			});
+			expect(container).toMatchSnapshot();
+		});
+		it('renders a valid HTML structure', () => {
+			const { container } = renderFileInput({
+				invalid: true,
+				message: 'This file is not valid',
+			});
+			expect(container).toHTMLValidate({
+				extends: ['html-validate:recommended'],
+				// react 18s `useId` break this rule
+				rules: { 'valid-id': 'off' },
+			});
+		});
+	});
 });

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -48,7 +48,6 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		},
 		ref
 	) {
-		const styles = fileInputStyles();
 		return (
 			<Field
 				label={label}
@@ -60,28 +59,35 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 				id={id}
 			>
 				{(a11yProps) => (
-					<input ref={ref} css={styles} {...a11yProps} type="file" {...props} />
+					<input
+						ref={ref}
+						css={{
+							...fontGrid('sm', 'default'),
+							fontFamily: tokens.font.body,
+							color: boxPalette.foregroundText,
+
+							'::file-selector-button': {
+								...buttonStyles({
+									size: 'md',
+									variant: 'secondary',
+									block: false,
+								}),
+								margin: `0 ${mapSpacing(1)} 0 0`,
+							},
+
+							'&:disabled': {
+								cursor: 'not-allowed',
+								opacity: 0.3,
+							},
+
+							'&:focus': packs.outline,
+						}}
+						{...a11yProps}
+						type="file"
+						{...props}
+					/>
 				)}
 			</Field>
 		);
 	}
 );
-
-export const fileInputStyles = () =>
-	({
-		...fontGrid('sm', 'default'),
-		fontFamily: tokens.font.body,
-		color: boxPalette.foregroundText,
-
-		'::file-selector-button': {
-			...buttonStyles({ size: 'md', variant: 'secondary', block: false }),
-			margin: `0 ${mapSpacing(1)} 0 0`,
-		},
-
-		'&:disabled': {
-			cursor: 'not-allowed',
-			opacity: 0.3,
-		},
-
-		'&:focus': packs.outline,
-	} as const);

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -48,7 +48,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		},
 		ref
 	) {
-		const styles = fileInputStyles({ invalid });
+		const styles = fileInputStyles();
 		return (
 			<Field
 				label={label}
@@ -67,7 +67,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 	}
 );
 
-export const fileInputStyles = ({ invalid }: { invalid?: boolean }) =>
+export const fileInputStyles = () =>
 	({
 		...fontGrid('sm', 'default'),
 		fontFamily: tokens.font.body,
@@ -77,11 +77,6 @@ export const fileInputStyles = ({ invalid }: { invalid?: boolean }) =>
 			...buttonStyles({ size: 'md', variant: 'secondary', block: false }),
 			margin: `0 ${mapSpacing(1)} 0 0`,
 		},
-
-		...(invalid && {
-			backgroundColor: boxPalette.systemErrorMuted,
-			color: boxPalette.systemError,
-		}),
 
 		'&:disabled': {
 			cursor: 'not-allowed',

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-1hjj1fi-Field"
+      class="css-15vg304-FileInput"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-1hjj1fi-Field"
+      class="css-15vg304-FileInput"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -1,5 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FileInput invalid renders correctly 1`] = `
+<div>
+  <div
+    class="css-1n67ua0-boxStyles-FieldContainer"
+  >
+    <label
+      class="css-79i25n-boxStyles"
+      for="field-:r2:"
+    >
+      <span
+        class="css-433uqb-boxStyles-Text"
+      >
+        Example
+      </span>
+      <span
+        class="css-1rpt3h8-boxStyles-Text"
+      >
+         
+        (optional)
+      </span>
+    </label>
+    <div
+      class="css-1xkbxzi-boxStyles"
+    >
+      <div
+        class="css-1ldvxqr-boxStyles"
+      >
+        <svg
+          aria-hidden="false"
+          aria-label="Error"
+          class="css-1cvvs16-FieldMessage"
+          clip-rule="evenodd"
+          focusable="true"
+          height="24"
+          role="img"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M16.4661 0.5C16.7332 0.5 16.9893 0.6069 17.1771 0.796862L23.2111 6.89871C23.3962 7.08591 23.5 7.33857 23.5 7.60185V16.3935C23.5 16.6595 23.394 16.9146 23.2055 17.1023L17.0712 23.2087C16.8838 23.3953 16.6301 23.5 16.3657 23.5H7.63889C7.37177 23.5 7.11576 23.3931 6.92792 23.2032L0.789033 16.9968C0.60386 16.8095 0.5 16.5569 0.5 16.2935V7.60646C0.5 7.34045 0.605983 7.08541 0.794505 6.89774L6.92885 0.791284C7.11625 0.604732 7.36991 0.5 7.63434 0.5H16.4661ZM16.7071 7.29289C17.0976 7.68342 17.0976 8.31658 16.7071 8.70711L13.4142 12L16.7071 15.2929C17.0976 15.6834 17.0976 16.3166 16.7071 16.7071C16.3166 17.0976 15.6834 17.0976 15.2929 16.7071L12 13.4142L8.70711 16.7071C8.31658 17.0976 7.68342 17.0976 7.29289 16.7071C6.90237 16.3166 6.90237 15.6834 7.29289 15.2929L10.5858 12L7.29289 8.70711C6.90237 8.31658 6.90237 7.68342 7.29289 7.29289C7.68342 6.90237 8.31658 6.90237 8.70711 7.29289L12 10.5858L15.2929 7.29289C15.6834 6.90237 16.3166 6.90237 16.7071 7.29289Z"
+            fill="currentColor"
+            fill-rule="evenodd"
+            stroke="none"
+          />
+        </svg>
+      </div>
+      <span
+        class="css-tfsyf8-boxStyles-Text"
+        id="field-:r2:-message"
+      >
+        This file is not valid
+      </span>
+    </div>
+    <input
+      aria-describedby="field-:r2:-message"
+      aria-invalid="true"
+      aria-required="false"
+      class="css-1hjj1fi-Field"
+      id="field-:r2:"
+      type="file"
+    />
+  </div>
+</div>
+`;
+
 exports[`FileInput renders correctly 1`] = `
 <div>
   <div


### PR DESCRIPTION
## Describe your changes

Removing the red tint and text colour from the button region of the FileInput component.

<img width="777" alt="image of file-input with proposed change" src="https://github.com/steelthreads/agds-next/assets/12689383/a3846a6b-f1b6-4b71-974a-042c8189c893">

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
