### PR TITLE
docs: Error page template - remove duplicate error code

### DIFF
--- a/docs/content/templates/error-page/ThirdParty.tsx
+++ b/docs/content/templates/error-page/ThirdParty.tsx
@@ -17,7 +17,6 @@ export const ThirdParty = () => {
 						try again later.
 					</p>
 				</Prose>
-				<Text color="muted">Error code: 503</Text>
 				<Callout title="Need help?">
 					<Prose>
 						<p>


### PR DESCRIPTION
## Describe your changes

Fix a typo in #1174 which showed the error code twice in the `Third party outage` template.