### PR TITLE
filter-drawer: Close drawer clicking the overlay

### DIFF
--- a/packages/react/src/filter-drawer/FilterDrawer.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawer.tsx
@@ -1,6 +1,7 @@
 import {
 	Fragment,
 	FunctionComponent,
+	MouseEventHandler,
 	PropsWithChildren,
 	ReactNode,
 	useEffect,
@@ -65,7 +66,7 @@ export const FilterDrawer: FunctionComponent<FilterDrawerProps> = ({
 			{dialogTransitions(({ translateX, opacity }, item) =>
 				item ? (
 					<div ref={modalContainerRef}>
-						<Overlay style={{ opacity }} />
+						<Overlay onClick={() => onDismiss()} style={{ opacity }} />
 						<FilterDrawerDialog
 							onDismiss={onDismiss}
 							title={title}
@@ -82,9 +83,16 @@ export const FilterDrawer: FunctionComponent<FilterDrawerProps> = ({
 	);
 };
 
-function Overlay({ style }: { style: { opacity: SpringValue<number> } }) {
+function Overlay({
+	onClick,
+	style,
+}: {
+	onClick: MouseEventHandler<HTMLDivElement>;
+	style: { opacity: SpringValue<number> };
+}) {
 	return (
 		<animated.div
+			onClick={onClick}
 			css={{
 				position: 'fixed',
 				inset: 0,

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -3,7 +3,7 @@ import FocusLock from 'react-focus-lock';
 import { animated, SpringValue } from '@react-spring/web';
 import { Box } from '../box';
 import { Flex } from '../flex';
-import { mapSpacing } from '../core';
+import { mapResponsiveProp, mapSpacing, mq } from '../core';
 import { CloseIcon } from '../icon';
 import { Button } from '../button';
 import { Text } from '../text';
@@ -51,14 +51,17 @@ export function FilterDrawerDialog({
 				<FilterDrawerContent>{children}</FilterDrawerContent>
 				{actions ? <FilterDrawerFooter>{actions}</FilterDrawerFooter> : null}
 				<Button
-					variant="tertiary"
+					variant="text"
 					onClick={onDismiss}
 					iconAfter={CloseIcon}
-					css={{
+					css={mq({
 						position: 'absolute',
-						top: mapSpacing(0.5),
-						right: mapSpacing(0.5),
-					}}
+						top: '1.25rem', // align with title
+						right: mapResponsiveProp({
+							xs: mapSpacing(0.75),
+							md: mapSpacing(1.5),
+						}),
+					})}
 				>
 					Close
 				</Button>

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -73,7 +73,7 @@ type FilterDrawerHeaderProps = PropsWithChildren<{}>;
 
 function FilterDrawerHeader({ children }: FilterDrawerHeaderProps) {
 	return (
-		<Box borderBottom paddingX={1.5} paddingY={1}>
+		<Box borderBottom paddingX={{ xs: 0.75, md: 1.5 }} paddingY={1}>
 			{children}
 		</Box>
 	);
@@ -108,7 +108,11 @@ type FilterDrawerContentProps = PropsWithChildren<{}>;
 
 function FilterDrawerContent({ children }: FilterDrawerContentProps) {
 	return (
-		<Box padding={1.5} css={{ overflowY: 'auto' }}>
+		<Box
+			paddingX={{ xs: 0.75, md: 1.5 }}
+			paddingY={{ xs: 1, md: 1.5 }}
+			css={{ overflowY: 'auto' }}
+		>
 			{children}
 		</Box>
 	);
@@ -120,7 +124,12 @@ type FilterDrawerFooterProps = PropsWithChildren<{}>;
 
 function FilterDrawerFooter({ children }: FilterDrawerFooterProps) {
 	return (
-		<Box borderTop paddingX={1.5} paddingY={1} css={{ marginTop: 'auto' }}>
+		<Box
+			borderTop
+			paddingX={{ xs: 0.75, md: 1.5 }}
+			paddingY={1}
+			css={{ marginTop: 'auto' }}
+		>
 			{children}
 		</Box>
 	);

--- a/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
+++ b/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`FilterDrawer renders correctly 1`] = `
         style="transform: translateX(100%);"
       >
         <div
-          class="css-1m212kh-boxStyles"
+          class="css-uyeuq7-boxStyles"
         >
           <h2
             class="css-4kc494-boxStyles-Text-FilterDrawerHeaderTitle"
@@ -38,7 +38,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </h2>
         </div>
         <div
-          class="css-16oc5h-boxStyles-FilterDrawerContent"
+          class="css-1e81yjk-boxStyles-FilterDrawerContent"
         >
           <p
             class="css-6j1v6l-boxStyles-Text"
@@ -47,7 +47,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </p>
         </div>
         <div
-          class="css-oe0ykg-boxStyles-FilterDrawerFooter"
+          class="css-nji5cg-boxStyles-FilterDrawerFooter"
         >
           <button
             class="css-3jmmp1-BaseButton-Button"

--- a/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
+++ b/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </button>
         </div>
         <button
-          class="css-1alhlgt-BaseButton-FilterDrawerDialog"
+          class="css-wlcd0o-BaseButton-FilterDrawerDialog"
           type="button"
         >
           <span>

--- a/packages/react/src/filter-drawer/docs/overview.mdx
+++ b/packages/react/src/filter-drawer/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Filter drawer
-description: Filter drawer can be used to display 6+ filters for a data set. It is overlayed on top of the main area of the page to capture the user's attention while keeping the context of the current task.
+description: Filter drawer can be used to display 6+ filters for a data set. It is overlayed on top of the main area of the page to capture the users attention while keeping the context of the current task.
 group: Layout
 storybookPath: /story/layout-filterdrawer--basic
 relatedComponents: ['modal']

--- a/packages/react/src/filter-drawer/docs/overview.mdx
+++ b/packages/react/src/filter-drawer/docs/overview.mdx
@@ -39,7 +39,7 @@ relatedComponents: ['modal']
 <DoHeading />
 
 - read the [Filtering a dataset pattern](/patterns/filtering-a-dataset)
-- use to display a large number of filters for a data list or table
+- use to display 6+ filters for a data list or table
 - use a [Button group](/components/button#button-group) to display actions
 - use a [Fieldset](/components/fieldset) to group related filters
 - include a Close button in the top right
@@ -65,8 +65,7 @@ The Filter drawer can be closed by either:
 2. Pressing the "Apply filters" button
 3. Pressing the "Cancel" button
 4. Pressing the "Escape" key
-
-The filter drawer does not close when pressing the overlay.
+5. Pressing the overlay
 
 When closing the Filter drawer, focus should be returned to the button that opened the Filter drawer.
 

--- a/packages/react/src/filter-drawer/docs/overview.mdx
+++ b/packages/react/src/filter-drawer/docs/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Filter drawer
-description: Filter drawer can be used to display a large number of filters for a data set. It is overlayed on top of the main area of the page to capture the user's attention while keeping the context of the current task.
+description: Filter drawer can be used to display 6+ filters for a data set. It is overlayed on top of the main area of the page to capture the user's attention while keeping the context of the current task.
 group: Layout
 storybookPath: /story/layout-filterdrawer--basic
 relatedComponents: ['modal']
@@ -39,7 +39,7 @@ relatedComponents: ['modal']
 <DoHeading />
 
 - read the [Filtering a dataset pattern](/patterns/filtering-a-dataset)
-- use to display 6+ filters for a data list or table
+- use to display 6+ filters for a data set
 - use a [Button group](/components/button#button-group) to display actions
 - use a [Fieldset](/components/fieldset) to group related filters
 - include a Close button in the top right


### PR DESCRIPTION
## Describe your changes

Follow up to PR #1099.

- Close the Filter drawer when the user clicks the overlay
- Updated padding in `FilterDialog` to match the padding of page content
- Update documentation

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1203/components/filter-drawer)