### PR TITLE
modal: Fix inconsistent padding on mobile

### DIFF
--- a/.changeset/mighty-carrots-battle.md
+++ b/.changeset/mighty-carrots-battle.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+modal: Fixed inconsistent padding on mobile

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -33,9 +33,8 @@ export const ModalDialog = ({
 				background="body"
 				aria-labelledby={titleId}
 				rounded
-				focus
-				padding={1.5}
-				paddingTop={4}
+				paddingX={{ xs: 0.75, md: 1.5 }}
+				paddingY={{ xs: 1, md: 1.5 }}
 				gap={1}
 				maxWidth={tokens.maxWidth.modalDialog}
 				css={{
@@ -57,15 +56,11 @@ export const ModalDialog = ({
 					</Box>
 				) : null}
 				<Button
-					variant="tertiary"
+					variant="text"
 					aria-label="Close modal"
 					onClick={onDismiss}
 					iconAfter={CloseIcon}
-					css={{
-						position: 'absolute',
-						top: mapSpacing(0.5),
-						right: mapSpacing(0.5),
-					}}
+					css={{ order: -1, alignSelf: 'flex-end' }}
 				>
 					Close
 				</Button>

--- a/packages/react/src/modal/ModalTitle.tsx
+++ b/packages/react/src/modal/ModalTitle.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from 'react';
+import { PropsWithChildren } from 'react';
 import { Text } from '../text';
 
-export type ModalTitleProps = { children: ReactNode; id?: string };
+export type ModalTitleProps = PropsWithChildren<{ id: string }>;
 
 export const ModalTitle = ({ children, id }: ModalTitleProps) => {
 	return (

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Modal renders correctly 1`] = `
       <div
         aria-labelledby="modal-:r0:-title"
         aria-modal="true"
-        class="css-2sldpu-boxStyles-ModalDialog"
+        class="css-ekoxby-boxStyles-ModalDialog"
         role="dialog"
       >
         <h2
@@ -60,7 +60,7 @@ exports[`Modal renders correctly 1`] = `
         </div>
         <button
           aria-label="Close modal"
-          class="css-1tn8j9z-BaseButton-ModalDialog"
+          class="css-14ch2j2-BaseButton-ModalDialog"
           type="button"
         >
           <span>


### PR DESCRIPTION
## Describe your changes

Updated modal padding on mobile as it is inconsistent with Filter dialog and other components.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1205/storybook/iframe.html?id=content-modal--basic&viewMode=story)

| Before | After |
|--------|--------|
| <img width="373" alt="Screenshot 2023-06-20 at 10 55 07 am" src="https://github.com/steelthreads/agds-next/assets/6265154/13b186a4-433a-4520-aa9f-af40f1644422"> | <img width="373" alt="Screenshot 2023-06-20 at 10 54 54 am" src="https://github.com/steelthreads/agds-next/assets/6265154/a9286d04-0df5-454a-8dbb-86a577a9c9bf"> |

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
