### PR TITLE
filter-drawer: Update mobile "stickyness" behaviour

### DIFF
--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -129,6 +129,7 @@ export const DateRangePicker = ({
 	const [refEl, setRefEl] = useState<HTMLDivElement | null>(null);
 	const [popperEl, setPopperEl] = useState<HTMLDivElement | null>(null);
 	const { styles, attributes } = usePopper(refEl, popperEl, {
+		strategy: 'fixed',
 		placement: 'bottom-start',
 		modifiers: [{ name: 'offset', options: { offset: [0, 8] } }],
 	});

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -32,8 +32,8 @@ export function FilterDrawerDialog({
 				flexDirection="column"
 				role="dialog"
 				aria-modal="true"
-				aria-labelledby={titleId}
 				background="body"
+				aria-labelledby={titleId}
 				maxWidth="32rem"
 				css={{
 					position: 'fixed',
@@ -59,12 +59,12 @@ export function FilterDrawerDialog({
 					iconAfter={CloseIcon}
 					css={mq({
 						position: 'fixed',
+						zIndex: tokens.zIndex.elevated,
 						top: '1.25rem', // align with title
 						right: mapResponsiveProp({
 							xs: mapSpacing(0.75),
 							md: mapSpacing(1.5),
 						}),
-						zIndex: tokens.zIndex.elevated,
 					})}
 				>
 					Close
@@ -157,11 +157,7 @@ function FilterDrawerFooter({ children }: FilterDrawerFooterProps) {
 			borderTop
 			paddingX={{ xs: 0.75, md: 1.5 }}
 			paddingY={1}
-			css={{
-				position: 'relative',
-				marginTop: 'auto',
-				zIndex: tokens.zIndex.elevated,
-			}}
+			css={{ marginTop: 'auto' }}
 		>
 			{children}
 		</Box>

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -32,14 +32,17 @@ export function FilterDrawerDialog({
 				flexDirection="column"
 				role="dialog"
 				aria-modal="true"
-				background="body"
 				aria-labelledby={titleId}
+				background="body"
 				maxWidth="32rem"
 				css={{
 					position: 'fixed',
 					inset: 0,
 					marginLeft: 'auto',
 					zIndex: tokens.zIndex.dialog,
+					[tokens.mediaQuery.max.xs]: {
+						overflowY: 'scroll',
+					},
 				}}
 				style={style}
 			>
@@ -55,12 +58,13 @@ export function FilterDrawerDialog({
 					onClick={onDismiss}
 					iconAfter={CloseIcon}
 					css={mq({
-						position: 'absolute',
+						position: 'fixed',
 						top: '1.25rem', // align with title
 						right: mapResponsiveProp({
 							xs: mapSpacing(0.75),
 							md: mapSpacing(1.5),
 						}),
+						zIndex: tokens.zIndex.elevated,
 					})}
 				>
 					Close
@@ -76,7 +80,20 @@ type FilterDrawerHeaderProps = PropsWithChildren<{}>;
 
 function FilterDrawerHeader({ children }: FilterDrawerHeaderProps) {
 	return (
-		<Box borderBottom paddingX={{ xs: 0.75, md: 1.5 }} paddingY={1}>
+		<Box
+			background="body"
+			borderBottom
+			paddingX={{ xs: 0.75, md: 1.5 }}
+			paddingY={1}
+			css={{
+				position: 'sticky',
+				top: 0,
+				zIndex: tokens.zIndex.elevated,
+				[tokens.mediaQuery.min.sm]: {
+					position: 'relative',
+				},
+			}}
+		>
 			{children}
 		</Box>
 	);
@@ -98,7 +115,9 @@ function FilterDrawerHeaderTitle({
 			data-autofocus
 			focus
 			tabIndex={-1}
-			css={{ display: 'inline-block' }}
+			css={{
+				display: 'inline-block',
+			}}
 		>
 			{children}
 		</Text>
@@ -112,9 +131,15 @@ type FilterDrawerContentProps = PropsWithChildren<{}>;
 function FilterDrawerContent({ children }: FilterDrawerContentProps) {
 	return (
 		<Box
+			background="body"
+			flexGrow={1}
 			paddingX={{ xs: 0.75, md: 1.5 }}
 			paddingY={{ xs: 1, md: 1.5 }}
-			css={{ overflowY: 'auto' }}
+			css={{
+				[tokens.mediaQuery.min.sm]: {
+					overflowY: 'auto',
+				},
+			}}
 		>
 			{children}
 		</Box>
@@ -128,10 +153,15 @@ type FilterDrawerFooterProps = PropsWithChildren<{}>;
 function FilterDrawerFooter({ children }: FilterDrawerFooterProps) {
 	return (
 		<Box
+			background="body"
 			borderTop
 			paddingX={{ xs: 0.75, md: 1.5 }}
 			paddingY={1}
-			css={{ marginTop: 'auto' }}
+			css={{
+				position: 'relative',
+				marginTop: 'auto',
+				zIndex: tokens.zIndex.elevated,
+			}}
 		>
 			{children}
 		</Box>

--- a/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
+++ b/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </p>
         </div>
         <div
-          class="css-12edmau-boxStyles-FilterDrawerFooter"
+          class="css-1lcrni6-boxStyles-FilterDrawerFooter"
         >
           <button
             class="css-3jmmp1-BaseButton-Button"
@@ -66,7 +66,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </button>
         </div>
         <button
-          class="css-ajuhn4-BaseButton-FilterDrawerDialog"
+          class="css-1vsr4nb-BaseButton-FilterDrawerDialog"
           type="button"
         >
           <span>

--- a/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
+++ b/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
@@ -21,12 +21,12 @@ exports[`FilterDrawer renders correctly 1`] = `
       <div
         aria-labelledby="filter-drawer-:r0:-title"
         aria-modal="true"
-        class="css-ul6pn6-boxStyles-FilterDrawerDialog"
+        class="css-14wnhfz-boxStyles-FilterDrawerDialog"
         role="dialog"
         style="transform: translateX(100%);"
       >
         <div
-          class="css-uyeuq7-boxStyles"
+          class="css-rlusyu-boxStyles-FilterDrawerHeader"
         >
           <h2
             class="css-4kc494-boxStyles-Text-FilterDrawerHeaderTitle"
@@ -38,7 +38,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </h2>
         </div>
         <div
-          class="css-1e81yjk-boxStyles-FilterDrawerContent"
+          class="css-su8s1i-boxStyles-FilterDrawerContent"
         >
           <p
             class="css-6j1v6l-boxStyles-Text"
@@ -47,7 +47,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </p>
         </div>
         <div
-          class="css-nji5cg-boxStyles-FilterDrawerFooter"
+          class="css-12edmau-boxStyles-FilterDrawerFooter"
         >
           <button
             class="css-3jmmp1-BaseButton-Button"
@@ -66,7 +66,7 @@ exports[`FilterDrawer renders correctly 1`] = `
           </button>
         </div>
         <button
-          class="css-wlcd0o-BaseButton-FilterDrawerDialog"
+          class="css-ajuhn4-BaseButton-FilterDrawerDialog"
           type="button"
         >
           <span>


### PR DESCRIPTION
## Describe your changes

Follow up to PR #1203.

This updates the "stickyness" of the Filter drawer component on mobile devices only. With this update, the Filter drawer footer component will no longer be stuck to the bottom of the scree which provides much more space for the main content area.

### Example video

https://github.com/steelthreads/agds-next/assets/6265154/602e320a-e9d6-4e06-a38c-ce95cd4c100d


 