### PR TITLE
core: Add tokens for `z-index`

### DIFF
--- a/.changeset/shiny-hotels-wink.md
+++ b/.changeset/shiny-hotels-wink.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+core: Created a set of tokens for `z-index`

--- a/docs/content/tokens/index.ts
+++ b/docs/content/tokens/index.ts
@@ -40,6 +40,12 @@ export const TOKEN_PAGES = {
 		description:
 			'A set of predefined text styles to ensure text is consistent and legible.',
 	},
+	elevation: {
+		slug: 'elevation',
+		label: 'Elevation',
+		pageTitle: 'Elevation tokens',
+		description: 'A set of predefined tokens to handle elevation.',
+	},
 } as const;
 
 export const TOKEN_NAV_LINKS = Object.values(TOKEN_PAGES).map((item) => ({

--- a/docs/content/tokens/index.ts
+++ b/docs/content/tokens/index.ts
@@ -44,7 +44,8 @@ export const TOKEN_PAGES = {
 		slug: 'elevation',
 		label: 'Elevation',
 		pageTitle: 'Elevation tokens',
-		description: 'A set of predefined tokens to handle elevation.',
+		description:
+			'A set of predefined tokens for handling the relative distance between two surfaces along the z-axis.',
 	},
 } as const;
 

--- a/docs/pages/foundations/tokens/elevation.tsx
+++ b/docs/pages/foundations/tokens/elevation.tsx
@@ -1,5 +1,6 @@
+import { Fragment, ReactNode } from 'react';
 import { tokens } from '@ag.ds-next/react/core';
-import { Prose, proseBlockClassname } from '@ag.ds-next/react/prose';
+import { TextLink } from '@ag.ds-next/react/text-link';
 import {
 	TableWrapper,
 	Table,
@@ -15,32 +16,56 @@ import { getTokensBreadcrumbs, TOKEN_PAGES } from '../../../content/tokens';
 
 const tokenDescriptions: Record<
 	keyof typeof tokens.zIndex,
-	{ value: number; description: string }
+	{ value: number; description: ReactNode }
 > = {
 	base: {
 		value: tokens.zIndex.base,
-		description: 'Used for base elements.',
+		description: 'The base z-index.',
 	},
 	elevated: {
 		value: tokens.zIndex.elevated,
 		description:
-			'Used for components that need to be elevated above adjacent siblings.',
+			'Used to elevate elements above adjacent elements that sit on the base z-index.',
 	},
 	overlay: {
 		value: tokens.zIndex.overlay,
-		description: 'Used for modal overlays.',
+		description: (
+			<Fragment>
+				Used for overlays in modals and other components that sit on top of the
+				page - e.g. <TextLink href="/components/modal">Modal</TextLink>,{' '}
+				<TextLink href="/components/filter-drawer">Filter drawer</TextLink>,{' '}
+				<TextLink href="/components/main-nav">Main nav (mobile)</TextLink>.
+			</Fragment>
+		),
 	},
-	modal: {
-		value: tokens.zIndex.modal,
-		description: 'Used for modal dialogs.',
+	dialog: {
+		value: tokens.zIndex.dialog,
+		description: (
+			<Fragment>
+				Used for the main dialog element in modals and other components that sit
+				on top of the - e.g. <TextLink href="/components/modal">Modal</TextLink>
+				, <TextLink href="/components/filter-drawer">Filter drawer</TextLink>,{' '}
+				<TextLink href="/components/main-nav">Main nav (mobile)</TextLink>.
+			</Fragment>
+		),
 	},
 	popover: {
 		value: tokens.zIndex.popover,
-		description: 'Used for popover elements - eg. date picker calendar.',
+		description: (
+			<Fragment>
+				Used for popover elements - e.g. the calendar popover in the{' '}
+				<TextLink href="/components/date-picker">Date picker</TextLink>.
+			</Fragment>
+		),
 	},
 	skipLink: {
 		value: tokens.zIndex.skipLink,
-		description: 'Used for skip links.',
+		description: (
+			<Fragment>
+				Used for focused{' '}
+				<TextLink href="/components/skip-link">Skip links</TextLink>.
+			</Fragment>
+		),
 	},
 };
 
@@ -57,41 +82,37 @@ export default function TokensElevationPage() {
 				breadcrumbs={getTokensBreadcrumbs(TOKEN_PAGES.elevation)}
 				editPath="/docs/pages/foundations/tokens/max-width.tsx"
 			>
-				<Prose>
-					<div className={proseBlockClassname}>
-						<TableWrapper>
-							<Table>
-								<TableCaption>Z-Index tokens</TableCaption>
-								<TableHead>
-									<tr>
-										<TableHeader scope="col" width="25%">
-											Token
-										</TableHeader>
-										<TableHeader scope="col" width="25%">
-											Value
-										</TableHeader>
-										<TableHeader scope="col" width="50%">
-											Description
-										</TableHeader>
-									</tr>
-								</TableHead>
-								<TableBody>
-									{Object.entries(tokenDescriptions).map(
-										([token, { value, description }]) => {
-											return (
-												<tr key={token}>
-													<TableCell>{token}</TableCell>
-													<TableCell>{value}</TableCell>
-													<TableCell>{description}</TableCell>
-												</tr>
-											);
-										}
-									)}
-								</TableBody>
-							</Table>
-						</TableWrapper>
-					</div>
-				</Prose>
+				<TableWrapper>
+					<Table>
+						<TableCaption>Z-Index tokens</TableCaption>
+						<TableHead>
+							<tr>
+								<TableHeader scope="col" width="25%">
+									Token
+								</TableHeader>
+								<TableHeader scope="col" width="25%">
+									Value
+								</TableHeader>
+								<TableHeader scope="col" width="50%">
+									Description
+								</TableHeader>
+							</tr>
+						</TableHead>
+						<TableBody>
+							{Object.entries(tokenDescriptions).map(
+								([token, { value, description }]) => {
+									return (
+										<tr key={token}>
+											<TableCell>{token}</TableCell>
+											<TableCell>{value}</TableCell>
+											<TableCell>{description}</TableCell>
+										</tr>
+									);
+								}
+							)}
+						</TableBody>
+					</Table>
+				</TableWrapper>
 			</TokenLayout>
 		</>
 	);

--- a/docs/pages/foundations/tokens/elevation.tsx
+++ b/docs/pages/foundations/tokens/elevation.tsx
@@ -19,27 +19,28 @@ const tokenDescriptions: Record<
 > = {
 	base: {
 		value: tokens.zIndex.base,
-		description: 'Lorem ipsum',
+		description: 'Used for base elements.',
 	},
 	elevated: {
 		value: tokens.zIndex.elevated,
-		description: 'Lorem ipsum',
+		description:
+			'Used for components that need to be elevated above adjacent siblings.',
 	},
 	overlay: {
 		value: tokens.zIndex.overlay,
-		description: 'Lorem ipsum',
+		description: 'Used for modal overlays.',
 	},
 	modal: {
 		value: tokens.zIndex.modal,
-		description: 'Lorem ipsum',
+		description: 'Used for modal dialogs.',
 	},
 	popover: {
 		value: tokens.zIndex.popover,
-		description: 'Lorem ipsum',
+		description: 'Used for popover elements - eg. date picker calendar.',
 	},
 	skipLink: {
 		value: tokens.zIndex.skipLink,
-		description: 'Lorem ipsum',
+		description: 'Used for skip links.',
 	},
 };
 

--- a/docs/pages/foundations/tokens/elevation.tsx
+++ b/docs/pages/foundations/tokens/elevation.tsx
@@ -1,0 +1,97 @@
+import { tokens } from '@ag.ds-next/react/core';
+import { Prose, proseBlockClassname } from '@ag.ds-next/react/prose';
+import {
+	TableWrapper,
+	Table,
+	TableCaption,
+	TableHead,
+	TableHeader,
+	TableBody,
+	TableCell,
+} from '@ag.ds-next/react/table';
+import { DocumentTitle } from '../../../components/DocumentTitle';
+import { TokenLayout } from '../../../components/TokenLayout';
+import { getTokensBreadcrumbs, TOKEN_PAGES } from '../../../content/tokens';
+
+const tokenDescriptions: Record<
+	keyof typeof tokens.zIndex,
+	{ value: number; description: string }
+> = {
+	base: {
+		value: tokens.zIndex.base,
+		description: 'Lorem ipsum',
+	},
+	elevated: {
+		value: tokens.zIndex.elevated,
+		description: 'Lorem ipsum',
+	},
+	overlay: {
+		value: tokens.zIndex.overlay,
+		description: 'Lorem ipsum',
+	},
+	modal: {
+		value: tokens.zIndex.modal,
+		description: 'Lorem ipsum',
+	},
+	popover: {
+		value: tokens.zIndex.popover,
+		description: 'Lorem ipsum',
+	},
+	skipLink: {
+		value: tokens.zIndex.skipLink,
+		description: 'Lorem ipsum',
+	},
+};
+
+export default function TokensElevationPage() {
+	return (
+		<>
+			<DocumentTitle
+				title={TOKEN_PAGES.elevation.pageTitle}
+				description={TOKEN_PAGES.elevation.description}
+			/>
+			<TokenLayout
+				title={TOKEN_PAGES.elevation.pageTitle}
+				description={TOKEN_PAGES.elevation.description}
+				breadcrumbs={getTokensBreadcrumbs(TOKEN_PAGES.elevation)}
+				editPath="/docs/pages/foundations/tokens/max-width.tsx"
+			>
+				<Prose>
+					<div className={proseBlockClassname}>
+						<TableWrapper>
+							<Table>
+								<TableCaption>Z-Index tokens</TableCaption>
+								<TableHead>
+									<tr>
+										<TableHeader scope="col" width="25%">
+											Token
+										</TableHeader>
+										<TableHeader scope="col" width="25%">
+											Value
+										</TableHeader>
+										<TableHeader scope="col" width="50%">
+											Description
+										</TableHeader>
+									</tr>
+								</TableHead>
+								<TableBody>
+									{Object.entries(tokenDescriptions).map(
+										([token, { value, description }]) => {
+											return (
+												<tr key={token}>
+													<TableCell>{token}</TableCell>
+													<TableCell>{value}</TableCell>
+													<TableCell>{description}</TableCell>
+												</tr>
+											);
+										}
+									)}
+								</TableBody>
+							</Table>
+						</TableWrapper>
+					</div>
+				</Prose>
+			</TokenLayout>
+		</>
+	);
+}

--- a/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
@@ -75,7 +75,7 @@ export function AppLayoutSidebarDialog({
 								width={tokens.maxWidth.mobileMenu}
 								css={{
 									position: 'fixed',
-									zIndex: tokens.zIndex.modal,
+									zIndex: tokens.zIndex.dialog,
 									top: 0,
 									left: 0,
 									bottom: 0,

--- a/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
@@ -75,7 +75,7 @@ export function AppLayoutSidebarDialog({
 								width={tokens.maxWidth.mobileMenu}
 								css={{
 									position: 'fixed',
-									zIndex: 100,
+									zIndex: tokens.zIndex.modal,
 									top: 0,
 									left: 0,
 									bottom: 0,
@@ -132,7 +132,7 @@ function Overlay({
 					bottom: 0,
 					right: 0,
 					backgroundColor: boxPalette.overlay,
-					zIndex: 99,
+					zIndex: tokens.zIndex.overlay,
 				},
 			}}
 			onClick={onClick}

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`Autocomplete renders correctly 1`] = `
         class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 200;"
       />
     </div>
   </div>

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -48,10 +48,10 @@ exports[`Autocomplete renders correctly 1`] = `
       />
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-5wdaps-boxStyles-ComboboxList"
+        class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -84,7 +84,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	const { ref: menuRef, ...menuProps } = combobox.getMenuProps({
 		...attributes.popper,
 		style: {
-			...popperStyles,
+			...popperStyles.popper,
 			zIndex: tokens.zIndex.popover,
 		},
 	});

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -1,7 +1,7 @@
 import { Fragment, ReactNode, useState } from 'react';
 import { UseComboboxReturnValue } from 'downshift';
 import { usePopper } from 'react-popper';
-import { FieldMaxWidth, mergeRefs } from '../../core';
+import { FieldMaxWidth, mergeRefs, tokens } from '../../core';
 import { textInputStyles } from '../../text-input';
 import { Field } from '../../field';
 import { DefaultComboboxOption } from '../utils';
@@ -67,7 +67,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	// Popper state
 	const [refEl, setRefEl] = useState<HTMLDivElement | null>(null);
 	const [popperEl, setPopperEl] = useState<HTMLDivElement | null>(null);
-	const { styles, attributes } = usePopper(refEl, popperEl, {
+	const { styles: popperStyles, attributes } = usePopper(refEl, popperEl, {
 		placement: 'bottom-start',
 		modifiers: [{ name: 'offset', options: { offset: [0, 8] } }],
 	});
@@ -83,7 +83,10 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 
 	const { ref: menuRef, ...menuProps } = combobox.getMenuProps({
 		...attributes.popper,
-		style: styles.popper,
+		style: {
+			...popperStyles,
+			zIndex: tokens.zIndex.popover,
+		},
 	});
 
 	return (

--- a/packages/react/src/combobox/ComboboxBase/ComboboxList.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxList.tsx
@@ -24,7 +24,6 @@ export const ComboboxList = forwardRef<HTMLUListElement, ComboboxListProps>(
 					maxHeight: 295,
 					maxWidth: block ? tokens.maxWidth.field[maxWidth] : undefined,
 					width: '100%',
-					zIndex: 1,
 					...(!isOpen && {
 						opacity: 0,
 						visibility: 'hidden',

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -126,7 +126,13 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 
 	const { ref: menuRef, ...menuProps } = combobox.getMenuProps({
 		...attributes.popper,
-		style: popperStyles.popper,
+		style: {
+			...attributes.popper,
+			style: {
+				...styles.popper,
+				zIndex: tokens.zIndex.popover,
+			},
+		},
 	});
 
 	// Focus the input element if the user clicks inside the container

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -127,11 +127,8 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 	const { ref: menuRef, ...menuProps } = combobox.getMenuProps({
 		...attributes.popper,
 		style: {
-			...attributes.popper,
-			style: {
-				...styles.popper,
-				zIndex: tokens.zIndex.popover,
-			},
+			...popperStyles.popper,
+			zIndex: tokens.zIndex.popover,
 		},
 	});
 

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`Combobox renders correctly 1`] = `
         class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 200;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -77,10 +77,10 @@ exports[`Combobox renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-5wdaps-boxStyles-ComboboxList"
+        class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -77,10 +77,10 @@ exports[`ComboboxAsync renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-5wdaps-boxStyles-ComboboxList"
+        class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -80,7 +80,7 @@ exports[`ComboboxAsync renders correctly 1`] = `
         class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 200;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
         class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 200;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -85,10 +85,10 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-5wdaps-boxStyles-ComboboxList"
+        class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -85,10 +85,10 @@ exports[`ComboboxMulti renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-5wdaps-boxStyles-ComboboxList"
+        class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
       />
     </div>
   </div>

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`ComboboxMulti renders correctly 1`] = `
         class="css-1xv1xw2-boxStyles-ComboboxList"
         id="downshift-0-menu"
         role="listbox"
-        style="position: absolute; left: 0px; top: 0px; z-index: 120;"
+        style="position: absolute; left: 0px; top: 0px; z-index: 200;"
       />
     </div>
   </div>

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -123,9 +123,9 @@ const zIndex = {
 	base: 0,
 	elevated: 1,
 	overlay: 100,
-	modal: 110,
-	popover: 120,
-	skipLink: 200,
+	dialog: 110,
+	popover: 200,
+	skipLink: 999,
 };
 
 export type zIndex = keyof typeof zIndex;

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -119,6 +119,17 @@ const transition = {
 	timingFunction: 'ease', // https://developer.mozilla.org/en-US/docs/Web/CSS/transition-timing-function
 };
 
+const zIndex = {
+	base: 0,
+	elevated: 1,
+	overlay: 100,
+	modal: 110,
+	popover: 120,
+	skipLink: 200,
+};
+
+export type zIndex = keyof typeof zIndex;
+
 export const tokens = {
 	breakpoint,
 	mediaQuery,
@@ -133,4 +144,5 @@ export const tokens = {
 	borderRadius,
 	borderWidth,
 	transition,
+	zIndex,
 };

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -128,7 +128,7 @@ const zIndex = {
 	skipLink: 999,
 };
 
-export type zIndex = keyof typeof zIndex;
+export type ZIndex = keyof typeof zIndex;
 
 export const tokens = {
 	breakpoint,

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -10,7 +10,12 @@ import {
 } from 'react';
 import { usePopper } from 'react-popper';
 import { SelectSingleEventHandler } from 'react-day-picker';
-import { FieldMaxWidth, useClickOutside, useTernaryState } from '../core';
+import {
+	FieldMaxWidth,
+	tokens,
+	useClickOutside,
+	useTernaryState,
+} from '../core';
 import { CalendarSingle } from './Calendar';
 import { DateInput } from './DatePickerInput';
 import {
@@ -193,9 +198,8 @@ export const DatePicker = ({
 			{isCalendarOpen ? (
 				<div
 					ref={setPopperEl}
-					style={styles.popper}
+					style={{ ...styles.popper, zIndex: tokens.zIndex.popover }}
 					{...attributes.popper}
-					css={{ zIndex: 1 }}
 				>
 					<CalendarSingle
 						initialFocus

--- a/packages/react/src/date-picker/reactDayPickerStyles.ts
+++ b/packages/react/src/date-picker/reactDayPickerStyles.ts
@@ -28,7 +28,7 @@ export const reactDayPickerStyles = (range: boolean) =>
 			marginBottom: mapSpacing(0.5),
 		},
 		'.rdp-caption_label': {
-			zIndex: 1,
+			zIndex: tokens.zIndex.elevated,
 			whiteSpace: 'nowrap',
 			margin: 0,
 			color: boxPalette.foregroundText,

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -337,9 +337,8 @@ export const DateRangePicker = ({
 				{isCalendarOpen ? (
 					<div
 						ref={setPopperEl}
-						style={styles.popper}
+						style={{ ...styles.popper, zIndex: tokens.zIndex.popover }}
 						{...attributes.popper}
-						css={{ zIndex: 1 }}
 					>
 						<CalendarRange
 							initialFocus

--- a/packages/react/src/filter-drawer/FilterDrawer.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawer.tsx
@@ -11,6 +11,7 @@ import { createPortal } from 'react-dom';
 import { useTransition, animated, SpringValue } from '@react-spring/web';
 import {
 	boxPalette,
+	tokens,
 	useAriaModalPolyfill,
 	usePrefersReducedMotion,
 } from '../core';
@@ -97,7 +98,7 @@ function Overlay({
 				position: 'fixed',
 				inset: 0,
 				backgroundColor: boxPalette.overlay,
-				zIndex: 100,
+				zIndex: tokens.zIndex.overlay,
 			}}
 			style={style}
 		/>

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -3,7 +3,7 @@ import FocusLock from 'react-focus-lock';
 import { animated, SpringValue } from '@react-spring/web';
 import { Box } from '../box';
 import { Flex } from '../flex';
-import { mapResponsiveProp, mapSpacing, mq } from '../core';
+import { mapResponsiveProp, mapSpacing, mq, tokens } from '../core';
 import { CloseIcon } from '../icon';
 import { Button } from '../button';
 import { Text } from '../text';

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -39,7 +39,7 @@ export function FilterDrawerDialog({
 					position: 'fixed',
 					inset: 0,
 					marginLeft: 'auto',
-					zIndex: tokens.zIndex.modal,
+					zIndex: tokens.zIndex.dialog,
 				}}
 				style={style}
 			>

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -39,7 +39,7 @@ export function FilterDrawerDialog({
 					position: 'fixed',
 					inset: 0,
 					marginLeft: 'auto',
-					zIndex: 100,
+					zIndex: tokens.zIndex.modal,
 				}}
 				style={style}
 			>

--- a/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
+++ b/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FilterDrawer renders correctly 1`] = `
       <div
         aria-labelledby="filter-drawer-:r0:-title"
         aria-modal="true"
-        class="css-1xt2kod-boxStyles-FilterDrawerDialog"
+        class="css-ul6pn6-boxStyles-FilterDrawerDialog"
         role="dialog"
         style="transform: translateX(100%);"
       >

--- a/packages/react/src/hero-banner/HeroBanner/HeroBannerContent.tsx
+++ b/packages/react/src/hero-banner/HeroBanner/HeroBannerContent.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren, ReactNode } from 'react';
+import { tokens } from '../../core';
 import { Flex } from '../../flex';
 import { Stack } from '../../stack';
 import { Content } from '../../content';
@@ -23,7 +24,7 @@ export const HeroBannerContent = ({
 					width={['100%', '100%', image ? '60%' : '100%']}
 					paddingTop={{ xs: 2, md: 4 }}
 					paddingBottom={{ xs: 3, md: 4 }}
-					css={{ zIndex: 1 }}
+					css={{ zIndex: tokens.zIndex.elevated }}
 				>
 					{children}
 				</Stack>

--- a/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`HeroBanner renders correctly 1`] = `
           class="css-1jhrbpg-boxStyles"
         >
           <div
-            class="css-1u6uxdt-boxStyles-HeroBannerContent"
+            class="css-1uuwobt-boxStyles-HeroBannerContent"
           >
             <div
               class="css-1mxr31d-boxStyles"

--- a/packages/react/src/hero-banner/HeroCategoryBanner/HeroCategoryBannerContent.tsx
+++ b/packages/react/src/hero-banner/HeroCategoryBanner/HeroCategoryBannerContent.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren, ReactNode } from 'react';
+import { tokens } from '../../core';
 import { Flex } from '../../flex';
 import { Stack } from '../../stack';
 import { Content } from '../../content';
@@ -23,7 +24,7 @@ export const HeroCategoryBannerContent = ({
 					width={['100%', '100%', image ? '60%' : '100%']}
 					paddingTop={{ xs: 2, md: 4 }}
 					paddingBottom={{ xs: 3, md: 4 }}
-					css={{ zIndex: 1 }}
+					css={{ zIndex: tokens.zIndex.elevated }}
 				>
 					{children}
 				</Stack>

--- a/packages/react/src/hero-banner/HeroCategoryBanner/__snapshots__/HeroCategoryBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroCategoryBanner/__snapshots__/HeroCategoryBanner.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`HeroCategoryBanner renders correctly 1`] = `
           class="css-1jhrbpg-boxStyles"
         >
           <div
-            class="css-10v19du-boxStyles-HeroCategoryBannerContent"
+            class="css-shh8uh-boxStyles-HeroCategoryBannerContent"
           >
             <h1
               class="css-18pa81a-boxStyles"

--- a/packages/react/src/loading/LoadingBlanketContainer.tsx
+++ b/packages/react/src/loading/LoadingBlanketContainer.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from 'react';
+import { tokens } from '../core';
 import { Flex } from '../flex';
 
 export type LoadingBlanketContainerProps = PropsWithChildren<{
@@ -20,7 +21,7 @@ export const LoadingBlanketContainer = ({
 		css={{
 			position: fullScreen ? 'fixed' : 'absolute',
 			inset: 0,
-			zIndex: 100,
+			zIndex: tokens.zIndex.overlay,
 			backgroundColor: `rgba(255, 255, 255, 0.9)`,
 		}}
 	>

--- a/packages/react/src/main-nav/NavContainer.tsx
+++ b/packages/react/src/main-nav/NavContainer.tsx
@@ -139,7 +139,7 @@ function NavContainerDialog({
 			id="main-nav-dialog"
 			css={{
 				[tokens.mediaQuery.max.md]: {
-					zIndex: 200,
+					zIndex: tokens.zIndex.modal,
 					position: 'fixed',
 					display: menuVisiblyOpen ? 'block' : 'none',
 					background: boxPalette.backgroundBody,
@@ -182,7 +182,7 @@ function Overlay({ onClick }: { onClick: MouseEventHandler<HTMLDivElement> }) {
 				bottom: 0,
 				right: 0,
 				backgroundColor: boxPalette.overlay,
-				zIndex: 100,
+				zIndex: tokens.zIndex.overlay,
 			}}
 			onClick={onClick}
 		/>

--- a/packages/react/src/main-nav/NavContainer.tsx
+++ b/packages/react/src/main-nav/NavContainer.tsx
@@ -139,7 +139,7 @@ function NavContainerDialog({
 			id="main-nav-dialog"
 			css={{
 				[tokens.mediaQuery.max.md]: {
-					zIndex: tokens.zIndex.modal,
+					zIndex: tokens.zIndex.dialog,
 					position: 'fixed',
 					display: menuVisiblyOpen ? 'block' : 'none',
 					background: boxPalette.backgroundBody,

--- a/packages/react/src/main-nav/NavListItem.tsx
+++ b/packages/react/src/main-nav/NavListItem.tsx
@@ -1,5 +1,12 @@
 import type { PropsWithChildren } from 'react';
-import { boxPalette, mapSpacing, mq, mapResponsiveProp, packs } from '../core';
+import {
+	boxPalette,
+	mapSpacing,
+	mq,
+	mapResponsiveProp,
+	packs,
+	tokens,
+} from '../core';
 import { Flex } from '../flex';
 import { localPalette } from './utils';
 
@@ -76,15 +83,11 @@ export function NavListItem({
 						// Focus styles
 						'&:focus': {
 							outline: 'none',
-
 							'&:before': {
 								content: '""',
 								position: 'absolute',
-								zIndex: 100,
-								top: 0,
-								left: 0,
-								height: '100%',
-								width: '100%',
+								inset: 0,
+								zIndex: tokens.zIndex.elevated,
 								...packs.outline,
 							},
 							'&::-moz-focus-inner': {

--- a/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`MainNav renders correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-heefmy-light-boxStyles-element"
+          class="css-1cxgfke-light-boxStyles-element"
           id="main-nav-dialog"
         >
           <div
@@ -100,7 +100,7 @@ exports[`MainNav renders correctly 1`] = `
                 class="css-5nrt7j-boxStyles-NavListContainer"
               >
                 <li
-                  class="css-1pszxfd-boxStyles-NavListItem"
+                  class="css-1iz4dhy-boxStyles-NavListItem"
                 >
                   <a
                     href="#home"
@@ -111,7 +111,7 @@ exports[`MainNav renders correctly 1`] = `
                   </a>
                 </li>
                 <li
-                  class="css-32saf7-boxStyles-NavListItem"
+                  class="css-tk5pii-boxStyles-NavListItem"
                 >
                   <a
                     aria-current="page"
@@ -123,7 +123,7 @@ exports[`MainNav renders correctly 1`] = `
                   </a>
                 </li>
                 <li
-                  class="css-1pszxfd-boxStyles-NavListItem"
+                  class="css-1iz4dhy-boxStyles-NavListItem"
                 >
                   <a
                     href="#form"
@@ -134,7 +134,7 @@ exports[`MainNav renders correctly 1`] = `
                   </a>
                 </li>
                 <li
-                  class="css-1pszxfd-boxStyles-NavListItem"
+                  class="css-1iz4dhy-boxStyles-NavListItem"
                 >
                   <a
                     href="#simple"
@@ -161,7 +161,7 @@ exports[`MainNav renders correctly 1`] = `
             class="css-1ltfh56-boxStyles"
           >
             <li
-              class="css-6lwpn8-boxStyles-NavListItem"
+              class="css-1ieyr45-boxStyles-NavListItem"
             >
               <a
                 href="#sign-in"

--- a/packages/react/src/modal/ModalCover.tsx
+++ b/packages/react/src/modal/ModalCover.tsx
@@ -16,7 +16,7 @@ export const ModalCover = forwardRef<HTMLDivElement, ModalCoverProps>(
 					bottom: 0,
 					right: 0,
 					backgroundColor: boxPalette.overlay,
-					zIndex: 100,
+					zIndex: tokens.zIndex.overlay,
 					overflowY: 'auto',
 					animation: `${animateFadeInOut} ${tokens.transition.duration}ms ${tokens.transition.timingFunction}`,
 				}}

--- a/packages/react/src/search-box/SearchBoxInput.tsx
+++ b/packages/react/src/search-box/SearchBoxInput.tsx
@@ -65,10 +65,5 @@ const inputStyles = () => {
 			{
 				display: 'none',
 			},
-
-		'&:focus': {
-			...baseStyles['&:focus'],
-			zIndex: 2,
-		},
 	};
 };

--- a/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
+++ b/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`SearchBox renders correctly 1`] = `
         </label>
         <input
           autocomplete="off"
-          class="css-183xz77-SearchBoxInput"
+          class="css-1d0mzew-SearchBoxInput"
           id="search-:r0:"
           type="search"
         />

--- a/packages/react/src/skip-link/SkipLinkItem.tsx
+++ b/packages/react/src/skip-link/SkipLinkItem.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, PropsWithChildren } from 'react';
 import { buttonStyles } from '../button';
 import { visuallyHiddenStyles } from '../a11y';
-import { mapSpacing } from '../core';
+import { mapSpacing, tokens } from '../core';
 
 export type SkipLinkItemProps = PropsWithChildren<{ href: string }>;
 
@@ -24,7 +24,7 @@ export const SkipLinkItem = forwardRef<HTMLAnchorElement, SkipLinkItemProps>(
 							overflow: 'visible',
 							whiteSpace: 'normal',
 							width: 'auto',
-							zIndex: 999,
+							zIndex: tokens.zIndex.skipLink,
 						},
 					},
 				]}

--- a/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
+++ b/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`SkipLinks renders correctly 1`] = `
     aria-label="skip links"
   >
     <a
-      class="css-r7btdr-SkipLinkItem"
+      class="css-11dw5me-SkipLinkItem"
       href="#main-content"
     >
       Skip to main content
     </a>
     <a
-      class="css-r7btdr-SkipLinkItem"
+      class="css-11dw5me-SkipLinkItem"
       href="#main-nav"
     >
       Skip to main navigation

--- a/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
+++ b/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`SkipLinks renders correctly 1`] = `
     aria-label="skip links"
   >
     <a
-      class="css-11dw5me-SkipLinkItem"
+      class="css-r7btdr-SkipLinkItem"
       href="#main-content"
     >
       Skip to main content
     </a>
     <a
-      class="css-11dw5me-SkipLinkItem"
+      class="css-r7btdr-SkipLinkItem"
       href="#main-nav"
     >
       Skip to main navigation

--- a/packages/react/src/sub-nav/SubNavList.tsx
+++ b/packages/react/src/sub-nav/SubNavList.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 import { Flex } from '../flex';
-import { useLinkComponent, LinkProps } from '../core';
+import { useLinkComponent, LinkProps, tokens } from '../core';
 import { SubNavListItem } from './SubNavListItem';
 
 export type SubNavListLink = Omit<LinkProps, 'children'> & {
@@ -20,7 +20,7 @@ export function SubNavList({ links, activePath }: SubNavListProps) {
 			as="ul"
 			flexDirection={['column', 'row']}
 			flexWrap="wrap"
-			css={{ position: 'relative' }}
+			css={{ position: 'relative', zIndex: tokens.zIndex.elevated }}
 		>
 			{links.map(({ href, label, endElement, ...props }, index) => {
 				const active = href === activePath;

--- a/packages/react/src/sub-nav/SubNavList.tsx
+++ b/packages/react/src/sub-nav/SubNavList.tsx
@@ -20,7 +20,7 @@ export function SubNavList({ links, activePath }: SubNavListProps) {
 			as="ul"
 			flexDirection={['column', 'row']}
 			flexWrap="wrap"
-			css={{ position: 'relative', zIndex: 1 }}
+			css={{ position: 'relative' }}
 		>
 			{links.map(({ href, label, endElement, ...props }, index) => {
 				const active = href === activePath;

--- a/packages/react/src/sub-nav/SubNavListItem.tsx
+++ b/packages/react/src/sub-nav/SubNavListItem.tsx
@@ -68,7 +68,6 @@ export function SubNavListItem({ children, active }: SubNavListItemProps) {
 							content: '""',
 							position: 'absolute',
 							inset: 0,
-							zIndex: tokens.zIndex.elevated,
 							...packs.outline,
 						},
 						'&::-moz-focus-inner': {

--- a/packages/react/src/sub-nav/SubNavListItem.tsx
+++ b/packages/react/src/sub-nav/SubNavListItem.tsx
@@ -67,11 +67,8 @@ export function SubNavListItem({ children, active }: SubNavListItemProps) {
 						'&:before': {
 							content: '""',
 							position: 'absolute',
-							zIndex: 100,
-							top: 0,
-							left: 0,
-							height: '100%',
-							width: '100%',
+							inset: 0,
+							zIndex: tokens.zIndex.elevated,
 							...packs.outline,
 						},
 						'&::-moz-focus-inner': {

--- a/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
+++ b/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`SubNav renders correctly 1`] = `
     class="css-29r04f-boxStyles-SubNavContainer"
   >
     <ul
-      class="css-1m8vze-boxStyles-SubNavList"
+      class="css-keymc7-boxStyles-SubNavList"
     >
       <li
-        class="css-1nm17kl-boxStyles-SubNavListItem"
+        class="css-10c2u5k-boxStyles-SubNavListItem"
       >
         <a
           href="#usage"
@@ -21,7 +21,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-e3viqj-boxStyles-SubNavListItem"
+        class="css-12j3wfj-boxStyles-SubNavListItem"
       >
         <a
           aria-current="page"
@@ -33,7 +33,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-1nm17kl-boxStyles-SubNavListItem"
+        class="css-10c2u5k-boxStyles-SubNavListItem"
       >
         <a
           href="#content"
@@ -44,7 +44,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-1nm17kl-boxStyles-SubNavListItem"
+        class="css-10c2u5k-boxStyles-SubNavListItem"
       >
         <a
           href="#accessibility"

--- a/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
+++ b/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`SubNav renders correctly 1`] = `
     class="css-29r04f-boxStyles-SubNavContainer"
   >
     <ul
-      class="css-keymc7-boxStyles-SubNavList"
+      class="css-1ipxjn1-boxStyles-SubNavList"
     >
       <li
         class="css-10c2u5k-boxStyles-SubNavListItem"

--- a/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
+++ b/packages/react/src/sub-nav/__snapshots__/SubNav.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SubNav renders correctly 1`] = `
       class="css-1ipxjn1-boxStyles-SubNavList"
     >
       <li
-        class="css-10c2u5k-boxStyles-SubNavListItem"
+        class="css-18z49hf-boxStyles-SubNavListItem"
       >
         <a
           href="#usage"
@@ -21,7 +21,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-12j3wfj-boxStyles-SubNavListItem"
+        class="css-tzzdp7-boxStyles-SubNavListItem"
       >
         <a
           aria-current="page"
@@ -33,7 +33,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-10c2u5k-boxStyles-SubNavListItem"
+        class="css-18z49hf-boxStyles-SubNavListItem"
       >
         <a
           href="#content"
@@ -44,7 +44,7 @@ exports[`SubNav renders correctly 1`] = `
         </a>
       </li>
       <li
-        class="css-10c2u5k-boxStyles-SubNavListItem"
+        class="css-18z49hf-boxStyles-SubNavListItem"
       >
         <a
           href="#accessibility"


### PR DESCRIPTION
## Describe your changes

This PR extends our tokens to include a set of z-indexes. The proposed values are:

```tsx
const zIndex = {
	base: 0,
	elevated: 1,
	overlay: 100,
	dialog: 110,
	popover: 200,
	skipLink: 999,
};
```

I have also created a new "Elevation tokens" page on our documentation page. [View preview here](https://design-system.agriculture.gov.au/pr-preview/pr-1210/foundations/tokens/elevation).

I have also gone through and removed any hard-coded values for z-index and replaced them with our new tokens.