### PR TITLE
docs: `enableProse` flag on `Code` previews

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -7,7 +7,6 @@ import React, {
 	KeyboardEvent,
 	useContext,
 } from 'react';
-import { useRouter } from 'next/router';
 import { LiveProvider, LiveEditor, LivePreview, LiveContext } from 'react-live';
 import { createUrl } from 'playroom/utils';
 import { Highlight } from 'prism-react-renderer';
@@ -46,9 +45,14 @@ const PlaceholderImage = () => (
 	/>
 );
 
-function LiveCode({ showCode = false }: { showCode?: boolean }) {
+function LiveCode({
+	showCode = false,
+	enableProse = false,
+}: {
+	showCode?: boolean;
+	enableProse?: boolean;
+}) {
 	const liveCodeToggleButton = useRef<HTMLButtonElement>(null);
-	const { query } = useRouter();
 	const live = useContext(LiveContext);
 
 	const liveOnChange = live.onChange;
@@ -98,9 +102,7 @@ function LiveCode({ showCode = false }: { showCode?: boolean }) {
 			<LivePreview
 				aria-label="Rendered code snippet example"
 				// Prevents prose styles from being inherited in live code examples (except for the prose example)
-				className={
-					query.slug === 'prose' ? undefined : unsetProseStylesClassname
-				}
+				className={enableProse ? undefined : unsetProseStylesClassname}
 				css={{
 					// The mdx codeblock transform wraps the code component in a pre which
 					// applies some weirdness here. This resets back to normal things
@@ -271,9 +273,16 @@ type CodeProps = {
 	className?: string;
 	live?: boolean;
 	showCode?: boolean;
+	enableProse?: boolean;
 };
 
-export function Code({ children, live, showCode, className }: CodeProps) {
+export function Code({
+	children,
+	live,
+	showCode,
+	enableProse,
+	className,
+}: CodeProps) {
 	const childrenAsString = children?.toString().trim();
 	const language = className?.replace(/language-/, '');
 
@@ -286,7 +295,7 @@ export function Code({ children, live, showCode, className }: CodeProps) {
 				scope={LIVE_SCOPE}
 				language={language}
 			>
-				<LiveCode showCode={showCode} />
+				<LiveCode showCode={showCode} enableProse={enableProse} />
 			</LiveProvider>
 		);
 	}

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -38,9 +38,11 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		children,
 		live,
 		showCode,
+		enableProse,
 	}: HTMLAttributes<HTMLPreElement> & {
 		live?: boolean;
 		showCode?: boolean;
+		enableProse?: boolean;
 	}) => {
 		return (
 			<Fragment>
@@ -51,6 +53,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 							key={element.key}
 							live={live}
 							showCode={showCode}
+							enableProse={enableProse}
 							{...element.props}
 						/>
 					);

--- a/docs/content/templates/single-page-form/index.mdx
+++ b/docs/content/templates/single-page-form/index.mdx
@@ -44,7 +44,7 @@ Instead, allow users to interact with buttons and receive feedback.
 
 A form should validate when a user attempts to submit. Validation errors should be summarised as a list inside of a [Page alert](/components/page-alert) with the 'error' tone. The page alert should be placed at the top of the form, and focused immediately after a submission attempt. When clicked, each error in the list should scroll and focus the user focus respective form field.
 
-```tsx live
+```tsx live enableProse
 <PageAlert tone="error" title="There is a problem">
 	<Prose>
 		<p>Please correct the following fields and try again</p>
@@ -87,7 +87,7 @@ An invalid field is highlighted with a red border and a red error message. They 
 
 When a form is successfully completed, return the user to the entry point of the form and display a [Page alert](/components/page-alert) with the 'success' tone and a clear message which communicates the successful submission. When possible, provide persistent methods for a user to return and see the status of the submitted artefact, for example a reference number.
 
-```tsx live
+```tsx live enableProse
 <PageAlert
 	tabIndex={-1}
 	tone="success"

--- a/packages/react/src/accordion/docs/overview.mdx
+++ b/packages/react/src/accordion/docs/overview.mdx
@@ -75,7 +75,7 @@ Grouped accordions are single action accordions. They don’t influence each oth
 
 Users can choose what content they want to see.
 
-```jsx live
+```jsx live enableProse
 <Accordion>
 	<AccordionItem title="Accordion 1">
 		<AccordionItemContent>

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -58,7 +58,7 @@ The success page alert is used for notifying the user that a task is fully compl
 
 The error page alert should be used with form validation errors or other errors which the user must action before they can can continue.
 
-```jsx live
+```jsx live enableProse
 <PageAlert tone="error" title="There is a problem">
 	<Prose>
 		<p>Please correct the following fields and try again</p>
@@ -88,7 +88,7 @@ Use warning page alerts to tell the user something urgent. Only use an alert if 
 
 You can take advantage of our `Prose` component to ensure consistant spacing between HTML elements.
 
-```jsx live
+```jsx live enableProse
 <PageAlert tone="error" title="There is a problem">
 	<Prose>
 		<p>Please correct the following fields and try again</p>

--- a/packages/react/src/prose/docs/overview.mdx
+++ b/packages/react/src/prose/docs/overview.mdx
@@ -9,7 +9,7 @@ Many websites will often have to style vanilla HTML, typically sourced from a Co
 
 The `Prose` component should only be used in the context of a page to format long-form content. It should not be used inside a 'framing' component like a `Card` or `Modal`. Instead, a simple `Stack` should be used.
 
-```jsx live
+```jsx live enableProse
 <Prose>
 	<h1>Heading level 1. Page heading</h1>
 	<h2>Heading level 2, proceeding H1</h2>


### PR DESCRIPTION
## Describe your changes

In our docs site live code previews, we disable the page's Prose styles to ensure they don't modify the appearance of examples not related to body content. However, we do want to enable this in some examples.

This PR introduces a flag on the live code snippet declarations to opt-in to use Prose styles.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
