### PR TITLE
Table filtering: Remove redundant "Reset Filters" button

### DIFF
--- a/.storybook/stories/DataFiltering/TableFilteringMedium.tsx
+++ b/.storybook/stories/DataFiltering/TableFilteringMedium.tsx
@@ -127,7 +127,6 @@ export const TableFilteringMedium = ({
 						filters={filters}
 						isOpen={isOpen}
 						setFilters={setFilters}
-						resetFilters={resetFilters}
 					/>
 					<ActiveFilters
 						filters={filters}

--- a/.storybook/stories/DataFiltering/components/FilterAccordion.tsx
+++ b/.storybook/stories/DataFiltering/components/FilterAccordion.tsx
@@ -2,7 +2,6 @@ import { useSpring, animated } from '@react-spring/web';
 import { useRef } from 'react';
 import { Flex } from '@ag.ds-next/react/flex';
 import { DateRangePicker } from '@ag.ds-next/react/date-range-picker';
-import { Button } from '@ag.ds-next/react/button';
 import { usePrefersReducedMotion } from '@ag.ds-next/react/core';
 import { GetDataFilters } from '../lib/getData';
 import { FilterAssigneeSelect } from './FilterAssigneeSelect';
@@ -14,14 +13,12 @@ export const FilterAccordion = ({
 	isOpen,
 	filters,
 	setFilters,
-	resetFilters,
 }: {
 	ariaLabelledBy: string;
 	id: string;
 	isOpen: boolean;
 	filters: GetDataFilters;
 	setFilters: (filters: GetDataFilters) => void;
-	resetFilters: () => void;
 }) => {
 	// This code has been copied from the Accordion component.
 	const ref = useRef<HTMLDivElement>(null);
@@ -81,14 +78,6 @@ export const FilterAccordion = ({
 					}
 					value={filters.requestDate}
 				/>
-				<Button
-					variant="secondary"
-					onClick={() => {
-						resetFilters();
-					}}
-				>
-					Reset filters
-				</Button>
 			</Flex>
 		</animated.section>
 	);


### PR DESCRIPTION
## Describe your changes

During a recent design review for the upcoming vertical filters pattern, Paul noticed this inconsistency with Figma.

This 'Reset filters' button is redundant, as a 'Clear filters' button appears with the active filter tags when at least one filters has been applied.

<img width="1203" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/08ecf6e7-9aef-4e89-96b2-a4f905c44648">

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
