### PR TITLE
status-badge: Add new `weight` prop

### DIFF
--- a/.changeset/moody-shrimps-pull.md
+++ b/.changeset/moody-shrimps-pull.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+status-badge: Added new `weight` prop which can be used to set the visual weight of the badge. The two accepted values are `subtle` and `regular` (default).

--- a/.storybook/stories/DataFiltering/components/DashboardTable.tsx
+++ b/.storybook/stories/DataFiltering/components/DashboardTable.tsx
@@ -201,7 +201,10 @@ export const DashboardTable = forwardRef<HTMLTableElement, DashboardTableProps>(
 													{format(requestDate, 'dd/MM/yyyy')}
 												</TableCell>
 												<TableCell>
-													<StatusBadge {...STATUS_MAP[status]} />
+													<StatusBadge
+														weight="subtle"
+														{...STATUS_MAP[status]}
+													/>
 												</TableCell>
 											</tr>
 										);

--- a/.storybook/stories/DataFiltering/components/DashboardTable.tsx
+++ b/.storybook/stories/DataFiltering/components/DashboardTable.tsx
@@ -197,7 +197,7 @@ export const DashboardTable = forwardRef<HTMLTableElement, DashboardTableProps>(
 												<TableCell>
 													{city}, {state}
 												</TableCell>
-												<TableCell textAlign="right">
+												<TableCell>
 													{format(requestDate, 'dd/MM/yyyy')}
 												</TableCell>
 												<TableCell>

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -424,6 +424,14 @@ function KitchenSink({ background }: KitchenSinkProps) {
 								<StatusBadge tone="neutral" label="Draft" />
 							</Flex>
 
+							<Flex gap={0.5} flexWrap="wrap">
+								<StatusBadge weight="subtle" tone="info" label="In progress" />
+								<StatusBadge weight="subtle" tone="success" label="Resolved" />
+								<StatusBadge weight="subtle" tone="error" label="Rejected" />
+								<StatusBadge weight="subtle" tone="warning" label="Attention" />
+								<StatusBadge weight="subtle" tone="neutral" label="Draft" />
+							</Flex>
+
 							<Flex gap={0.5}>
 								<NotificationBadge tone="neutral" value={16} />
 								<NotificationBadge tone="action" value={8} />

--- a/packages/react/src/status-badge/StatusBadge.stories.tsx
+++ b/packages/react/src/status-badge/StatusBadge.stories.tsx
@@ -27,8 +27,24 @@ export const Info: Story = {
 	},
 };
 
+export const InfoSubtle: Story = {
+	args: {
+		weight: 'subtle',
+		tone: 'info',
+		label: 'Resolved',
+	},
+};
+
 export const Success: Story = {
 	args: {
+		tone: 'success',
+		label: 'Resolved',
+	},
+};
+
+export const SuccessSubtle: Story = {
+	args: {
+		weight: 'subtle',
 		tone: 'success',
 		label: 'Resolved',
 	},
@@ -41,6 +57,14 @@ export const Error: Story = {
 	},
 };
 
+export const ErrorSubtle: Story = {
+	args: {
+		weight: 'subtle',
+		tone: 'error',
+		label: 'Rejected',
+	},
+};
+
 export const Warning: Story = {
 	args: {
 		tone: 'warning',
@@ -48,8 +72,24 @@ export const Warning: Story = {
 	},
 };
 
+export const WarningSubtle: Story = {
+	args: {
+		weight: 'subtle',
+		tone: 'warning',
+		label: 'Attention',
+	},
+};
+
 export const Neutral: Story = {
 	args: {
+		tone: 'neutral',
+		label: 'Draft',
+	},
+};
+
+export const NeutralSubtle: Story = {
+	args: {
+		weight: 'subtle',
 		tone: 'neutral',
 		label: 'Draft',
 	},
@@ -110,7 +150,11 @@ export const InTable = () => {
 							<TableCell>{businessName}</TableCell>
 							<TableCell>{type}</TableCell>
 							<TableCell>
-								<StatusBadge tone={toneMapper[status]} label={status} />
+								<StatusBadge
+									weight="subtle"
+									tone={toneMapper[status]}
+									label={status}
+								/>
 							</TableCell>
 							<TableCell>
 								<TextLink href={`#${id}`}>

--- a/packages/react/src/status-badge/StatusBadge.test.tsx
+++ b/packages/react/src/status-badge/StatusBadge.test.tsx
@@ -14,7 +14,7 @@ function renderStatusBadge(props: StatusBadgeProps) {
 	return render(<StatusBadge {...props} />);
 }
 
-const weight: StatusBadgeWeight[] = ['subtle', 'regular'];
+const weights: StatusBadgeWeight[] = ['subtle', 'regular'];
 
 const tones: StatusBadgeTone[] = [
 	'error',
@@ -25,7 +25,7 @@ const tones: StatusBadgeTone[] = [
 ];
 
 describe('StatusBadge', () => {
-	weight.forEach((weight) => {
+	weights.forEach((weight) => {
 		describe(`weight: ${weight}`, () => {
 			tones.forEach((tone) => {
 				describe(`tone: ${tone}`, () => {

--- a/packages/react/src/status-badge/StatusBadge.test.tsx
+++ b/packages/react/src/status-badge/StatusBadge.test.tsx
@@ -1,13 +1,20 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { cleanup, render } from '../../../../test-utils';
-import { StatusBadge, StatusBadgeProps, StatusBadgeTone } from './StatusBadge';
+import {
+	StatusBadge,
+	StatusBadgeProps,
+	StatusBadgeTone,
+	StatusBadgeWeight,
+} from './StatusBadge';
 
 afterEach(cleanup);
 
 function renderStatusBadge(props: StatusBadgeProps) {
 	return render(<StatusBadge {...props} />);
 }
+
+const weight: StatusBadgeWeight[] = ['subtle', 'regular'];
 
 const tones: StatusBadgeTone[] = [
 	'error',
@@ -18,17 +25,29 @@ const tones: StatusBadgeTone[] = [
 ];
 
 describe('StatusBadge', () => {
-	tones.forEach((tone) => {
-		describe(`tone: ${tone}`, () => {
-			it('renders correctly', () => {
-				const { container } = renderStatusBadge({ tone, label: `Example` });
-				expect(container).toMatchSnapshot();
-			});
+	weight.forEach((weight) => {
+		describe(`weight: ${weight}`, () => {
+			tones.forEach((tone) => {
+				describe(`tone: ${tone}`, () => {
+					it('renders correctly', () => {
+						const { container } = renderStatusBadge({
+							weight,
+							tone,
+							label: `Example`,
+						});
+						expect(container).toMatchSnapshot();
+					});
 
-			it('renders a valid HTML structure', () => {
-				const { container } = renderStatusBadge({ tone, label: `Example` });
-				expect(container).toHTMLValidate({
-					extends: ['html-validate:recommended'],
+					it('renders a valid HTML structure', () => {
+						const { container } = renderStatusBadge({
+							weight,
+							tone,
+							label: `Example`,
+						});
+						expect(container).toHTMLValidate({
+							extends: ['html-validate:recommended'],
+						});
+					});
 				});
 			});
 		});

--- a/packages/react/src/status-badge/StatusBadge.tsx
+++ b/packages/react/src/status-badge/StatusBadge.tsx
@@ -6,7 +6,7 @@ import { SuccessIcon, AlertIcon, InfoIcon, WarningIcon } from '../icon';
 import { Text } from '../text';
 
 export type StatusBadgeProps = {
-	/** The weight of the badge to apply. */
+	/** The visual weight to apply. */
 	weight?: StatusBadgeWeight;
 	/** The status that is printed in the text label. */
 	label: ReactNode;

--- a/packages/react/src/status-badge/StatusBadge.tsx
+++ b/packages/react/src/status-badge/StatusBadge.tsx
@@ -1,32 +1,41 @@
 import { ReactNode } from 'react';
 import { Box } from '../box';
 import { Flex } from '../flex';
-import { boxPalette, mapSpacing } from '../core';
+import { boxPalette, mapSpacing, tokens } from '../core';
 import { SuccessIcon, AlertIcon, InfoIcon, WarningIcon } from '../icon';
 import { Text } from '../text';
 
 export type StatusBadgeProps = {
+	/** The weight of the badge to apply. */
+	weight?: StatusBadgeWeight;
 	/** The status that is printed in the text label. */
 	label: ReactNode;
-	/** The colour tone to apply. */
+	/** The color tone to apply. */
 	tone: StatusBadgeTone;
 };
 
-export const StatusBadge = ({ label, tone }: StatusBadgeProps) => {
+export const StatusBadge = ({
+	label,
+	weight = 'regular',
+	tone,
+}: StatusBadgeProps) => {
 	const { borderColor, icon: Icon } = toneMap[tone];
 	return (
 		<Flex
 			display="inline-flex"
 			alignItems="center"
 			gap={0.5}
-			height={height}
-			paddingX={0.75}
-			background="body"
-			border
 			css={{
-				overflow: 'hidden',
-				borderRadius,
-				borderColor,
+				...(weight === 'regular' && {
+					height,
+					background: boxPalette.backgroundBody,
+					borderWidth: tokens.borderWidth.sm,
+					borderStyle: 'solid',
+					borderColor,
+					borderRadius,
+					paddingLeft: mapSpacing(1),
+					paddingRight: mapSpacing(1),
+				}),
 				'& svg': {
 					flexShrink: 0,
 					width: iconWidth,
@@ -87,3 +96,5 @@ const toneMap = {
 		icon: () => <WarningIcon color="warning" />,
 	},
 } as const;
+
+export type StatusBadgeWeight = 'subtle' | 'regular';

--- a/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StatusBadge tone: error renders correctly 1`] = `
+exports[`StatusBadge weight: regular tone: error renders correctly 1`] = `
 <div>
   <div
-    class="css-766z4q-boxStyles-StatusBadge"
+    class="css-16xnn81-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="true"
@@ -35,10 +35,10 @@ exports[`StatusBadge tone: error renders correctly 1`] = `
 </div>
 `;
 
-exports[`StatusBadge tone: info renders correctly 1`] = `
+exports[`StatusBadge weight: regular tone: info renders correctly 1`] = `
 <div>
   <div
-    class="css-1jpdeo9-boxStyles-StatusBadge"
+    class="css-11uollg-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="true"
@@ -75,10 +75,10 @@ exports[`StatusBadge tone: info renders correctly 1`] = `
 </div>
 `;
 
-exports[`StatusBadge tone: neutral renders correctly 1`] = `
+exports[`StatusBadge weight: regular tone: neutral renders correctly 1`] = `
 <div>
   <div
-    class="css-13gpbg6-boxStyles-StatusBadge"
+    class="css-mazyxq-boxStyles-StatusBadge"
   >
     <div
       class="css-1ttchuf-boxStyles-NeutralDot"
@@ -92,10 +92,10 @@ exports[`StatusBadge tone: neutral renders correctly 1`] = `
 </div>
 `;
 
-exports[`StatusBadge tone: success renders correctly 1`] = `
+exports[`StatusBadge weight: regular tone: success renders correctly 1`] = `
 <div>
   <div
-    class="css-1w1m57w-boxStyles-StatusBadge"
+    class="css-1j8vzzn-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="true"
@@ -126,10 +126,174 @@ exports[`StatusBadge tone: success renders correctly 1`] = `
 </div>
 `;
 
-exports[`StatusBadge tone: warning renders correctly 1`] = `
+exports[`StatusBadge weight: regular tone: warning renders correctly 1`] = `
 <div>
   <div
-    class="css-180b22v-boxStyles-StatusBadge"
+    class="css-1mxhjjp-boxStyles-StatusBadge"
+  >
+    <svg
+      aria-hidden="true"
+      class="css-qz15ef-Icon"
+      clip-rule="evenodd"
+      focusable="false"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12.8858 2.69113C12.5115 1.97647 11.4876 1.97824 11.1132 2.6929C7.60041 9.39921 5.30783 13.776 1.76707 20.5356C1.4183 21.2014 1.90105 22 2.65269 22H21.3473C22.099 22 22.5819 21.2018 22.2331 20.536L12.8858 2.69113Z"
+      />
+      <line
+        x1="12"
+        x2="12"
+        y1="14"
+        y2="9"
+      />
+      <path
+        d="M12 18H12.01"
+      />
+    </svg>
+    <span
+      class="css-10dvol5-boxStyles-Text-StatusBadge"
+    >
+      Example
+    </span>
+  </div>
+</div>
+`;
+
+exports[`StatusBadge weight: subtle tone: error renders correctly 1`] = `
+<div>
+  <div
+    class="css-1ab91q-boxStyles-StatusBadge"
+  >
+    <svg
+      aria-hidden="true"
+      class="css-1h89p7b-Icon"
+      clip-rule="evenodd"
+      focusable="false"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M16.7525 1.79686C16.5646 1.6069 16.3086 1.5 16.0414 1.5H8.04987C7.78544 1.5 7.53178 1.60473 7.34437 1.79128L1.79451 7.31592C1.60598 7.50359 1.5 7.75863 1.5 8.02464V15.8844C1.5 16.1478 1.60386 16.4005 1.78903 16.5877L7.34344 22.2032C7.53128 22.3931 7.7873 22.5 8.05441 22.5H15.9501C16.2146 22.5 16.4682 22.3953 16.6556 22.2087L22.2055 16.6841C22.394 16.4964 22.5 16.2414 22.5 15.9754V8.02003C22.5 7.75675 22.3962 7.5041 22.2111 7.31689L16.7525 1.79686Z"
+      />
+      <path
+        d="M8 16L16 8"
+      />
+      <path
+        d="M16 16L8 8"
+      />
+    </svg>
+    <span
+      class="css-10dvol5-boxStyles-Text-StatusBadge"
+    >
+      Example
+    </span>
+  </div>
+</div>
+`;
+
+exports[`StatusBadge weight: subtle tone: info renders correctly 1`] = `
+<div>
+  <div
+    class="css-1ab91q-boxStyles-StatusBadge"
+  >
+    <svg
+      aria-hidden="true"
+      class="css-1curl5b-Icon"
+      clip-rule="evenodd"
+      focusable="false"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+      />
+      <line
+        x1="12"
+        x2="12"
+        y1="17"
+        y2="11"
+      />
+      <path
+        d="M12 7H12.01"
+      />
+    </svg>
+    <span
+      class="css-10dvol5-boxStyles-Text-StatusBadge"
+    >
+      Example
+    </span>
+  </div>
+</div>
+`;
+
+exports[`StatusBadge weight: subtle tone: neutral renders correctly 1`] = `
+<div>
+  <div
+    class="css-1ab91q-boxStyles-StatusBadge"
+  >
+    <div
+      class="css-1ttchuf-boxStyles-NeutralDot"
+    />
+    <span
+      class="css-10dvol5-boxStyles-Text-StatusBadge"
+    >
+      Example
+    </span>
+  </div>
+</div>
+`;
+
+exports[`StatusBadge weight: subtle tone: success renders correctly 1`] = `
+<div>
+  <div
+    class="css-1ab91q-boxStyles-StatusBadge"
+  >
+    <svg
+      aria-hidden="true"
+      class="css-1esj8rc-Icon"
+      clip-rule="evenodd"
+      focusable="false"
+      height="24"
+      role="img"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10.5"
+      />
+      <path
+        d="M7 13L10 16L17 9"
+      />
+    </svg>
+    <span
+      class="css-10dvol5-boxStyles-Text-StatusBadge"
+    >
+      Example
+    </span>
+  </div>
+</div>
+`;
+
+exports[`StatusBadge weight: subtle tone: warning renders correctly 1`] = `
+<div>
+  <div
+    class="css-1ab91q-boxStyles-StatusBadge"
   >
     <svg
       aria-hidden="true"

--- a/packages/react/src/status-badge/docs/overview.mdx
+++ b/packages/react/src/status-badge/docs/overview.mdx
@@ -11,6 +11,7 @@ relatedComponents: ['notification-badge', 'indicator-dot', 'tags']
 
 - use to indicate the status of a task or process
 - use to help users differentiate between multiple statuses
+- apply the `subtle` weight in tables to reduce visual emphasis and overall height of the parent component
 
 <DontHeading />
 
@@ -31,5 +32,19 @@ The five supported tones are `info`, `success`, `error`, `warning` and `neutral`
 	<StatusBadge tone="error" label="Rejected" />
 	<StatusBadge tone="warning" label="Attention" />
 	<StatusBadge tone="neutral" label="Draft" />
+</Flex>
+```
+
+## Weight
+
+Apply the `subtle` weight in tables to reduce visual emphasis and overall height of the parent component.
+
+```jsx live
+<Flex flexWrap="wrap" gap={2}>
+	<StatusBadge weight="subtle" tone="info" label="In progress" />
+	<StatusBadge weight="subtle" tone="success" label="Resolved" />
+	<StatusBadge weight="subtle" tone="error" label="Rejected" />
+	<StatusBadge weight="subtle" tone="warning" label="Attention" />
+	<StatusBadge weight="subtle" tone="neutral" label="Draft" />
 </Flex>
 ```


### PR DESCRIPTION
## Describe your changes

Added new `weight` prop which can be used to set the visual weight of the badge. The two accepted values are `subtle` and `regular` (default).

- [View docs preview](https://design-system.agriculture.gov.au/pr-preview/pr-1218/components/status-badge)
- [View storybook preview](https://design-system.agriculture.gov.au/pr-preview/pr-1218/storybook/index.html?path=/story/content-statusbadge--info)

### Example screenshot

<img width="1242" alt="Screenshot 2023-06-26 at 11 17 40 am" src="https://github.com/steelthreads/agds-next/assets/6265154/9dc1ee86-6152-4f8e-ab46-19f67ba05c9b">

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).