### PR TITLE
docs: Add support for `diff` syntax highlighting

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react';
 import { LiveProvider, LiveEditor, LivePreview, LiveContext } from 'react-live';
 import { createUrl } from 'playroom/utils';
-import { Highlight } from 'prism-react-renderer';
+import { Highlight, Prism } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
 import { ExternalLinkCallout } from '@ag.ds-next/react/a11y';
 import {
@@ -36,6 +36,11 @@ import { withBasePath } from '../lib/img';
 import * as designSystemComponents from './designSystemComponents';
 import { ConditionalFieldContainer } from './ConditionalFieldContainer';
 import { prismTheme } from './prism-theme';
+
+// Add support for diff language support
+// https://github.com/FormidableLabs/prism-react-renderer#custom-language-support
+(typeof global !== 'undefined' ? global : window).Prism = Prism;
+require('prismjs/components/prism-diff');
 
 const PlaceholderImage = () => (
 	<img

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
 		"next-sitemap": "^3.1.32",
 		"playroom": "^0.31.0",
 		"prism-react-renderer": "^2.0.4",
+		"prismjs": "^1.29.0",
 		"react": "18.1.0",
 		"react-dom": "18.1.0",
 		"react-live": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12487,6 +12487,11 @@ prism-react-renderer@*, prism-react-renderer@^2.0.4:
     "@types/prismjs" "^1.26.0"
     clsx "^1.2.1"
 
+prismjs@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
+  integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"


### PR DESCRIPTION
## Describe your changes

Added support for `diff` syntax highlighting. This was done via the recommended way mentioned on the documentation page which can be found here https://github.com/FormidableLabs/prism-react-renderer#custom-language-support

This was accidecanlly removed in PR #1157 where we upgraded `prism-react-renderer` to version 2.

| Before | After |
|--------|--------|
| <img width="828" alt="Screenshot 2023-06-29 at 11 05 14 am" src="https://github.com/steelthreads/agds-next/assets/6265154/416b1ed5-799d-437d-844d-8b63ff401d39"> | <img width="824" alt="Screenshot 2023-06-29 at 11 05 19 am" src="https://github.com/steelthreads/agds-next/assets/6265154/bdaaba3c-ed6f-486c-8398-191b5076d295"> |