### PR TITLE
docs: Restyle footnote in content principles

### DIFF
--- a/.changeset/thick-bees-scream.md
+++ b/.changeset/thick-bees-scream.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+prose: Increased margin between `hr` elements

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -21,7 +21,7 @@ import {
 	TableHeader,
 	TableWrapper,
 } from '@ag.ds-next/react/table';
-import { mapSpacing } from '@ag.ds-next/react/core';
+import { boxPalette, fontGrid, mapSpacing } from '@ag.ds-next/react/core';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 import { DirectionLink } from '@ag.ds-next/react/direction-link';
@@ -179,8 +179,15 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 	),
 	Box,
 	FootnotesList: ({ children }: HTMLAttributes<HTMLOListElement>) => (
-		<Box as="ul" color="muted" css={{ marginTop: mapSpacing(1.5) }}>
+		<ol
+			css={{
+				...fontGrid('sm', 'default'),
+				color: boxPalette.foregroundMuted,
+				marginTop: mapSpacing(1.5),
+				marginBottom: '0rem',
+			}}
+		>
 			{children}
-		</Box>
+		</ol>
 	),
 };

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -178,4 +178,9 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		</DirectionLink>
 	),
 	Box,
+	FootnotesList: ({ children }: HTMLAttributes<HTMLOListElement>) => (
+		<Box as="ul" color="muted" css={{ marginTop: mapSpacing(1.5) }}>
+			{children}
+		</Box>
+	),
 };

--- a/docs/content/content/content-principles.mdx
+++ b/docs/content/content/content-principles.mdx
@@ -142,26 +142,29 @@ If content already appears on the Export Service or the [Department of Agricultu
 
 ## Notes
 
-<ol>
-	<li id="cite-1">
-		The ABS reports that approximately 45% of Australians over 15 years (or 7.3
-		million people) have literary skills of level 2 or below. They can’t
-		complete tasks where they need to:
-		<ul>
-			<li>
-				identify, interpret, or evaluate one or more pieces of information, and
-			</li>
-			<li>
-				construct meaning across larger chunks of text or perform multi-step
-				operations, while
-			</li>
-			<li>
-				disregarding irrelevant or inappropriate content to arrive at a
-				decision.
-			</li>
-		</ul>
-		Source: Australian Bureau of Statistics (2013)  [Programme for the
-		International Assessment of Adult Competencies,
-		Australia](https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/4228.0main+features202011-12)
-	</li>
-</ol>
+<Box className="agds-prose-block" color="muted" fontSize="xs">
+	<ol>
+		<li id="cite-1">
+			The ABS reports that approximately 45% of Australians over 15 years (or
+			7.3 million people) have literary skills of level 2 or below. They can’t
+			complete tasks where they need to:
+			<ul>
+				<li>
+					identify, interpret, or evaluate one or more pieces of information,
+					and
+				</li>
+				<li>
+					construct meaning across larger chunks of text or perform multi-step
+					operations, while
+				</li>
+				<li>
+					disregarding irrelevant or inappropriate content to arrive at a
+					decision.
+				</li>
+			</ul>
+			Source: Australian Bureau of Statistics (2013)  [Programme for the
+			International Assessment of Adult Competencies,
+			Australia](https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/4228.0main+features202011-12)
+		</li>
+	</ol>
+</Box>

--- a/docs/content/content/content-principles.mdx
+++ b/docs/content/content/content-principles.mdx
@@ -129,6 +129,8 @@ If content already appears on the Export Service or the [Department of Agricultu
 
 <BackToTop />
 
+---
+
 ## Related links
 
 - [How to create guidance in the Export Service](/guides/how-to-create-guidance)
@@ -138,33 +140,28 @@ If content already appears on the Export Service or the [Department of Agricultu
 - [Design principles](/foundations/design-principles)
 - [Writing and designing content I Style Manual](https://www.stylemanual.gov.au/writing-and-designing-content)
 
----
-
 ## Notes
 
-<Box className="agds-prose-block" color="muted" fontSize="xs">
-	<ol>
-		<li id="cite-1">
-			The ABS reports that approximately 45% of Australians over 15 years (or
-			7.3 million people) have literary skills of level 2 or below. They can’t
-			complete tasks where they need to:
-			<ul>
-				<li>
-					identify, interpret, or evaluate one or more pieces of information,
-					and
-				</li>
-				<li>
-					construct meaning across larger chunks of text or perform multi-step
-					operations, while
-				</li>
-				<li>
-					disregarding irrelevant or inappropriate content to arrive at a
-					decision.
-				</li>
-			</ul>
-			Source: Australian Bureau of Statistics (2013)  [Programme for the
-			International Assessment of Adult Competencies,
-			Australia](https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/4228.0main+features202011-12)
-		</li>
-	</ol>
-</Box>
+<FootnotesList>
+	<li id="cite-1">
+		The ABS reports that approximately 45% of Australians over 15 years (or 7.3
+		million people) have literary skills of level 2 or below. They can’t
+		complete tasks where they need to:
+		<ul>
+			<li>
+				identify, interpret, or evaluate one or more pieces of information, and
+			</li>
+			<li>
+				construct meaning across larger chunks of text or perform multi-step
+				operations, while
+			</li>
+			<li>
+				disregarding irrelevant or inappropriate content to arrive at a
+				decision.
+			</li>
+		</ul>
+		Source: Australian Bureau of Statistics (2013)  [Programme for the
+		International Assessment of Adult Competencies,
+		Australia](https://www.abs.gov.au/ausstats/abs@.nsf/Lookup/4228.0main+features202011-12)
+	</li>
+</FootnotesList>

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -572,7 +572,7 @@ For more information, see Commas in the DAFF Style guide (internal DAFF staff on
 
 An en dash (also known as an en rule) is the width of the letter ‘N’. Hyphens are often used incorrectly in place of an en dash.
 
-Use an en dash (-) to:
+Use an en dash (–) to:
 
 - indicate ranges in spans of figures
 - join subjects of equal weight

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`PageAlert tone: error renders correctly 1`] = `
           There is a problem
         </h3>
         <div
-          class="css-1ms0txp-boxStyles-proseClass"
+          class="css-1x94sgg-boxStyles-proseClass"
         >
           <ul>
             <li>

--- a/packages/react/src/prose/Prose.tsx
+++ b/packages/react/src/prose/Prose.tsx
@@ -356,11 +356,11 @@ export const proseClass = css({
 		borderTopWidth: tokens.borderWidth.sm,
 		borderTopStyle: 'solid',
 		borderColor: boxPalette.borderMuted,
-		marginBottom: mapSpacing(1.5),
+		marginBottom: mapSpacing(3),
 	},
 
 	[`* + hr${notSelector}`]: {
-		marginTop: mapSpacing(1.5),
+		marginTop: mapSpacing(3),
 	},
 
 	/**


### PR DESCRIPTION
## Describe your changes

- Apply muted colour to footnote in content principles page
- Replace hyphen with en-dash in en-dash example

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1233/content/content-principles)