### PR TITLE
core: Remove `modalDialog` from max-width tokens

### DIFF
--- a/.changeset/thick-points-arrive.md
+++ b/.changeset/thick-points-arrive.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: Removed `modalDialog` max-width token as it is only ever used in the `Modal` component.

--- a/docs/pages/foundations/tokens/max-width.tsx
+++ b/docs/pages/foundations/tokens/max-width.tsx
@@ -28,11 +28,6 @@ const tokenDescriptions: Record<
 		value: tokens.maxWidth.container,
 		description: 'Used for setting the max-width of the page container.',
 	},
-	modalDialog: {
-		value: tokens.maxWidth.modalDialog,
-		description:
-			'Used for setting the max-width of the dialog in the Modal component.',
-	},
 	mobileMenu: {
 		value: tokens.maxWidth.mobileMenu,
 		description:

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -89,7 +89,6 @@ const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
 	mobileMenu: '17.5rem', // 280 px
-	modalDialog: '45rem', // 720 px
 	field: {
 		xs: '5rem', // 80 px
 		sm: '8rem', // 128 px

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -36,7 +36,7 @@ export const ModalDialog = ({
 				paddingX={{ xs: 0.75, md: 1.5 }}
 				paddingY={{ xs: 1, md: 1.5 }}
 				gap={1}
-				maxWidth={tokens.maxWidth.modalDialog}
+				maxWidth="45rem" // 720 px
 				css={{
 					position: 'relative',
 					margin: '0 auto',


### PR DESCRIPTION
## Describe your changes

Removed `modalDialog` max-width token as it is only ever used in the `Modal` component

- [Updated tokens page](https://design-system.agriculture.gov.au/pr-preview/pr-1235/foundations/tokens/max-width)
- [Updated modal page](https://design-system.agriculture.gov.au/pr-preview/pr-1235/components/modal)