### PR TITLE
docs: Consistent styling to Content examples

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -12,7 +12,7 @@ import { createUrl } from 'playroom/utils';
 import { Highlight, Prism } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
 import { ExternalLinkCallout } from '@ag.ds-next/react/a11y';
-import { CardHeader } from '@ag.ds-next/react/card';
+import { Card, CardHeader } from '@ag.ds-next/react/card';
 import {
 	globalPalette,
 	mapSpacing,
@@ -55,11 +55,11 @@ const PlaceholderImage = () => (
 function LiveCode({
 	showCode = false,
 	enableProse = false,
-	headingType,
+	exampleContentHeadingType,
 }: {
 	showCode?: boolean;
 	enableProse?: boolean;
-	headingType?: 'h2' | 'h3' | 'h4';
+	exampleContentHeadingType?: 'h2' | 'h3' | 'h4';
 }) {
 	const liveCodeToggleButton = useRef<HTMLButtonElement>(null);
 	const live = useContext(LiveContext);
@@ -107,10 +107,10 @@ function LiveCode({
 	);
 
 	return (
-		<Box border rounded borderColor="muted" className={proseBlockClassname}>
-			{headingType && (
+		<Card className={proseBlockClassname}>
+			{exampleContentHeadingType && (
 				<CardHeader>
-					<Heading type={headingType}>Example</Heading>
+					<Heading type={exampleContentHeadingType}>Example</Heading>
 				</CardHeader>
 			)}
 			<LivePreview
@@ -203,7 +203,7 @@ function LiveCode({
 					{live.error}
 				</Box>
 			) : null}
-		</Box>
+		</Card>
 	);
 }
 
@@ -288,7 +288,7 @@ type CodeProps = {
 	live?: boolean;
 	showCode?: boolean;
 	enableProse?: boolean;
-	headingType?: 'h2' | 'h3' | 'h4';
+	exampleContentHeadingType?: 'h2' | 'h3' | 'h4';
 };
 
 export function Code({
@@ -297,7 +297,7 @@ export function Code({
 	showCode,
 	enableProse,
 	className,
-	headingType,
+	exampleContentHeadingType,
 }: CodeProps) {
 	const childrenAsString = children?.toString().trim();
 	const language = className?.replace(/language-/, '');
@@ -314,7 +314,7 @@ export function Code({
 				<LiveCode
 					showCode={showCode}
 					enableProse={enableProse}
-					headingType={headingType}
+					exampleContentHeadingType={exampleContentHeadingType}
 				/>
 			</LiveProvider>
 		);

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -12,6 +12,7 @@ import { createUrl } from 'playroom/utils';
 import { Highlight, Prism } from 'prism-react-renderer';
 import copy from 'clipboard-copy';
 import { ExternalLinkCallout } from '@ag.ds-next/react/a11y';
+import { CardHeader } from '@ag.ds-next/react/card';
 import {
 	globalPalette,
 	mapSpacing,
@@ -22,6 +23,7 @@ import {
 } from '@ag.ds-next/react/core';
 import { Box } from '@ag.ds-next/react/box';
 import { Flex } from '@ag.ds-next/react/flex';
+import { Heading } from '@ag.ds-next/react/heading';
 import {
 	unsetProseStylesClassname,
 	proseBlockClassname,
@@ -53,9 +55,11 @@ const PlaceholderImage = () => (
 function LiveCode({
 	showCode = false,
 	enableProse = false,
+	headingType,
 }: {
 	showCode?: boolean;
 	enableProse?: boolean;
+	headingType?: 'h2' | 'h3' | 'h4';
 }) {
 	const liveCodeToggleButton = useRef<HTMLButtonElement>(null);
 	const live = useContext(LiveContext);
@@ -104,6 +108,11 @@ function LiveCode({
 
 	return (
 		<Box border rounded borderColor="muted" className={proseBlockClassname}>
+			{headingType && (
+				<CardHeader>
+					<Heading type={headingType}>Example</Heading>
+				</CardHeader>
+			)}
 			<LivePreview
 				aria-label="Rendered code snippet example"
 				// Prevents prose styles from being inherited in live code examples (except for the prose example)
@@ -279,6 +288,7 @@ type CodeProps = {
 	live?: boolean;
 	showCode?: boolean;
 	enableProse?: boolean;
+	headingType?: 'h2' | 'h3' | 'h4';
 };
 
 export function Code({
@@ -287,6 +297,7 @@ export function Code({
 	showCode,
 	enableProse,
 	className,
+	headingType,
 }: CodeProps) {
 	const childrenAsString = children?.toString().trim();
 	const language = className?.replace(/language-/, '');
@@ -300,7 +311,11 @@ export function Code({
 				scope={LIVE_SCOPE}
 				language={language}
 			>
-				<LiveCode showCode={showCode} enableProse={enableProse} />
+				<LiveCode
+					showCode={showCode}
+					enableProse={enableProse}
+					headingType={headingType}
+				/>
 			</LiveProvider>
 		);
 	}

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -44,12 +44,12 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		live,
 		showCode,
 		enableProse,
-		headingType,
+		exampleContentHeadingType,
 	}: HTMLAttributes<HTMLPreElement> & {
 		live?: boolean;
 		showCode?: boolean;
 		enableProse?: boolean;
-		headingType?: 'h2' | 'h3' | 'h4';
+		exampleContentHeadingType?: 'h2' | 'h3' | 'h4';
 	}) => {
 		return (
 			<Fragment>
@@ -61,7 +61,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 							live={live}
 							showCode={showCode}
 							enableProse={enableProse}
-							headingType={headingType}
+							exampleContentHeadingType={exampleContentHeadingType}
 							{...element.props}
 						/>
 					);

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -5,6 +5,8 @@ import {
 	HTMLAttributes,
 	AnchorHTMLAttributes,
 	ImgHTMLAttributes,
+	ReactNode,
+	PropsWithChildren,
 } from 'react';
 import type { MDXRemoteProps } from 'next-mdx-remote';
 import Link from 'next/link';
@@ -25,6 +27,8 @@ import { mapSpacing } from '@ag.ds-next/react/core';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 import { DirectionLink } from '@ag.ds-next/react/direction-link';
+import { Card, CardHeader, CardInner } from '@ag.ds-next/react/card';
+import { Heading } from '@ag.ds-next/react/heading';
 import { slugify } from '../lib/slugify';
 import { withBasePath } from '../lib/img';
 import generatedComponentPropsData from '../__generated__/componentProps.json';
@@ -176,6 +180,23 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		>
 			Back to top
 		</DirectionLink>
+	),
+	ExampleContent: ({
+		heading,
+		children,
+	}: PropsWithChildren<{
+		heading?: string | ReactNode;
+	}>) => (
+		<Card className={proseBlockClassname}>
+			<CardHeader>
+				{heading && typeof heading === 'string' ? (
+					<Heading type="h4">{heading}</Heading>
+				) : (
+					heading
+				)}
+			</CardHeader>
+			<CardInner>{children}</CardInner>
+		</Card>
 	),
 	Box,
 };

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -28,7 +28,7 @@ import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
 import { DirectionLink } from '@ag.ds-next/react/direction-link';
 import { Card, CardHeader, CardInner } from '@ag.ds-next/react/card';
-import { Heading } from '@ag.ds-next/react/heading';
+import { H3, H4 } from '@ag.ds-next/react/heading';
 import { slugify } from '../lib/slugify';
 import { withBasePath } from '../lib/img';
 import generatedComponentPropsData from '../__generated__/componentProps.json';
@@ -44,10 +44,12 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		live,
 		showCode,
 		enableProse,
+		headingType,
 	}: HTMLAttributes<HTMLPreElement> & {
 		live?: boolean;
 		showCode?: boolean;
 		enableProse?: boolean;
+		headingType?: 'h2' | 'h3' | 'h4';
 	}) => {
 		return (
 			<Fragment>
@@ -59,6 +61,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 							live={live}
 							showCode={showCode}
 							enableProse={enableProse}
+							headingType={headingType}
 							{...element.props}
 						/>
 					);
@@ -131,6 +134,8 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 			</h3>
 		);
 	},
+	H3,
+	H4,
 	PageAlert: (props: PageAlertProps) => (
 		<div className={proseBlockClassname}>
 			<PageAlert {...props} />
@@ -182,19 +187,13 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		</DirectionLink>
 	),
 	ExampleContent: ({
-		heading,
+		heading = <H4>Example</H4>,
 		children,
 	}: PropsWithChildren<{
-		heading?: string | ReactNode;
+		heading?: ReactNode;
 	}>) => (
 		<Card className={proseBlockClassname}>
-			<CardHeader>
-				{heading && typeof heading === 'string' ? (
-					<Heading type="h4">{heading}</Heading>
-				) : (
-					heading
-				)}
-			</CardHeader>
+			{heading ? <CardHeader>{heading}</CardHeader> : null}
 			<CardInner>{children}</CardInner>
 		</Card>
 	),

--- a/docs/content/content/content-patterns.mdx
+++ b/docs/content/content/content-patterns.mdx
@@ -44,7 +44,7 @@ Use ‘Need more help?’ as the heading. Not, ‘Need help?’ or ‘For more h
 
 Make sure the Export Service phone number is accessible and linked. Don’t use bullet points or a colon after ‘Call’ or ‘Email’. Don’t use a full stop after the email address.
 
-```jsx live enableProse headingType='h3'
+```jsx live enableProse exampleContentHeadingType='h3'
 <Callout title="Need more help?">
 	<Prose>
 		<p>

--- a/docs/content/content/content-patterns.mdx
+++ b/docs/content/content/content-patterns.mdx
@@ -44,7 +44,7 @@ Use ‘Need more help?’ as the heading. Not, ‘Need help?’ or ‘For more h
 
 Make sure the Export Service phone number is accessible and linked. Don’t use bullet points or a colon after ‘Call’ or ‘Email’. Don’t use a full stop after the email address.
 
-```jsx live enableProse
+```jsx live enableProse headingType='h3'
 <Callout title="Need more help?">
 	<Prose>
 		<p>

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -11,7 +11,7 @@ Don’t use the ampersand symbol (&) instead of ‘and’ in a heading or senten
 
 That’s unless it’s a part of a proper noun or name.
 
-```jsx live enableProse headingType='h3'
+```jsx live enableProse exampleContentHeadingType='h3'
 <Prose>
 	<h1>Summary and findings</h1>
 
@@ -199,7 +199,7 @@ If the information applies to all users, don’t hide an FAQ in an accordion or 
 
 Monitor and measure the success of FAQs. If no one is using them, remove FAQ content.
 
-```jsx live enableProse headingType="h3"
+```jsx live enableProse exampleContentHeadingType="h3"
 <Details label="How were my details prefilled?" iconBefore>
 	<Prose>
 		<p>
@@ -239,7 +239,7 @@ A H1 can also be a question. But try to use questions as headings minimally or i
 
 For more information, see Structuring headings and labels in [Content structure](/content/content-structure#structuring-headings-and-labels). Also see Frequently Asked Questions in [Content styles](#frequently-asked-questions) and [Headings](/components/heading).
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <Stack gap={3}>
 	<H1>Find an export guide for agricultural goods</H1>
 	<Text as="p" fontSize="lg" color="muted">
@@ -328,7 +328,7 @@ For more information, see Technical guidance in [How to create guidance in the E
 
 Include a short introduction that describes a page’s content under the heading (H1). It should be 1 to 2 sentences (about 30 words) and end with a full stop.
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <Stack gap={1.5}>
 	<H1>Business owner or principal authority</H1>
 	<Text as="p" fontSize="md" color="muted">
@@ -361,7 +361,7 @@ For more information on links, see:
 
 - External links I DAFF Style guide (internal DAFF staff only).
 
-```jsx live enableProse headingType="h3"
+```jsx live enableProse exampleContentHeadingType="h3"
 <Prose>
 <p>To create your myGovID:</a>
 <ol>
@@ -374,7 +374,7 @@ For more information on links, see:
 </Prose>
 ```
 
-```jsx live enableProse headingType="h3"
+```jsx live enableProse exampleContentHeadingType="h3"
 <p>
 	You can propose an arrangement to us to approve. You can do this at the same
 	time you apply to{' '}
@@ -395,7 +395,7 @@ Don't use full stops at the end of the last item on a list if the item is next t
 
 Use a capital letter on the first word of listed items next to radio buttons or multi-select checkboxes.
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <Fieldset legend="Select commodities">
 	<ControlGroup
 		label="Which commodities are you applying to register?"
@@ -442,7 +442,7 @@ When you create microcopy in the Export Service, make sure content:
 - offers a specific solution to fix any problem. For example, accepted formats
 - uses [‘Please and thanks’](#please-and-thanks) sparingly and only if the user’s action will be something extra.
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <FormStack>
 	<TextInput
 		label="Email address"
@@ -474,7 +474,7 @@ Always spell out ‘one’ and ‘zero’ in words, so users don’t confuse the
 
 For more information, see Numbers in the DAFF Style guide (internal DAFF staff only). Also see [Numbers and measurements](https://www.stylemanual.gov.au/grammar-punctuation-and-conventions/numbers-and-measurements).
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <Prose>
 	<h1>Linking a business in RAM</h1>
 	<p>
@@ -501,7 +501,7 @@ Use ‘please’ and ‘thanks’ sparingly. Only add it to content when you’r
 
 For example, if you are asking them to give feedback on a web page. Use ‘thanks’ instead of ‘thank you’ in these instances.
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <FormStack>
 	<H2>Thanks for your feedback</H2>
 	<Textarea label="Please tell us more" hint="Don't provide personal details" />
@@ -514,7 +514,7 @@ For example, if you are asking them to give feedback on a web page. Use ‘thank
 
 Use ‘(s)’ to indicate one or more of a word to users in the Export Service.
 
-```jsx live headingType="h3"
+```jsx live exampleContentHeadingType="h3"
 <Stack gap={1.5}>
 	<SummaryList>
 		<SummaryListItem>
@@ -535,7 +535,7 @@ Use commas minimally in Export Service content. Instead, break up content into s
 
 Don’t use the Oxford comma. That is, a comma before the final ‘and’ in a sentence.
 
-```jsx live headingType="h4"
+```jsx live exampleContentHeadingType="h4"
 <Card shadow clickable>
 	<CardInner>
 		<Stack gap={1}>
@@ -600,7 +600,7 @@ Some of the preferred terms we use on common button labels in the Export Service
 - Change (instead of 'edit' or 'update')
 - Manage [element]
 
-```jsx live headingType="h4"
+```jsx live exampleContentHeadingType="h4"
 <Button>Edit registered establishments</Button>
 ```
 

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -11,6 +11,8 @@ Don’t use the ampersand symbol (&) instead of ‘and’ in a heading or senten
 
 That’s unless it’s a part of a proper noun or name.
 
+### Example
+
 ```jsx live enableProse
 <Prose>
 	<h1>Summary and findings</h1>
@@ -88,8 +90,9 @@ Conduct research where possible to see if you should use contractions in Export 
 
 ### Examples
 
-- "We’ll get back to you within 2 days".
-- "You don’t have access to this business".
+<ExampleContent>We’ll get back to you within 2 days.</ExampleContent>
+
+<ExampleContent>You don’t have access to this business.</ExampleContent>
 
 For more information, see [Contractions](https://www.stylemanual.gov.au/grammar-punctuation-and-conventions/shortened-words-and-phrases/contractions). Also see Abbreviations and other shortened forms in the DAFF Style guide (internal DAFF staff only).
 
@@ -114,6 +117,8 @@ If you include an email address in Export Service content, the full address shou
 Don’t include a full stop after an email address if it’s part of sentence fragment or on a line by itself.
 
 You can use a full stop after an email address if it’s at the end of a sentence. But make sure the full stop is not included in the link text. Otherwise, users may confuse it with being a part of the email address.
+
+### Examples
 
 ```jsx live
 <Text>
@@ -205,6 +210,8 @@ If the information applies to all users, don’t hide an FAQ in an accordion or 
 
 Monitor and measure the success of FAQs. If no one is using them, remove FAQ content.
 
+### Example
+
 ```jsx live enableProse
 <Details label="How were my details prefilled?" iconBefore>
 	<Prose>
@@ -244,6 +251,8 @@ Use conjunctions, prepositions and pronouns in between so a statement heading so
 A H1 can also be a question. But try to use questions as headings minimally or instead of a statement. Start with 1 of the 5 ‘Ws’: ‘who’, ‘what’, ‘where’, ‘when’ or ‘why’ for question headings.
 
 For more information, see Structuring headings and labels in [Content structure](/content/content-structure#structuring-headings-and-labels). Also see Frequently Asked Questions in [Content styles](#frequently-asked-questions) and [Headings](/components/heading).
+
+### Example
 
 ```jsx live
 <Stack gap={3}>
@@ -306,19 +315,15 @@ Use a forward arrow (>) to separate the tabs or buttons users need to select.
 
 ### Examples
 
-```jsx live
-<Text>
+<ExampleContent>
 	To carry out any of these actions, sign in to the Export Service and select
 	the 'Establishments' tab.
-</Text>
-```
+</ExampleContent>
 
-```jsx live
-<Text>
+<ExampleContent>
 	On the Insert tab, select Symbol > More symbols > Special characters > En
 	dash.
-</Text>
-```
+</ExampleContent>
 
 ```jsx live enableProse
 <Prose>
@@ -376,6 +381,8 @@ For more information on links, see:
 
 - External links I DAFF Style guide (internal DAFF staff only).
 
+### Examples
+
 ```jsx live enableProse
 <Prose>
 <p>To create your myGovID:</a>
@@ -409,6 +416,8 @@ For more information on links, see:
 Don't use full stops at the end of the last item on a list if the item is next to a radio button or a multi-select checkbox. For example, lists in a form or interactive experience.
 
 Use a capital letter on the first word of listed items next to radio buttons or multi-select checkboxes.
+
+### Example
 
 ```jsx live
 <Fieldset legend="Select commodities">
@@ -457,6 +466,8 @@ When you create microcopy in the Export Service, make sure content:
 - offers a specific solution to fix any problem. For example, accepted formats
 - uses [‘Please and thanks’](#please-and-thanks) sparingly and only if the user’s action will be something extra.
 
+### Examples
+
 ```jsx live
 <FormStack>
 	<TextInput
@@ -488,6 +499,8 @@ However, there are a few exceptions to this rule. Spell out a number as a word i
 Always spell out ‘one’ and ‘zero’ in words, so users don’t confuse them with letters. That’s unless you are comparing something directly. For example, ‘Digital Services to Take Farmers to Markets is 1 of 5 measures in the Busting Congestion package.’
 
 For more information, see Numbers in the DAFF Style guide (internal DAFF staff only). Also see [Numbers and measurements](https://www.stylemanual.gov.au/grammar-punctuation-and-conventions/numbers-and-measurements).
+
+### Examples
 
 ```jsx live
 <Prose>
@@ -682,9 +695,13 @@ A search engine optimised (SEO) URL:
 
 ### Examples
 
-`https://exports.agriculture.gov.au/help/register-establishment`
+<ExampleContent>
+	https://exports.agriculture.gov.au/help/register-establishment
+</ExampleContent>
 
-`https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods`
+<ExampleContent>
+	https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods
+</ExampleContent>
 
 <BackToTop />
 

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -11,9 +11,7 @@ Don’t use the ampersand symbol (&) instead of ‘and’ in a heading or senten
 
 That’s unless it’s a part of a proper noun or name.
 
-### Example
-
-```jsx live enableProse
+```jsx live enableProse headingType='h3'
 <Prose>
 	<h1>Summary and findings</h1>
 
@@ -88,11 +86,13 @@ Avoid complex contractions which are harder to interpret. Some users may find th
 
 Conduct research where possible to see if you should use contractions in Export Service content.
 
-### Examples
+<ExampleContent heading={<H3>Example</H3>}>
+	We’ll get back to you within 2 days.
+</ExampleContent>
 
-<ExampleContent>We’ll get back to you within 2 days.</ExampleContent>
-
-<ExampleContent>You don’t have access to this business.</ExampleContent>
+<ExampleContent heading={<H3>Example</H3>}>
+	You don’t have access to this business.
+</ExampleContent>
 
 For more information, see [Contractions](https://www.stylemanual.gov.au/grammar-punctuation-and-conventions/shortened-words-and-phrases/contractions). Also see Abbreviations and other shortened forms in the DAFF Style guide (internal DAFF staff only).
 
@@ -118,26 +118,15 @@ Don’t include a full stop after an email address if it’s part of sentence fr
 
 You can use a full stop after an email address if it’s at the end of a sentence. But make sure the full stop is not included in the link text. Otherwise, users may confuse it with being a part of the email address.
 
-### Examples
+<ExampleContent heading={<H3>Example</H3>}>
+	Email address
+	[exportservice@agriculture.gov.au](mailto:exportservice@agriculture.gov.au)
+</ExampleContent>
 
-```jsx live
-<Text>
-	Email address{' '}
-	<TextLink href="mailto:exportservice@agriculture.gov.au">
-		exportservice@agriculture.gov.au
-	</TextLink>
-</Text>
-```
-
-```jsx live
-<Text>
-	If you're interested in taking part or would like to find out more, email{' '}
-	<TextLink href="mailto:exportassurance@agriculture.gov.au">
-		exportassurance@agriculture.gov.au
-	</TextLink>
-	.
-</Text>
-```
+<ExampleContent heading={<H3>Example</H3>}>
+	If you're interested in taking part or would like to find out more, email
+	[exportassurance@agriculture.gov.au](mailto:exportassurance@agriculture.gov.au)
+</ExampleContent>
 
 For more information, see [Text link](/components/text-link) and [Full stops](https://www.stylemanual.gov.au/grammar-punctuation-and-conventions/punctuation-and-capitalisation/full-stops#dont_end_web_or_email_addresses_with_full_stops).
 
@@ -210,9 +199,7 @@ If the information applies to all users, don’t hide an FAQ in an accordion or 
 
 Monitor and measure the success of FAQs. If no one is using them, remove FAQ content.
 
-### Example
-
-```jsx live enableProse
+```jsx live enableProse headingType="h3"
 <Details label="How were my details prefilled?" iconBefore>
 	<Prose>
 		<p>
@@ -252,9 +239,7 @@ A H1 can also be a question. But try to use questions as headings minimally or i
 
 For more information, see Structuring headings and labels in [Content structure](/content/content-structure#structuring-headings-and-labels). Also see Frequently Asked Questions in [Content styles](#frequently-asked-questions) and [Headings](/components/heading).
 
-### Example
-
-```jsx live
+```jsx live headingType="h3"
 <Stack gap={3}>
 	<H1>Find an export guide for agricultural goods</H1>
 	<Text as="p" fontSize="lg" color="muted">
@@ -313,32 +298,27 @@ Ideally, include one action the user needs to take in each step. But if space is
 
 Use a forward arrow (>) to separate the tabs or buttons users need to select.
 
-### Examples
-
-<ExampleContent>
+<ExampleContent heading={<H3>Example</H3>}>
 	To carry out any of these actions, sign in to the Export Service and select
 	the 'Establishments' tab.
 </ExampleContent>
 
-<ExampleContent>
+<ExampleContent heading={<H3>Example</H3>}>
 	On the Insert tab, select Symbol > More symbols > Special characters > En
 	dash.
 </ExampleContent>
 
-```jsx live enableProse
-<Prose>
-	<p>You can see details of your audit in your Export Service account.</p>
-	<p>To find a summary and findings of your audit:</p>
-	<ol>
-		<li>Sign in to your Export Service account.</li>
-		<li>Select ‘Compliance’.</li>
-		<li>
-			Under Audit reports, find the audit reference number and select ‘View’.
-		</li>
-		<li>Go to the Findings section.</li>
-	</ol>
-</Prose>
-```
+<ExampleContent heading={<H3>Example</H3>}>
+	You can see details of your audit in your Export Service account.
+
+    To find a summary and findings of your audit:
+
+    	1. Sign in to your Export Service account.
+    	2. Select ‘Compliance’.
+    	3. Under Audit reports, find the audit reference number and select ‘View’.
+    	4. Go to the Findings section.
+
+</ExampleContent>
 
 For more information, see Technical guidance in [How to create guidance in the Export Service](/guides/how-to-write-guidance/how-to-present-guidance#technical-guidance).
 
@@ -348,7 +328,7 @@ For more information, see Technical guidance in [How to create guidance in the E
 
 Include a short introduction that describes a page’s content under the heading (H1). It should be 1 to 2 sentences (about 30 words) and end with a full stop.
 
-```jsx live
+```jsx live headingType="h3"
 <Stack gap={1.5}>
 	<H1>Business owner or principal authority</H1>
 	<Text as="p" fontSize="md" color="muted">
@@ -381,9 +361,7 @@ For more information on links, see:
 
 - External links I DAFF Style guide (internal DAFF staff only).
 
-### Examples
-
-```jsx live enableProse
+```jsx live enableProse headingType="h3"
 <Prose>
 <p>To create your myGovID:</a>
 <ol>
@@ -396,7 +374,7 @@ For more information on links, see:
 </Prose>
 ```
 
-```jsx live enableProse
+```jsx live enableProse headingType="h3"
 <p>
 	You can propose an arrangement to us to approve. You can do this at the same
 	time you apply to{' '}
@@ -417,9 +395,7 @@ Don't use full stops at the end of the last item on a list if the item is next t
 
 Use a capital letter on the first word of listed items next to radio buttons or multi-select checkboxes.
 
-### Example
-
-```jsx live
+```jsx live headingType="h3"
 <Fieldset legend="Select commodities">
 	<ControlGroup
 		label="Which commodities are you applying to register?"
@@ -466,9 +442,7 @@ When you create microcopy in the Export Service, make sure content:
 - offers a specific solution to fix any problem. For example, accepted formats
 - uses [‘Please and thanks’](#please-and-thanks) sparingly and only if the user’s action will be something extra.
 
-### Examples
-
-```jsx live
+```jsx live headingType="h3"
 <FormStack>
 	<TextInput
 		label="Email address"
@@ -500,9 +474,7 @@ Always spell out ‘one’ and ‘zero’ in words, so users don’t confuse the
 
 For more information, see Numbers in the DAFF Style guide (internal DAFF staff only). Also see [Numbers and measurements](https://www.stylemanual.gov.au/grammar-punctuation-and-conventions/numbers-and-measurements).
 
-### Examples
-
-```jsx live
+```jsx live headingType="h3"
 <Prose>
 	<h1>Linking a business in RAM</h1>
 	<p>
@@ -529,7 +501,7 @@ Use ‘please’ and ‘thanks’ sparingly. Only add it to content when you’r
 
 For example, if you are asking them to give feedback on a web page. Use ‘thanks’ instead of ‘thank you’ in these instances.
 
-```jsx live
+```jsx live headingType="h3"
 <FormStack>
 	<H2>Thanks for your feedback</H2>
 	<Textarea label="Please tell us more" hint="Don't provide personal details" />
@@ -542,7 +514,7 @@ For example, if you are asking them to give feedback on a web page. Use ‘thank
 
 Use ‘(s)’ to indicate one or more of a word to users in the Export Service.
 
-```jsx live
+```jsx live headingType="h3"
 <Stack gap={1.5}>
 	<SummaryList>
 		<SummaryListItem>
@@ -563,7 +535,7 @@ Use commas minimally in Export Service content. Instead, break up content into s
 
 Don’t use the Oxford comma. That is, a comma before the final ‘and’ in a sentence.
 
-```jsx live
+```jsx live headingType="h4"
 <Card shadow clickable>
 	<CardInner>
 		<Stack gap={1}>
@@ -628,7 +600,7 @@ Some of the preferred terms we use on common button labels in the Export Service
 - Change (instead of 'edit' or 'update')
 - Manage [element]
 
-```jsx live
+```jsx live headingType="h4"
 <Button>Edit registered establishments</Button>
 ```
 
@@ -666,17 +638,13 @@ Don’t use ‘such as’ or ‘includes’ in place of ‘for example’.
 
 For more information, see ‘e.g.’ or ‘for example’ in the DAFF Style guide (internal DAFF staff only).
 
-```jsx live
-<Text as="p">
+<ExampleContent heading={<H3>Example</H3>}>
 	This tool is for exporting citrus fruits (for example, oranges and lemons).
-</Text>
-```
+</ExampleContent>
 
-```jsx live
-<Text as="p">
+<ExampleContent heading={<H3>Example</H3>}>
 	You’ll need identity documents, for example a driver licence.
-</Text>
-```
+</ExampleContent>
 
 <BackToTop />
 
@@ -693,13 +661,11 @@ A search engine optimised (SEO) URL:
 - has 20 to 70 characters if possible
 - is consistent with the H1 on the page if possible. But try not to repeat a word if it's already a part of the URL domain/folder URL stem.
 
-### Examples
-
-<ExampleContent>
+<ExampleContent heading={<H4>Example</H4>}>
 	https://exports.agriculture.gov.au/help/register-establishment
 </ExampleContent>
 
-<ExampleContent>
+<ExampleContent heading={<H4>Example</H4>}>
 	https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods
 </ExampleContent>
 

--- a/docs/content/content/voice-and-tone.mdx
+++ b/docs/content/content/voice-and-tone.mdx
@@ -43,13 +43,13 @@ When you write our content, use [active voice](https://www.stylemanual.gov.au/wr
 
 That is, use the general pattern of ‘subject-verb-object’ to convey active voice in content.
 
-<DoHeading />
+<ExampleContent heading={<DoHeading />}>
+	‘You can apply to register your property as an export establishment.’
+</ExampleContent>
 
-‘You can apply to register your property as an export establishment.’
-
-<DontHeading />
-
-‘Your property can be registered as an export establishment.’
+<ExampleContent heading={<DontHeading />}>
+	‘Your property can be registered as an export establishment.’
+</ExampleContent>
 
 <BackToTop />
 
@@ -84,17 +84,19 @@ But use humour sparingly - if at all - and carefully. It is subjective and works
 
 Avoid using humour where it might make something less clear.
 
-<DoHeading />
-
+<ExampleContent heading={<DoHeading />}>
 "Ask us if you need to lodge an application for a proposed new technology.
 
 We need to be sure that we understand the risks attached to introducing a new technology or procedure."
 
-<DontHeading />
+</ExampleContent>
 
+<ExampleContent heading={<DontHeading />}>
 "Applicants may propose alternative procedures or new technology, which may or may not be on the grounds of scientific research and differs from currently accepted and approved science and/or industrial practices within the Australian export meat industry, or those detailed in the relevant Australian Meat Standard.
 
 Clarification from the department should be sought on the need or not to lodge an application for a proposed new technology or procedure where initial indications are that no adverse impact would result from the introduction of the new technology or procedure."
+
+</ExampleContent>
 
 <BackToTop />
 

--- a/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
+++ b/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
@@ -36,7 +36,7 @@ You can use the [Card](/components/card) component to provide tailored guidance 
 
 For example, to deliver results at the end of a multi-page form experience such as the interactive guidance tool to [Find an export guide for agricultural goods](https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods).
 
-```jsx live headingType="h4"
+```jsx live exampleContentHeadingType="h4"
 <Stack gap={1.5}>
 	<Stack>
 		<Text fontWeight="bold" color="muted">
@@ -112,7 +112,7 @@ The user is filling out a form or completing a task to find information. There a
 
 Where guidance is relevant to all users, you can provide concise guidance above form fields to help users complete a form step and move on.
 
-```jsx live headingType="h4"
+```jsx live exampleContentHeadingType="h4"
 <Stack gap={1.5}>
 	<Stack>
 		<Text fontWeight="bold" color="muted">
@@ -150,7 +150,7 @@ Where guidance is relevant to all users, you can provide concise guidance above 
 
 Use hint text to provide more context to help users successfully complete a form field. Hint text is optional and additional information to help users understand what the field is about.
 
-```jsx live headingType="h4"
+```jsx live exampleContentHeadingType="h4"
 <TextInput label="Label" hint="Hint text" />
 ```
 
@@ -164,7 +164,7 @@ This reduces cognitive load for users. That is, we won’t overwhelm the user wi
 
 You can link from inside the Details component to other content for further guidance.
 
-```jsx live headingType="h4"
+```jsx live exampleContentHeadingType="h4"
 <Stack gap={1.5}>
 	<Stack>
 		<Text fontWeight="bold" color="muted">
@@ -268,7 +268,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 
 ### Step-by-step instructions
 
-```jsx live enableProse headingType="h5"
+```jsx live enableProse exampleContentHeadingType="h5"
 <Prose>
 	<h2>To remove someone's access:</h2>
 	<ol>
@@ -289,7 +289,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 </Prose>
 ```
 
-```jsx live headingType="h5"
+```jsx live exampleContentHeadingType="h5"
 <p>
 	On the Insert tab, select Symbol > More symbols > Special characters > En
 	dash.

--- a/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
+++ b/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
@@ -262,13 +262,11 @@ For more information, see [Content structure](/content/content-structure) and [H
 - Instructions
 - Lists.
 
-### Examples
-
-#### ‘How-to’ or troubleshooting content
+### ‘How-to’ or troubleshooting content
 
 See the Export Service [Help](https://exports.agriculture.gov.au/help) section for examples.
 
-#### Step-by-step instructions
+### Step-by-step instructions
 
 ```jsx live enableProse headingType="h5"
 <Prose>

--- a/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
+++ b/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
@@ -36,7 +36,7 @@ You can use the [Card](/components/card) component to provide tailored guidance 
 
 For example, to deliver results at the end of a multi-page form experience such as the interactive guidance tool to [Find an export guide for agricultural goods](https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods).
 
-```jsx live
+```jsx live headingType="h4"
 <Stack gap={1.5}>
 	<Stack>
 		<Text fontWeight="bold" color="muted">
@@ -112,7 +112,7 @@ The user is filling out a form or completing a task to find information. There a
 
 Where guidance is relevant to all users, you can provide concise guidance above form fields to help users complete a form step and move on.
 
-```jsx live
+```jsx live headingType="h4"
 <Stack gap={1.5}>
 	<Stack>
 		<Text fontWeight="bold" color="muted">
@@ -150,7 +150,7 @@ Where guidance is relevant to all users, you can provide concise guidance above 
 
 Use hint text to provide more context to help users successfully complete a form field. Hint text is optional and additional information to help users understand what the field is about.
 
-```jsx live
+```jsx live headingType="h4"
 <TextInput label="Label" hint="Hint text" />
 ```
 
@@ -164,7 +164,7 @@ This reduces cognitive load for users. That is, we won’t overwhelm the user wi
 
 You can link from inside the Details component to other content for further guidance.
 
-```jsx live
+```jsx live headingType="h4"
 <Stack gap={1.5}>
 	<Stack>
 		<Text fontWeight="bold" color="muted">
@@ -270,7 +270,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 
 #### Step-by-step instructions
 
-```jsx live enableProse
+```jsx live enableProse headingType="h5"
 <Prose>
 	<h2>To remove someone's access:</h2>
 	<ol>
@@ -291,7 +291,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 </Prose>
 ```
 
-```jsx live
+```jsx live headingType="h5"
 <p>
 	On the Insert tab, select Symbol > More symbols > Special characters > En
 	dash.


### PR DESCRIPTION
## Describe your changes

Unify appearance of example content and code blocks across the Content and Content Guides sections.

Each 'example' is treated as a seperate card with the heading 'Example'. This is the case for any 'ContentExample', or Code example which exists on the same page as a ContentExample.

Please see the PR preview deployment for [Content](https://design-system.agriculture.gov.au/pr-preview/pr-1239/content) and [How to present guidance](https://design-system.agriculture.gov.au/pr-preview/pr-1239/guides/how-to-write-guidance/how-to-present-guidance).

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
