### PR TITLE
core: Remove modalDialog and mobileMenu tokens

### DIFF
--- a/.changeset/rich-shirts-eat.md
+++ b/.changeset/rich-shirts-eat.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: Removed `modalDialog` and `mobileMenu` max-width tokens,  as they are related to specific components.

--- a/.changeset/rich-shirts-eat.md
+++ b/.changeset/rich-shirts-eat.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-core: Removed `modalDialog` and `mobileMenu` max-width tokens,  as they are related to specific components.
+core: Removed `modalDialog` and `mobileMenu` max-width tokens as they are related to specific components.

--- a/docs/pages/foundations/tokens/max-width.tsx
+++ b/docs/pages/foundations/tokens/max-width.tsx
@@ -28,11 +28,6 @@ const tokenDescriptions: Record<
 		value: tokens.maxWidth.container,
 		description: 'Used for setting the max-width of the page container.',
 	},
-	mobileMenu: {
-		value: tokens.maxWidth.mobileMenu,
-		description:
-			'Used for setting the max-width of the modal dialog in the mobile version of the MainNav.',
-	},
 };
 
 export default function TokensMaxWidthsPage() {

--- a/docs/pages/foundations/tokens/max-width.tsx
+++ b/docs/pages/foundations/tokens/max-width.tsx
@@ -28,11 +28,6 @@ const tokenDescriptions: Record<
 		value: tokens.maxWidth.container,
 		description: 'Used for setting the max-width of the page container.',
 	},
-	modalDialog: {
-		value: tokens.maxWidth.modalDialog,
-		description:
-			'Used for setting the max-width of the dialog in the Modal component.',
-	},
 	mobileMenu: {
 		value: tokens.maxWidth.mobileMenu,
 		description:

--- a/packages/react/src/app-layout/AppLayout.tsx
+++ b/packages/react/src/app-layout/AppLayout.tsx
@@ -1,7 +1,10 @@
 import { PropsWithChildren } from 'react';
-import { mapResponsiveProp, mq, tokens, useTernaryState } from '../core';
+import { mapResponsiveProp, mq, useTernaryState } from '../core';
 import { AppLayoutContext } from './AppLayoutContext';
-import { APP_LAYOUT_DESKTOP_BREAKPOINT } from './utils';
+import {
+	APP_LAYOUT_DESKTOP_BREAKPOINT,
+	APP_LAYOUT_SIDEBAR_WIDTH,
+} from './utils';
 
 export type AppLayoutProps = PropsWithChildren<{
 	/** Set to `true` while users are completing multi-page forms to reduce distractions. When true, the app layout sidebar will not be rendered. */
@@ -41,7 +44,7 @@ function AppLayoutGrid({ children, focusMode }: AppLayoutGridProps) {
 					xs: '1fr',
 					[APP_LAYOUT_DESKTOP_BREAKPOINT]: focusMode
 						? '1fr'
-						: `${tokens.maxWidth.mobileMenu} 1fr`,
+						: `${APP_LAYOUT_SIDEBAR_WIDTH} 1fr`,
 				}),
 			})}
 		>

--- a/packages/react/src/app-layout/AppLayoutSidebar.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.tsx
@@ -4,7 +4,10 @@ import { Stack } from '../stack';
 import { AppLayoutSidebarNav, NavItem } from './AppLayoutSidebarNav';
 import { useAppLayoutContext } from './AppLayoutContext';
 import { AppLayoutSidebarDialog } from './AppLayoutSidebarDialog';
-import { APP_LAYOUT_DESKTOP_BREAKPOINT } from './utils';
+import {
+	APP_LAYOUT_DESKTOP_BREAKPOINT,
+	APP_LAYOUT_SIDEBAR_WIDTH,
+} from './utils';
 
 export type AppLayoutSidebarProps = {
 	/** Used for highlighting the active element. */
@@ -27,7 +30,7 @@ export function AppLayoutSidebar({ activePath, items }: AppLayoutSidebarProps) {
 				flexGrow={1}
 				css={{
 					display: 'none',
-					width: tokens.maxWidth.mobileMenu,
+					width: APP_LAYOUT_SIDEBAR_WIDTH,
 					[tokens.mediaQuery.min[APP_LAYOUT_DESKTOP_BREAKPOINT]]: {
 						display: focusMode ? 'none' : 'flex',
 					},

--- a/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarDialog.tsx
@@ -21,7 +21,10 @@ import { CloseIcon } from '../icon';
 import { VisuallyHidden } from '../a11y';
 import { BaseButton } from '../button';
 import { useAppLayoutContext } from './AppLayoutContext';
-import { APP_LAYOUT_DESKTOP_BREAKPOINT } from './utils';
+import {
+	APP_LAYOUT_DESKTOP_BREAKPOINT,
+	APP_LAYOUT_SIDEBAR_WIDTH,
+} from './utils';
 
 export type AppLayoutSidebarDialogProps = PropsWithChildren<{}>;
 
@@ -73,7 +76,7 @@ export function AppLayoutSidebarDialog({
 								role="dialog"
 								aria-modal="true"
 								background="shade"
-								width={tokens.maxWidth.mobileMenu}
+								width={APP_LAYOUT_SIDEBAR_WIDTH}
 								css={{
 									position: 'fixed',
 									zIndex: tokens.zIndex.dialog,

--- a/packages/react/src/app-layout/utils.ts
+++ b/packages/react/src/app-layout/utils.ts
@@ -1,2 +1,4 @@
 // The breakpoint where we show the sidebar in a two column layout
 export const APP_LAYOUT_DESKTOP_BREAKPOINT = 'xl';
+
+export const APP_LAYOUT_SIDEBAR_WIDTH = '17.5rem'; // 280 px

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -89,7 +89,6 @@ const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
 	mobileMenu: '17.5rem', // 280 px
-	modalDialog: '45rem', // 720 px
 	field: {
 		xs: '5rem', // 80 px
 		sm: '8rem', // 128 px

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -88,7 +88,6 @@ const containerPadding = { xs: 0.75, md: 2 } as const;
 const maxWidth = {
 	bodyText: '42em',
 	container: '80rem', // 1280 px
-	mobileMenu: '17.5rem', // 280 px
 	field: {
 		xs: '5rem', // 80 px
 		sm: '8rem', // 128 px

--- a/packages/react/src/main-nav/NavContainer.tsx
+++ b/packages/react/src/main-nav/NavContainer.tsx
@@ -103,6 +103,8 @@ type NavContainerDialogProps = PropsWithChildren<{
 	palette?: BoxPalette;
 }>;
 
+const MOBILE_MAX_WIDTH = '17.5rem'; // 280 px
+
 function NavContainerDialog({
 	children,
 	close,
@@ -147,7 +149,7 @@ function NavContainerDialog({
 					left: 0,
 					bottom: 0,
 					width: '100%',
-					maxWidth: tokens.maxWidth.mobileMenu,
+					maxWidth: MOBILE_MAX_WIDTH,
 					padding: mapSpacing(1),
 					boxSizing: 'border-box',
 					overflowY: 'auto',

--- a/packages/react/src/modal/ModalDialog.tsx
+++ b/packages/react/src/modal/ModalDialog.tsx
@@ -18,6 +18,8 @@ export type ModalDialogProps = PropsWithChildren<{
 	title: string;
 }>;
 
+const MAX_WIDTH = '45rem'; // 720 px
+
 export const ModalDialog = ({
 	actions,
 	children,
@@ -36,7 +38,7 @@ export const ModalDialog = ({
 				paddingX={{ xs: 0.75, md: 1.5 }}
 				paddingY={{ xs: 1, md: 1.5 }}
 				gap={1}
-				maxWidth={tokens.maxWidth.modalDialog}
+				maxWidth={MAX_WIDTH}
 				css={{
 					position: 'relative',
 					margin: '0 auto',


### PR DESCRIPTION
## Describe your changes

In hindsight, these maxWidth tokens are coupled to specific components, and should not have been brought into the global tokens.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
