### PR TITLE
app-layout: Add `badgeLabel` prop

### DIFF
--- a/.changeset/tall-islands-rhyme.md
+++ b/.changeset/tall-islands-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Added new prop `badgeLabel` to `AppLayoutHeader` which can be used to indicate if an application is in a prerelease state.

--- a/packages/react/src/app-layout/AppLayout.stories.tsx
+++ b/packages/react/src/app-layout/AppLayout.stories.tsx
@@ -31,6 +31,7 @@ function AppLayoutTemplate({ focusMode = false }: AppLayoutProps) {
 					href="/"
 					heading="Export Service"
 					subLine="Supporting Australian agricultural exports"
+					badgeLabel="Beta"
 					logo={<Logo />}
 					accountDetails={{
 						href: '#account',

--- a/packages/react/src/app-layout/AppLayout.test.tsx
+++ b/packages/react/src/app-layout/AppLayout.test.tsx
@@ -26,6 +26,7 @@ function renderAppLayout({ focusMode }: { focusMode: boolean }) {
 				logo={<Logo />}
 				heading="Export Service"
 				subLine="Supporting Australian agricultural exports"
+				badgeLabel="Beta"
 				accountDetails={{
 					href: '/account/preferences',
 					name: 'Toto Wolff',

--- a/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.stories.tsx
@@ -14,6 +14,7 @@ const meta: Meta<typeof AppLayoutHeader> = {
 		heading: 'Export Service',
 		subLine: 'Supporting Australian agricultural exports',
 		logo: <Logo />,
+		badgeLabel: 'Beta',
 		accountDetails: {
 			href: '#account',
 			name: 'Toto Wolff',
@@ -39,6 +40,12 @@ export const FocusMode: Story = {
 			<AppLayoutHeader {...props} />
 		</AppLayout>
 	),
+};
+
+export const WithoutBadge: Story = {
+	args: {
+		badgeLabel: undefined,
+	},
 };
 
 export const WithoutSubline: Story = {

--- a/packages/react/src/app-layout/AppLayoutHeader.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeader.tsx
@@ -16,6 +16,8 @@ export type AppLayoutHeaderProps = {
 	heading: string;
 	/** Used to provide additional information to describe your website or service. */
 	subLine?: string;
+	/** Used to indicate if an application is in a prerelease state. */
+	badgeLabel?: string;
 	/** Details for the authenticated account. */
 	accountDetails?: {
 		/** The name of the authenticated user. */
@@ -33,6 +35,7 @@ export function AppLayoutHeader({
 	href,
 	logo,
 	subLine,
+	badgeLabel,
 	accountDetails,
 }: AppLayoutHeaderProps) {
 	return (
@@ -65,6 +68,7 @@ export function AppLayoutHeader({
 					href={href}
 					logo={logo}
 					subLine={subLine}
+					badgeLabel={badgeLabel}
 				/>
 				{accountDetails ? (
 					<AppLayoutHeaderAccount

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -1,3 +1,4 @@
+import { PropsWithChildren } from 'react';
 import { Flex } from '../flex';
 import {
 	boxPalette,
@@ -7,17 +8,20 @@ import {
 	useLinkComponent,
 } from '../core';
 import { Text } from '../text';
+import { Box } from '../box';
 
 export type AppLayoutHeaderBrandProps = {
 	href: string;
 	logo: JSX.Element;
 	heading: string;
 	subLine?: string;
+	badgeLabel?: string;
 };
 
 export function AppLayoutHeaderBrand({
 	heading,
 	subLine,
+	badgeLabel,
 	logo,
 	href,
 }: AppLayoutHeaderBrandProps) {
@@ -55,9 +59,14 @@ export function AppLayoutHeaderBrand({
 					},
 				}}
 			>
-				<Text fontSize="lg" fontWeight="bold">
-					{heading}
-				</Text>
+				<Flex alignItems="flex-start" gap={0.5}>
+					<Text fontSize="lg" fontWeight="bold">
+						{heading}
+					</Text>
+					{badgeLabel && (
+						<AppLayoutHeaderBrandBadge>{badgeLabel}</AppLayoutHeaderBrandBadge>
+					)}
+				</Flex>
 				{subLine ? (
 					<Text color="muted" fontSize="xs">
 						{subLine}
@@ -65,5 +74,33 @@ export function AppLayoutHeaderBrand({
 				) : null}
 			</Flex>
 		</Flex>
+	);
+}
+
+type AppLayoutHeaderBrandBadgeProps = PropsWithChildren<{}>;
+
+// Note: This component has been copied over from the `Header` component
+function AppLayoutHeaderBrandBadge({
+	children,
+}: AppLayoutHeaderBrandBadgeProps) {
+	return (
+		<Box
+			as="span"
+			fontWeight="bold"
+			paddingLeft={0.5}
+			paddingRight={0.5}
+			border
+			borderWidth="md"
+			css={{
+				// These values don't exist in our tokens
+				fontSize: '0.75rem',
+				paddingTop: '2px',
+				paddingBottom: '2px',
+				borderColor: boxPalette.foregroundText,
+				borderRadius: '2em',
+			}}
+		>
+			{children}
+		</Box>
 	);
 }

--- a/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderBrand.tsx
@@ -85,7 +85,6 @@ function AppLayoutHeaderBrandBadge({
 }: AppLayoutHeaderBrandBadgeProps) {
 	return (
 		<Box
-			as="span"
 			fontWeight="bold"
 			paddingLeft={0.5}
 			paddingRight={0.5}

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -57,6 +57,11 @@ exports[`AppLayout renders correctly 1`] = `
               >
                 Export Service
               </span>
+              <span
+                class="css-c5y8sd-boxStyles-AppLayoutHeaderBrandBadge"
+              >
+                Beta
+              </span>
             </div>
             <span
               class="css-1lp7dl8-boxStyles-Text"

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -57,11 +57,11 @@ exports[`AppLayout renders correctly 1`] = `
               >
                 Export Service
               </span>
-              <span
+              <div
                 class="css-c5y8sd-boxStyles-AppLayoutHeaderBrandBadge"
               >
                 Beta
-              </span>
+              </div>
             </div>
             <span
               class="css-1lp7dl8-boxStyles-Text"

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -49,11 +49,15 @@ exports[`AppLayout renders correctly 1`] = `
           <div
             class="css-1l41q-boxStyles-AppLayoutHeaderBrand"
           >
-            <span
-              class="css-1lv1g9v-boxStyles-Text"
+            <div
+              class="css-1qp4da6-boxStyles"
             >
-              Export Service
-            </span>
+              <span
+                class="css-1lv1g9v-boxStyles-Text"
+              >
+                Export Service
+              </span>
+            </div>
             <span
               class="css-1lp7dl8-boxStyles-Text"
             >


### PR DESCRIPTION
## Describe your changes

Added new prop `badgeLabel` to `AppLayoutHeader` which can be used to indicate if an application is in a prerelease state.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1241/storybook/index.html?path=/story/layout-applayout--default)

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).