### PR TITLE
popover/filter-drawer: Use overflow auto

### DIFF
--- a/packages/react/src/_popover/Popover.tsx
+++ b/packages/react/src/_popover/Popover.tsx
@@ -26,7 +26,7 @@ export const Popover = forwardRefWithAs<'div', PopoverProps>(function Popover(
 			rounded
 			css={{
 				position: 'relative',
-				overflowY: 'scroll',
+				overflowY: 'auto',
 				boxShadow: '0 1px 1px rgba(0, 0, 0, 0.3)', // TODO Tokenize
 				zIndex: tokens.zIndex.popover,
 			}}

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Autocomplete renders correctly 1`] = `
       />
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-1br2jf0-boxStyles-Popover"
+        class="css-xh5q2i-boxStyles-Popover"
         id="downshift-0-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`Combobox renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-1br2jf0-boxStyles-Popover"
+        class="css-xh5q2i-boxStyles-Popover"
         id="downshift-0-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -77,7 +77,7 @@ exports[`ComboboxAsync renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-1br2jf0-boxStyles-Popover"
+        class="css-xh5q2i-boxStyles-Popover"
         id="downshift-0-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-1br2jf0-boxStyles-Popover"
+        class="css-xh5q2i-boxStyles-Popover"
         id="downshift-0-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ComboboxMulti renders correctly 1`] = `
       </div>
       <ul
         aria-labelledby="downshift-0-label"
-        class="css-1br2jf0-boxStyles-Popover"
+        class="css-xh5q2i-boxStyles-Popover"
         id="downshift-0-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"

--- a/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawerDialog.tsx
@@ -41,7 +41,7 @@ export function FilterDrawerDialog({
 					marginLeft: 'auto',
 					zIndex: tokens.zIndex.dialog,
 					[tokens.mediaQuery.max.xs]: {
-						overflowY: 'scroll',
+						overflowY: 'auto',
 					},
 				}}
 				style={style}

--- a/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
+++ b/packages/react/src/filter-drawer/__snapshots__/FilterDrawer.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FilterDrawer renders correctly 1`] = `
       <div
         aria-labelledby="filter-drawer-:r0:-title"
         aria-modal="true"
-        class="css-14wnhfz-boxStyles-FilterDrawerDialog"
+        class="css-8vg97b-boxStyles-FilterDrawerDialog"
         role="dialog"
         style="transform: translateX(100%);"
       >


### PR DESCRIPTION
## Describe your changes

Follow up to PRs #1206 and #1207. 

This PR replaces `overflowY: scroll` with `overflowY: auto` to remove the scrollbars on windows when they are not required.

No changeset required as these components have not been released yet.

| Before | After |
|--------|--------|
| <img width="416" alt="Screenshot 2023-07-07 at 3 08 21 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/7baaf078-0d80-4ff8-b99e-2a2bb576128e"> | <img width="397" alt="Screenshot 2023-07-07 at 3 08 07 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/a2f5cda1-b253-49d1-a5ec-4d342d8ab729"> |