### PR TITLE
AgDS Beta v1.8.0 release notes

### DIFF
--- a/docs/content/updates/2023-07-14.mdx
+++ b/docs/content/updates/2023-07-14.mdx
@@ -1,0 +1,25 @@
+---
+date: 14th June 2023
+title: AgDS Beta v1.8.0 release
+description: Initial release of the Tabs component.
+---
+
+## Updates
+
+### [Button](/components/button)
+
+- Extended `BaseButton` to support `onKeyDown`, `onBlur`, `onFocus`, `role` and `tabIndex` props ([#PR 1232](https://github.com/steelthreads/agds-next/pull/1232))
+
+### [Tabs](/components/tabs)
+
+- Initial release of the [Tabs](/components/tabs) component ([#PR 1232](https://github.com/steelthreads/agds-next/pull/1232))
+
+## Released packages
+
+```sh
+"@ag.ds-next/react": "1.8.0"
+```
+
+## Full Changelog
+
+Aside from the complete release notes on the @ag.ds-next website, you can also view the verbose change log in the [related PR](https://github.com/steelthreads/agds-next/pull/1259) for this release.


### PR DESCRIPTION
## Describe your changes

AgDS Beta v1.8.0 release notes

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1262/updates/2023-07-14)