### PR TITLE
date-picker: Fix click outside issue

### DIFF
--- a/.changeset/sixty-melons-shake.md
+++ b/.changeset/sixty-melons-shake.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+date-picker: Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover.
+
+date-range-picker: Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover.

--- a/packages/react/src/date-picker/Calendar.tsx
+++ b/packages/react/src/date-picker/Calendar.tsx
@@ -60,14 +60,7 @@ export function CalendarRange({
 	...props
 }: CalendarRangeProps) {
 	return (
-		<FocusLock
-			autoFocus={false}
-			onDeactivation={() => {
-				// https://github.com/theKashey/react-focus-lock#unmounting-and-focus-management
-				if (!returnFocusRef) return;
-				window.setTimeout(() => returnFocusRef.current?.focus(), 0);
-			}}
-		>
+		<FocusLock autoFocus={false} returnFocus>
 			<CalendarContainer range={true}>
 				<CalendarLabelContext.Provider value={{ yearRange }}>
 					<DayPicker mode="range" {...defaultDayPickerProps} {...props} />

--- a/packages/react/src/date-picker/Calendar.tsx
+++ b/packages/react/src/date-picker/Calendar.tsx
@@ -36,7 +36,7 @@ export type CalendarSingleProps = Omit<
 
 export function CalendarSingle({ yearRange, ...props }: CalendarSingleProps) {
 	return (
-		<FocusLock autoFocus={false}>
+		<FocusLock autoFocus={false} returnFocus>
 			<CalendarContainer range={false}>
 				<CalendarLabelContext.Provider value={{ yearRange }}>
 					<DayPicker mode="single" {...defaultDayPickerProps} {...props} />

--- a/packages/react/src/date-picker/Calendar.tsx
+++ b/packages/react/src/date-picker/Calendar.tsx
@@ -36,7 +36,7 @@ export type CalendarSingleProps = Omit<
 
 export function CalendarSingle({ yearRange, ...props }: CalendarSingleProps) {
 	return (
-		<FocusLock autoFocus={false} returnFocus>
+		<FocusLock autoFocus={false}>
 			<CalendarContainer range={false}>
 				<CalendarLabelContext.Provider value={{ yearRange }}>
 					<DayPicker mode="single" {...defaultDayPickerProps} {...props} />
@@ -60,7 +60,14 @@ export function CalendarRange({
 	...props
 }: CalendarRangeProps) {
 	return (
-		<FocusLock autoFocus={false} returnFocus>
+		<FocusLock
+			autoFocus={false}
+			onDeactivation={() => {
+				// https://github.com/theKashey/react-focus-lock#unmounting-and-focus-management
+				if (!returnFocusRef) return;
+				window.setTimeout(() => returnFocusRef.current?.focus(), 0);
+			}}
+		>
 			<CalendarContainer range={true}>
 				<CalendarLabelContext.Provider value={{ yearRange }}>
 					<DayPicker mode="range" {...defaultDayPickerProps} {...props} />

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -90,10 +90,10 @@ export const DatePicker = ({
 	maxWidth = 'md',
 	...props
 }: DatePickerProps) => {
+	const triggerRef = useRef<HTMLButtonElement>(null);
+
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
 	const toggleCalendar = isCalendarOpen ? closeCalendar : openCalendar;
-
-	const triggerRef = useRef<HTMLButtonElement>(null);
 
 	const popover = usePopover();
 

--- a/packages/react/src/date-picker/DatePicker.tsx
+++ b/packages/react/src/date-picker/DatePicker.tsx
@@ -5,6 +5,7 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from 'react';
 import { SelectSingleEventHandler } from 'react-day-picker';
@@ -90,6 +91,9 @@ export const DatePicker = ({
 	...props
 }: DatePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
+	const toggleCalendar = isCalendarOpen ? closeCalendar : openCalendar;
+
+	const triggerRef = useRef<HTMLButtonElement>(null);
 
 	const popover = usePopover();
 
@@ -141,7 +145,7 @@ export const DatePicker = ({
 		if (isCalendarOpen) closeCalendar();
 	}, [isCalendarOpen, closeCalendar]);
 
-	useClickOutside([popover.popoverRef], handleClickOutside);
+	useClickOutside([popover.popoverRef, triggerRef], handleClickOutside);
 
 	// Close the calendar when the user presses the escape key
 	useEffect(() => {
@@ -176,7 +180,8 @@ export const DatePicker = ({
 				ref={inputRef}
 				value={inputValue}
 				onChange={onInputChange}
-				buttonOnClick={openCalendar}
+				buttonRef={triggerRef}
+				buttonOnClick={toggleCalendar}
 			/>
 			{isCalendarOpen && (
 				<Popover {...popover.getPopoverProps()}>

--- a/packages/react/src/date-picker/DatePickerInput.tsx
+++ b/packages/react/src/date-picker/DatePickerInput.tsx
@@ -14,7 +14,7 @@ export type DateInputProps = Omit<TextInputProps, 'invalid'> & {
 		/** If true, only the input element will be rendered in an invalids state. */
 		input: boolean;
 	};
-	buttonRef?: RefObject<HTMLButtonElement>;
+	buttonRef: RefObject<HTMLButtonElement>;
 	buttonOnClick: MouseEventHandler<HTMLButtonElement>;
 };
 

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -110,29 +110,21 @@ export const DateRangePicker = ({
 	yearRange,
 }: DateRangePickerProps) => {
 	const [isCalendarOpen, openCalendar, closeCalendar] = useTernaryState(false);
+	const toggleCalendar = isCalendarOpen ? closeCalendar : openCalendar;
+
 	const [inputMode, setInputMode] = useState<'from' | 'to'>();
 
 	const fromTriggerRef = useRef<HTMLButtonElement>(null);
 	const toTriggerRef = useRef<HTMLButtonElement>(null);
 
 	function onFromTriggerClick() {
-		if (isCalendarOpen) {
-			closeCalendar();
-			setInputMode(undefined);
-		} else {
-			setInputMode('from');
-			openCalendar();
-		}
+		setInputMode('from');
+		toggleCalendar();
 	}
 
 	function onToTriggerClick() {
-		if (isCalendarOpen) {
-			closeCalendar();
-			setInputMode(undefined);
-		} else {
-			setInputMode('to');
-			openCalendar();
-		}
+		setInputMode('to');
+		toggleCalendar();
 	}
 
 	const popover = usePopover();
@@ -351,6 +343,9 @@ export const DateRangePicker = ({
 							onSelect={onSelect}
 							numberOfMonths={numberOfMonths}
 							disabled={disabledCalendarDays}
+							returnFocusRef={
+								inputMode === 'from' ? fromTriggerRef : toTriggerRef
+							}
 							yearRange={yearRange}
 						/>
 					</Popover>

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -115,15 +115,23 @@ export const DateRangePicker = ({
 	const fromTriggerRef = useRef<HTMLButtonElement>(null);
 	const toTriggerRef = useRef<HTMLButtonElement>(null);
 
-	const onFromTriggerClick = useCallback(() => {
-		setInputMode('from');
-		openCalendar();
-	}, [openCalendar]);
+	function onFromTriggerClick() {
+		if (isCalendarOpen) {
+			closeCalendar();
+		} else {
+			setInputMode('from');
+			openCalendar();
+		}
+	}
 
-	const onToTriggerClick = useCallback(() => {
-		setInputMode('to');
-		openCalendar();
-	}, [openCalendar]);
+	function onToTriggerClick() {
+		if (isCalendarOpen) {
+			closeCalendar();
+		} else {
+			setInputMode('to');
+			openCalendar();
+		}
+	}
 
 	const popover = usePopover();
 
@@ -239,7 +247,10 @@ export const DateRangePicker = ({
 		if (isCalendarOpen) closeCalendar();
 	}, [isCalendarOpen, closeCalendar]);
 
-	useClickOutside([popover.popoverRef], handleClickOutside);
+	useClickOutside(
+		[popover.popoverRef, fromTriggerRef, toTriggerRef],
+		handleClickOutside
+	);
 
 	// Close the calendar when the user presses the escape key
 	useEffect(() => {
@@ -350,10 +361,10 @@ export const DateRangePicker = ({
 	);
 };
 
-export const useDateRangePickerIds = (idProp?: string) => {
+export function useDateRangePickerIds(idProp?: string) {
 	const autoId = useId(idProp);
 	const fieldsetId = idProp ? idProp : `date-range-picker-${autoId}`;
 	const hintId = `date-range-picker-${autoId}-hint`;
 	const messageId = `date-range-picker-${autoId}-message`;
 	return { fieldsetId, hintId, messageId };
-};
+}

--- a/packages/react/src/date-range-picker/DateRangePicker.tsx
+++ b/packages/react/src/date-range-picker/DateRangePicker.tsx
@@ -118,6 +118,7 @@ export const DateRangePicker = ({
 	function onFromTriggerClick() {
 		if (isCalendarOpen) {
 			closeCalendar();
+			setInputMode(undefined);
 		} else {
 			setInputMode('from');
 			openCalendar();
@@ -127,6 +128,7 @@ export const DateRangePicker = ({
 	function onToTriggerClick() {
 		if (isCalendarOpen) {
 			closeCalendar();
+			setInputMode(undefined);
 		} else {
 			setInputMode('to');
 			openCalendar();
@@ -349,9 +351,6 @@ export const DateRangePicker = ({
 							onSelect={onSelect}
 							numberOfMonths={numberOfMonths}
 							disabled={disabledCalendarDays}
-							returnFocusRef={
-								inputMode === 'from' ? fromTriggerRef : toTriggerRef
-							}
 							yearRange={yearRange}
 						/>
 					</Popover>


### PR DESCRIPTION
## Describe your changes

This is based off PR #1266

Clicking the calendar button trigger while the calendar popover is open will now close the calendar popover.

### Before

https://github.com/steelthreads/agds-next/assets/6265154/5f9606d6-9a6f-441b-a3f3-b70d2159374e

### After

https://github.com/steelthreads/agds-next/assets/6265154/6ab85730-8acd-475e-9864-a99d062e5d84
