### PR TITLE
docs: Enable overflow in live code snippets

### DIFF
--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -107,7 +107,13 @@ function LiveCode({
 	);
 
 	return (
-		<Card className={proseBlockClassname}>
+		<Card
+			className={proseBlockClassname}
+			css={{
+				// Code snippets with popovers (date picker, dropdown menu etc) need overflow
+				overflow: 'visible',
+			}}
+		>
 			{exampleContentHeadingType && (
 				<CardHeader>
 					<Heading type={exampleContentHeadingType}>Example</Heading>


### PR DESCRIPTION
## Describe your changes

This PR fixes bug that was introduced in #1239.

| Before | After |
|--------|--------|
| <img width="821" alt="Screenshot 2023-07-21 at 10 44 22 am" src="https://github.com/steelthreads/agds-next/assets/6265154/216417cd-74da-4490-9b15-03b2e4ecdbe3"> | <img width="814" alt="Screenshot 2023-07-21 at 10 47 25 am" src="https://github.com/steelthreads/agds-next/assets/6265154/183d2112-28cf-4af9-8b55-b8ea3befd8a3"> |