### PR TITLE
combobox: Add new `inputRef` prop

### DIFF
--- a/.changeset/fast-pans-flow.md
+++ b/.changeset/fast-pans-flow.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+autocomplete: Added new `inputRef` prop
+
+combobox: Added new `inputRef` prop

--- a/packages/react/src/autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/autocomplete/Autocomplete.test.tsx
@@ -1,28 +1,28 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
+import { useRef } from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, cleanup, act, waitFor } from '../../../../test-utils';
-import { Autocomplete } from './Autocomplete';
+import {
+	render,
+	cleanup,
+	act,
+	waitFor,
+	renderHook,
+} from '../../../../test-utils';
+import { STATE_OPTIONS, Option } from '../combobox/test-utils';
+import { Autocomplete, AutocompleteProps } from './Autocomplete';
 
 afterEach(cleanup);
 
-const mockLoadOptions = jest.fn().mockResolvedValue([
-	{ label: 'Australian Capital Territory', value: 'act' },
-	{ label: 'New South Wales', value: 'nsw' },
-	{ label: 'Northern Territory', value: 'nt' },
-	{ label: 'Queensland', value: 'qld' },
-	{ label: 'South Australia', value: 'sa' },
-	{ label: 'Tasmania', value: 'tas' },
-	{ label: 'Victoria', value: 'vic' },
-	{ label: 'Western Australia', value: 'wa' },
-]);
+const mockLoadOptions = jest.fn().mockResolvedValue(STATE_OPTIONS);
 
-function renderAutocomplete() {
+function renderAutocomplete(props?: Partial<AutocompleteProps<Option>>) {
 	return render(
 		<Autocomplete
 			label="Find your state"
 			hint="Start typing to see results"
 			loadOptions={mockLoadOptions}
+			{...props}
 		/>
 	);
 }
@@ -80,5 +80,15 @@ describe('Autocomplete', () => {
 
 		// Expect the input to be updated
 		expect(input.value).toBe('');
+	});
+
+	it('accepts `inputRef` prop', () => {
+		const { result } = renderHook(() => useRef<HTMLInputElement>(null));
+		const inputRef = result.current;
+		const id = 'test-id';
+		renderAutocomplete({ inputRef, id });
+		expect(inputRef.current).toBeInTheDocument();
+		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+		expect(inputRef.current?.id).toBe(id);
 	});
 });

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -1,26 +1,21 @@
+import { useRef } from 'react';
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
+import { renderHook } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, cleanup, act } from '../../../../test-utils';
-import { Combobox } from './Combobox';
+import { Combobox, ComboboxProps } from './Combobox';
+import { STATE_OPTIONS, Option } from './test-utils';
 
 afterEach(cleanup);
 
-function renderCombobox() {
+function renderCombobox(props?: Partial<ComboboxProps<Option>>) {
 	return render(
 		<Combobox
 			label="Find your state"
 			hint="Start typing to see results"
-			options={[
-				{ label: 'Australian Capital Territory', value: 'act' },
-				{ label: 'New South Wales', value: 'nsw' },
-				{ label: 'Northern Territory', value: 'nt' },
-				{ label: 'Queensland', value: 'qld' },
-				{ label: 'South Australia', value: 'sa' },
-				{ label: 'Tasmania', value: 'tas' },
-				{ label: 'Victoria', value: 'vic' },
-				{ label: 'Western Australia', value: 'wa' },
-			]}
+			options={STATE_OPTIONS}
+			{...props}
 		/>
 	);
 }
@@ -64,5 +59,15 @@ describe('Combobox', () => {
 		expect(options[0].textContent).toBe('Australian Capital Territory');
 		await userEvent.click(options[0]);
 		expect(input.value).toBe('Australian Capital Territory');
+	});
+
+	it('accepts `inputRef` prop', () => {
+		const { result } = renderHook(() => useRef<HTMLInputElement>(null));
+		const inputRef = result.current;
+		const id = 'test-id';
+		renderCombobox({ inputRef, id });
+		expect(inputRef.current).toBeInTheDocument();
+		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+		expect(inputRef.current?.id).toBe(id);
 	});
 });

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from 'react';
+import { ReactNode, Ref, useState } from 'react';
 import { useCombobox } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxBase } from './ComboboxBase';
@@ -8,7 +8,9 @@ import {
 	useComboboxInputId,
 } from './utils';
 
-export type ComboboxProps<Option extends DefaultComboboxOption> = {
+export type ComboboxProps<
+	Option extends DefaultComboboxOption = DefaultComboboxOption,
+> = {
 	/** Describes the purpose of the field. */
 	label: string;
 	/** If true, "(optional)" will never be appended to the label. */
@@ -41,6 +43,8 @@ export type ComboboxProps<Option extends DefaultComboboxOption> = {
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
 	/** Message to display when no options match the users search term. */
 	emptyResultsMessage?: string;
+	/** Ref to the input element. */
+	inputRef?: Ref<HTMLInputElement>;
 };
 
 export function Combobox<Option extends DefaultComboboxOption>({
@@ -48,6 +52,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 	value,
 	onChange,
 	options,
+	inputRef: inputRefProp,
 	...props
 }: ComboboxProps<Option>) {
 	const inputId = useComboboxInputId(id);
@@ -90,6 +95,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 			combobox={combobox}
 			inputItems={inputItems}
 			inputId={inputId}
+			inputRef={inputRefProp}
 			{...props}
 		/>
 	);

--- a/packages/react/src/combobox/ComboboxAsync.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.test.tsx
@@ -1,28 +1,28 @@
+import { useRef } from 'react';
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import userEvent from '@testing-library/user-event';
-import { render, cleanup, act, waitFor } from '../../../../test-utils';
-import { ComboboxAsync } from './ComboboxAsync';
+import {
+	render,
+	cleanup,
+	act,
+	waitFor,
+	renderHook,
+} from '../../../../test-utils';
+import { ComboboxAsync, ComboboxAsyncProps } from './ComboboxAsync';
+import { STATE_OPTIONS, Option } from './test-utils';
 
 afterEach(cleanup);
 
-const mockLoadOptions = jest.fn().mockResolvedValue([
-	{ label: 'Australian Capital Territory', value: 'act' },
-	{ label: 'New South Wales', value: 'nsw' },
-	{ label: 'Northern Territory', value: 'nt' },
-	{ label: 'Queensland', value: 'qld' },
-	{ label: 'South Australia', value: 'sa' },
-	{ label: 'Tasmania', value: 'tas' },
-	{ label: 'Victoria', value: 'vic' },
-	{ label: 'Western Australia', value: 'wa' },
-]);
+const mockLoadOptions = jest.fn().mockResolvedValue(STATE_OPTIONS);
 
-function renderComboboxAsync() {
+function renderComboboxAsync(props?: Partial<ComboboxAsyncProps<Option>>) {
 	return render(
 		<ComboboxAsync
 			label="Find your state"
 			hint="Start typing to see results"
 			loadOptions={mockLoadOptions}
+			{...props}
 		/>
 	);
 }
@@ -70,5 +70,15 @@ describe('ComboboxAsync', () => {
 
 		// Expect the input to be updated
 		expect(input.value).toBe('Queensland');
+	});
+
+	it('accepts `inputRef` prop', () => {
+		const { result } = renderHook(() => useRef<HTMLInputElement>(null));
+		const inputRef = result.current;
+		const id = 'test-id';
+		renderComboboxAsync({ inputRef, id });
+		expect(inputRef.current).toBeInTheDocument();
+		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+		expect(inputRef.current?.id).toBe(id);
 	});
 });

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import {
+	ReactNode,
+	RefObject,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import { useCombobox } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxBase } from './ComboboxBase';
@@ -48,6 +55,8 @@ export type ComboboxAsyncProps<Option extends DefaultComboboxOption> = {
 	showDropdownTrigger?: boolean;
 	/** If true, the dropdown will open when the user focuses on the element  */
 	openDropdownOnFocus?: boolean;
+	/** Ref to the input element. */
+	inputRef?: RefObject<HTMLInputElement>;
 };
 
 export function ComboboxAsync<Option extends DefaultComboboxOption>({
@@ -58,6 +67,7 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 	clearable = false,
 	showDropdownTrigger = true,
 	openDropdownOnFocus = true,
+	inputRef: inputRefProp,
 	...props
 }: ComboboxAsyncProps<Option>) {
 	const inputId = useComboboxInputId(id);
@@ -197,6 +207,7 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 			inputItems={state.inputItems}
 			showDropdownTrigger={showDropdownTrigger}
 			clearable={clearable}
+			inputRef={inputRefProp}
 			{...props}
 		/>
 	);

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -1,27 +1,26 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { render, cleanup } from '../../../../test-utils';
-import { ComboboxAsyncMulti } from './ComboboxAsyncMulti';
+import { useRef } from 'react';
+import { render, cleanup, renderHook } from '../../../../test-utils';
+import {
+	ComboboxAsyncMulti,
+	ComboboxAsyncMultiProps,
+} from './ComboboxAsyncMulti';
+import { STATE_OPTIONS, Option } from './test-utils';
 
 afterEach(cleanup);
 
-const mockLoadOptions = jest.fn().mockResolvedValue([
-	{ label: 'Australian Capital Territory', value: 'act' },
-	{ label: 'New South Wales', value: 'nsw' },
-	{ label: 'Northern Territory', value: 'nt' },
-	{ label: 'Queensland', value: 'qld' },
-	{ label: 'South Australia', value: 'sa' },
-	{ label: 'Tasmania', value: 'tas' },
-	{ label: 'Victoria', value: 'vic' },
-	{ label: 'Western Australia', value: 'wa' },
-]);
+const mockLoadOptions = jest.fn().mockResolvedValue(STATE_OPTIONS);
 
-function renderComboboxAsyncMulti() {
+function renderComboboxAsyncMulti(
+	props?: Partial<ComboboxAsyncMultiProps<Option>>
+) {
 	return render(
 		<ComboboxAsyncMulti
 			label="Find your state"
 			hint="Start typing to see results"
 			loadOptions={mockLoadOptions}
+			{...props}
 		/>
 	);
 }
@@ -44,5 +43,15 @@ describe('ComboboxAsyncMulti', () => {
 				'valid-id': 'off',
 			},
 		});
+	});
+
+	it('accepts `inputRef` prop', () => {
+		const { result } = renderHook(() => useRef<HTMLInputElement>(null));
+		const inputRef = result.current;
+		const id = 'test-id';
+		renderComboboxAsyncMulti({ inputRef, id });
+		expect(inputRef.current).toBeInTheDocument();
+		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+		expect(inputRef.current?.id).toBe(id);
 	});
 });

--- a/packages/react/src/combobox/ComboboxAsyncMulti.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.tsx
@@ -1,5 +1,6 @@
 import {
 	ReactNode,
+	Ref,
 	useCallback,
 	useEffect,
 	useMemo,
@@ -49,6 +50,8 @@ export type ComboboxAsyncMultiProps<Option extends DefaultComboboxOption> = {
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
 	/** Message to display when no options match the users search term. */
 	emptyResultsMessage?: string;
+	/** Ref to the input element. */
+	inputRef?: Ref<HTMLInputElement>;
 };
 
 export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
@@ -56,6 +59,7 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 	value,
 	onChange,
 	loadOptions: loadOptionsProp,
+	inputRef: inputRefProp,
 	...props
 }: ComboboxAsyncMultiProps<Option>) {
 	const inputId = useComboboxInputId(id);
@@ -245,6 +249,7 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 			selectedItems={selectedItems}
 			onClear={onClear}
 			inputRef={inputRef}
+			inputRefProp={inputRefProp}
 			clearable
 			{...props}
 		/>

--- a/packages/react/src/combobox/ComboboxAsyncMulti.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.tsx
@@ -59,7 +59,6 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 	value,
 	onChange,
 	loadOptions: loadOptionsProp,
-	inputRef: inputRefProp,
 	...props
 }: ComboboxAsyncMultiProps<Option>) {
 	const inputId = useComboboxInputId(id);
@@ -231,13 +230,6 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 		loadOptions(shouldLoadOptions);
 	}, [shouldLoadOptions, debouncedInputValue, loadOptionsProp]);
 
-	const inputRef = useRef<HTMLInputElement>(null);
-
-	const onClear = useCallback(() => {
-		setSelectedItems([]);
-		inputRef.current?.focus();
-	}, [setSelectedItems]);
-
 	return (
 		<ComboboxMultiBase
 			combobox={combobox}
@@ -247,9 +239,7 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 			loading={state.loading}
 			networkError={state.networkError}
 			selectedItems={selectedItems}
-			onClear={onClear}
-			inputRef={inputRef}
-			inputRefProp={inputRefProp}
+			setSelectedItems={setSelectedItems}
 			clearable
 			{...props}
 		/>

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from 'react';
+import { Fragment, Ref, ReactNode } from 'react';
 import { UseComboboxReturnValue } from 'downshift';
 import { FieldMaxWidth } from '../../core';
 import { Popover, usePopover } from '../../_popover';
@@ -34,12 +34,13 @@ type ComboboxBaseProps<Option extends DefaultComboboxOption> = {
 	showDropdownTrigger?: boolean;
 	clearable?: boolean;
 	// Downshift
-	combobox: UseComboboxReturnValue<Option>;
+	inputRef?: Ref<HTMLInputElement>;
 	loading?: boolean;
 	inputItems?: Option[];
 	networkError?: boolean;
 	emptyResultsMessage?: string;
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
+	combobox: UseComboboxReturnValue<Option>;
 };
 
 export function ComboboxBase<Option extends DefaultComboboxOption>({
@@ -62,6 +63,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	networkError,
 	combobox,
 	inputItems,
+	inputRef: inputRefProp,
 }: ComboboxBaseProps<Option>) {
 	const showClearButton = clearable && combobox.selectedItem;
 	const hasButtons = showDropdownTrigger || showClearButton;
@@ -105,6 +107,7 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 						disabled={disabled}
 						{...combobox.getInputProps({
 							...a11yProps,
+							ref: inputRefProp,
 							type: 'text',
 							name: inputName,
 						})}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -5,7 +5,6 @@ import {
 	useCallback,
 	MouseEvent,
 	useRef,
-	RefObject,
 } from 'react';
 import {
 	UseComboboxReturnValue,
@@ -58,15 +57,14 @@ type ComboboxMultiBaseProps<Option extends DefaultComboboxOption> = {
 	combobox: UseComboboxReturnValue<Option>;
 	multiSelection: UseMultipleSelectionReturnValue<Option>;
 	selectedItems: Option[];
-	onClear: () => void;
+	setSelectedItems: (value: Option[]) => void;
 	loading?: boolean;
 	inputItems?: Option[];
 	networkError?: boolean;
 	emptyResultsMessage?: string;
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
 	// input ref
-	inputRef: RefObject<HTMLInputElement>;
-	inputRefProp?: Ref<HTMLInputElement>;
+	inputRef?: Ref<HTMLInputElement>;
 };
 
 export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
@@ -88,11 +86,12 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 	combobox,
 	inputItems,
 	selectedItems,
+	setSelectedItems,
 	multiSelection,
-	onClear,
-	inputRef,
-	inputRefProp,
+	inputRef: inputRefProp,
 }: ComboboxMultiBaseProps<Option>) {
+	const inputRef = useRef<HTMLInputElement>(null);
+
 	const [isInputFocused, setInputFocused, setInputBlurred] =
 		useTernaryState(false);
 
@@ -130,6 +129,11 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 		},
 		[inputRef]
 	);
+
+	const onClear = useCallback(() => {
+		setSelectedItems([]);
+		inputRef.current?.focus();
+	}, [setSelectedItems]);
 
 	const inputRefs = inputRefProp
 		? mergeRefs([inputRef, inputRefProp])
@@ -190,10 +194,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 						<ComboboxButtonContainer>
 							{showClearButton && (
 								<Fragment>
-									<ComboboxClearButton
-										disabled={disabled}
-										onClick={() => onClear()}
-									/>
+									<ComboboxClearButton disabled={disabled} onClick={onClear} />
 									<ComboboxButtonDivider />
 								</Fragment>
 							)}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -1,10 +1,11 @@
 import {
 	Fragment,
 	ReactNode,
-	RefObject,
+	Ref,
 	useCallback,
 	MouseEvent,
 	useRef,
+	RefObject,
 } from 'react';
 import {
 	UseComboboxReturnValue,
@@ -16,6 +17,7 @@ import {
 	FieldMaxWidth,
 	fontGrid,
 	mapSpacing,
+	mergeRefs,
 	packs,
 	tokens,
 	useTernaryState,
@@ -57,12 +59,14 @@ type ComboboxMultiBaseProps<Option extends DefaultComboboxOption> = {
 	multiSelection: UseMultipleSelectionReturnValue<Option>;
 	selectedItems: Option[];
 	onClear: () => void;
-	inputRef: RefObject<HTMLInputElement>;
 	loading?: boolean;
 	inputItems?: Option[];
 	networkError?: boolean;
 	emptyResultsMessage?: string;
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
+	// input ref
+	inputRef: RefObject<HTMLInputElement>;
+	inputRefProp?: Ref<HTMLInputElement>;
 };
 
 export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
@@ -87,6 +91,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 	multiSelection,
 	onClear,
 	inputRef,
+	inputRefProp,
 }: ComboboxMultiBaseProps<Option>) {
 	const [isInputFocused, setInputFocused, setInputBlurred] =
 		useTernaryState(false);
@@ -125,6 +130,10 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 		},
 		[inputRef]
 	);
+
+	const inputRefs = inputRefProp
+		? mergeRefs([inputRef, inputRefProp])
+		: inputRef;
 
 	return (
 		<Field
@@ -168,7 +177,7 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 								{...a11yProps}
 								{...combobox.getInputProps(
 									multiSelection.getDropdownProps({
-										ref: inputRef,
+										ref: inputRefs,
 										type: 'text',
 										preventKeyAction: combobox.isOpen,
 										onFocus: setInputFocused,

--- a/packages/react/src/combobox/ComboboxMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.test.tsx
@@ -1,17 +1,21 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
-import { render, cleanup } from '../../../../test-utils';
-import { ComboboxMulti } from './ComboboxMulti';
+import { useRef } from 'react';
+import { render, cleanup, renderHook } from '../../../../test-utils';
+import { ComboboxMulti, ComboboxMultiProps } from './ComboboxMulti';
 import { COUNTRY_OPTIONS } from './test-utils';
 
 afterEach(cleanup);
 
-function renderComboboxMulti() {
+type Option = (typeof COUNTRY_OPTIONS)[number];
+
+function renderComboboxMulti(props?: Partial<ComboboxMultiProps<Option>>) {
 	return render(
 		<ComboboxMulti
 			label="Find your state"
 			hint="Start typing to see results"
 			options={COUNTRY_OPTIONS}
+			{...props}
 		/>
 	);
 }
@@ -34,5 +38,15 @@ describe('ComboboxMulti', () => {
 				'valid-id': 'off',
 			},
 		});
+	});
+
+	it('accepts `inputRef` prop', () => {
+		const { result } = renderHook(() => useRef<HTMLInputElement>(null));
+		const inputRef = result.current;
+		const id = 'test-id';
+		renderComboboxMulti({ inputRef, id });
+		expect(inputRef.current).toBeInTheDocument();
+		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
+		expect(inputRef.current?.id).toBe(id);
 	});
 });

--- a/packages/react/src/combobox/ComboboxMulti.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Ref, useCallback, useMemo, useRef, useState } from 'react';
+import { ReactNode, Ref, useCallback, useMemo, useState } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxMultiBase } from './ComboboxBase';
@@ -50,7 +50,6 @@ export function ComboboxMulti<Option extends DefaultComboboxOption>({
 	value,
 	onChange,
 	options,
-	inputRef: inputRefProp,
 	...props
 }: ComboboxMultiProps<Option>) {
 	const [inputValue, setInputValue] = useState('');
@@ -133,13 +132,6 @@ export function ComboboxMulti<Option extends DefaultComboboxOption>({
 		},
 	});
 
-	const inputRef = useRef<HTMLInputElement>(null);
-
-	const onClear = useCallback(() => {
-		setSelectedItems([]);
-		inputRef.current?.focus();
-	}, [setSelectedItems]);
-
 	return (
 		<ComboboxMultiBase
 			combobox={combobox}
@@ -147,9 +139,7 @@ export function ComboboxMulti<Option extends DefaultComboboxOption>({
 			inputItems={items}
 			inputId={inputId}
 			selectedItems={selectedItems}
-			onClear={onClear}
-			inputRef={inputRef}
-			inputRefProp={inputRefProp}
+			setSelectedItems={setSelectedItems}
 			{...props}
 		/>
 	);

--- a/packages/react/src/combobox/ComboboxMulti.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { ReactNode, Ref, useCallback, useMemo, useRef, useState } from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxMultiBase } from './ComboboxBase';
@@ -41,6 +41,8 @@ export type ComboboxMultiProps<Option extends DefaultComboboxOption> = {
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
 	/** Message to display when no options match the users search term. */
 	emptyResultsMessage?: string;
+	/** Ref to the input element. */
+	inputRef?: Ref<HTMLInputElement>;
 };
 
 export function ComboboxMulti<Option extends DefaultComboboxOption>({
@@ -48,6 +50,7 @@ export function ComboboxMulti<Option extends DefaultComboboxOption>({
 	value,
 	onChange,
 	options,
+	inputRef: inputRefProp,
 	...props
 }: ComboboxMultiProps<Option>) {
 	const [inputValue, setInputValue] = useState('');
@@ -146,6 +149,7 @@ export function ComboboxMulti<Option extends DefaultComboboxOption>({
 			selectedItems={selectedItems}
 			onClear={onClear}
 			inputRef={inputRef}
+			inputRefProp={inputRefProp}
 			{...props}
 		/>
 	);

--- a/packages/react/src/combobox/test-utils.ts
+++ b/packages/react/src/combobox/test-utils.ts
@@ -1,4 +1,4 @@
-export type Option = (typeof COUNTRY_OPTIONS)[number];
+export type Option = { label: string; value: string };
 
 export const COUNTRY_OPTIONS = [
 	'Afghanistan',
@@ -197,3 +197,14 @@ export const COUNTRY_OPTIONS = [
 	'Zambia',
 	'Zimbabwe',
 ].map((country) => ({ label: country, value: country }));
+
+export const STATE_OPTIONS = [
+	{ label: 'Australian Capital Territory', value: 'act' },
+	{ label: 'New South Wales', value: 'nsw' },
+	{ label: 'Northern Territory', value: 'nt' },
+	{ label: 'Queensland', value: 'qld' },
+	{ label: 'South Australia', value: 'sa' },
+	{ label: 'Tasmania', value: 'tas' },
+	{ label: 'Victoria', value: 'vic' },
+	{ label: 'Western Australia', value: 'wa' },
+];


### PR DESCRIPTION
## Describe your changes

Added new `inputRef` prop to Autocomplete and Combobox components. This allows consumers to pass refs to the underlying HTML input element, which is consistent  with our Date picker and Date range picker component.

As part of this PR, I have improved some of the test files by consolidating some duplicated code.

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).