### PR TITLE
Box: Remove 'focus' from supported text styles

### DIFF
--- a/.changeset/loud-keys-begin.md
+++ b/.changeset/loud-keys-begin.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+box: Remove 'focus' from supported text styles

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -55,7 +55,6 @@ function paletteStyles({ palette, dark, light }: PaletteProps) {
 export const foregroundColorMap = {
 	text: boxPalette.foregroundText,
 	action: boxPalette.foregroundAction,
-	focus: boxPalette.foregroundFocus,
 	muted: boxPalette.foregroundMuted,
 	accent: boxPalette.accent,
 	error: boxPalette.systemError,


### PR DESCRIPTION
'Focus' is the name of our system focus ring colour. It should not be exposed as a value for text elements.

Remove focus from foregroundColorMap to avoid it used for text elements

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

