### PR TITLE
notification-badge: Update usage

### DIFF
--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -310,10 +310,18 @@ exports[`AppLayout renders correctly 1`] = `
               <span>
                 Messages
               </span>
-              <span
-                class="css-uouzcn-boxStyles-Text-NotificationBadge"
-              >
-                6
+              <span>
+                <span
+                  aria-hidden="true"
+                  class="css-uouzcn-boxStyles-Text-NotificationBadge"
+                >
+                  6
+                </span>
+                <span
+                  class="css-avudkd-VisuallyHidden"
+                >
+                  , 6 unread
+                </span>
               </span>
             </a>
           </li>

--- a/packages/react/src/app-layout/test-utils.tsx
+++ b/packages/react/src/app-layout/test-utils.tsx
@@ -1,4 +1,5 @@
 import { NotificationBadge } from '../notification-badge';
+import { VisuallyHidden } from '../a11y';
 import {
 	ChartLineIcon,
 	EmailIcon,
@@ -38,7 +39,12 @@ export const navigationItems = [
 			label: 'Messages',
 			icon: EmailIcon,
 			href: '/account/messages',
-			endElement: <NotificationBadge tone="action" value={6} max={99} />,
+			endElement: (
+				<span>
+					<NotificationBadge tone="action" value={6} max={99} aria-hidden />
+					<VisuallyHidden>, 6 unread</VisuallyHidden>
+				</span>
+			),
 		},
 		{
 			label: 'Account settings',

--- a/packages/react/src/main-nav/MainNav.stories.tsx
+++ b/packages/react/src/main-nav/MainNav.stories.tsx
@@ -1,4 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Fragment } from 'react';
+import { VisuallyHidden } from '../a11y';
 import { AvatarIcon } from '../icon';
 import { NotificationBadge } from '../notification-badge';
 import { MainNav } from './MainNav';
@@ -43,7 +45,12 @@ export const SecondaryLinks: Story = {
 			{
 				href: '#messages',
 				label: 'Messages',
-				endElement: <NotificationBadge tone="action" value={5} />,
+				endElement: (
+					<Fragment>
+						<NotificationBadge tone="action" value={5} aria-hidden />
+						<VisuallyHidden>, 5 unread</VisuallyHidden>
+					</Fragment>
+				),
 			},
 			{
 				href: '#sign-in',
@@ -88,7 +95,12 @@ export const EndElement: Story = {
 			{
 				href: '#issues',
 				label: 'Issues',
-				endElement: <NotificationBadge tone="action" value={5} />,
+				endElement: (
+					<Fragment>
+						<NotificationBadge tone="action" value={5} aria-hidden />
+						<VisuallyHidden>, 5 notifications</VisuallyHidden>
+					</Fragment>
+				),
 			},
 			{ href: '#pull-requests', label: 'Pull requests' },
 			{ href: '#security', label: 'Security' },

--- a/packages/react/src/sub-nav/SubNav.stories.tsx
+++ b/packages/react/src/sub-nav/SubNav.stories.tsx
@@ -1,4 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Fragment } from 'react';
+import { VisuallyHidden } from '../a11y';
 import { Box } from '../box';
 import { NotificationBadge } from '../notification-badge';
 import { SubNav } from './SubNav';
@@ -43,7 +45,12 @@ export const WithEndElements: Story = {
 			{
 				href: '/code',
 				label: 'Code',
-				endElement: <NotificationBadge value={5} tone="action" />,
+				endElement: (
+					<Fragment>
+						<NotificationBadge value={5} tone="action" aria-hidden />
+						<VisuallyHidden>, 5 notifications</VisuallyHidden>
+					</Fragment>
+				),
 			},
 			{ href: '/content', label: 'Content' },
 			{ href: '/accessibility', label: 'Accessibility' },

--- a/packages/react/src/tabs/Tabs.stories.tsx
+++ b/packages/react/src/tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react';
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { SiteLayout } from '../../../../docs/content/templates/__shared/SiteLayout';
+import { VisuallyHidden } from '../a11y';
 import { Box } from '../box';
 import { Breadcrumbs } from '../breadcrumbs';
 import { Button } from '../button';
@@ -219,7 +220,15 @@ export const WithEndElements: StoryObj = {
 					<TabButton>Tab 2</TabButton>
 					<TabButton
 						endElement={
-							<NotificationBadge value={100} max={99} tone="action" />
+							<Fragment>
+								<NotificationBadge
+									value={100}
+									max={99}
+									tone="action"
+									aria-hidden
+								/>
+								<VisuallyHidden>, 100 notifications</VisuallyHidden>
+							</Fragment>
 						}
 					>
 						Tab 3


### PR DESCRIPTION
## Describe your changes

Updated usage of `NotificationBadge` to include an accessible label when used in components as the `endElement` . This update will provides a better experience for screen readers.

An example of this update is the "App layout" example, which has the menu item "Messages" with a Notification badge. Instead of announcing "Messages 6", it will now announce "Messages, 6 unread".

[View preview (App layout)](https://design-system.agriculture.gov.au/pr-preview/pr-1290/storybook/index.html?path=/story/layout-applayout--default)

I have also done this in Ag Common https://github.com/steelthreads/ag-common/pull/67