### PR TITLE
checkbox/radio: Fix indicator bug

### DIFF
--- a/.changeset/bright-pillows-shout.md
+++ b/.changeset/bright-pillows-shout.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+checkbox: Updated CSS for toggling the display of the checkbox indicator which stops the checkbox from shifting slightly in certain browsers
+
+radio: Updated CSS for toggling the display of the radio indicator for consistency with the `Checkbox` component

--- a/packages/react/src/checkbox/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/CheckboxIndicator.tsx
@@ -62,7 +62,6 @@ const CheckboxIcon = ({ size }: { size: Spacing }) => (
 		css={{
 			width: mapSpacing(size),
 			height: mapSpacing(size),
-			display: 'none',
 			color: 'currentcolor',
 			fill: 'none',
 			stroke: 'currentColor',

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -14,7 +14,8 @@ export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
 					// When this component is focused, outline the `CheckboxIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked, show the indicators active state
-					'&:checked ~ span > svg': { display: 'block' },
+					'~ span > svg': { opacity: 0 },
+					'&:checked ~ span > svg': { opacity: 1 },
 				}}
 				{...props}
 			/>

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Checkbox renders correctly 1`] = `
     class="css-hp3wbe-boxStyles-CheckboxContainer"
   >
     <input
-      class="css-ovafqv-CheckboxInput"
+      class="css-2fffox-CheckboxInput"
       data-testid="example"
       name="my-checkbox"
       type="checkbox"
@@ -16,7 +16,7 @@ exports[`Checkbox renders correctly 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="css-umoisd-CheckboxIcon"
+        class="css-po1mz2-CheckboxIcon"
         clip-rule="evenodd"
         focusable="false"
         role="img"

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-a"
               type="checkbox"
             />
@@ -43,7 +43,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -68,7 +68,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-b"
               type="checkbox"
             />
@@ -77,7 +77,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -102,7 +102,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-c"
               type="checkbox"
             />
@@ -111,7 +111,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -136,7 +136,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-d"
               type="checkbox"
             />
@@ -145,7 +145,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -250,7 +250,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-a"
               type="checkbox"
             />
@@ -259,7 +259,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -286,7 +286,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-b"
               type="checkbox"
             />
@@ -295,7 +295,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -322,7 +322,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-c"
               type="checkbox"
             />
@@ -331,7 +331,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -358,7 +358,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-ovafqv-CheckboxInput"
+              class="css-2fffox-CheckboxInput"
               data-testid="option-d"
               type="checkbox"
             />
@@ -367,7 +367,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="css-umoisd-CheckboxIcon"
+                class="css-po1mz2-CheckboxIcon"
                 clip-rule="evenodd"
                 focusable="false"
                 role="img"
@@ -429,7 +429,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
           >
             <input
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-a"
               type="radio"
             />
@@ -437,7 +437,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -450,7 +450,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
           >
             <input
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-b"
               type="radio"
             />
@@ -458,7 +458,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -471,7 +471,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
           >
             <input
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-c"
               type="radio"
             />
@@ -479,7 +479,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -492,7 +492,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
             class="css-6pplfb-boxStyles-RadioContainer"
           >
             <input
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-d"
               type="radio"
             />
@@ -500,7 +500,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
               class="css-osss6w-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -593,7 +593,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r7:-message"
               aria-invalid="true"
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-a"
               type="radio"
             />
@@ -601,7 +601,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -616,7 +616,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r7:-message"
               aria-invalid="true"
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-b"
               type="radio"
             />
@@ -624,7 +624,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -639,7 +639,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r7:-message"
               aria-invalid="true"
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-c"
               type="radio"
             />
@@ -647,7 +647,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span
@@ -662,7 +662,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r7:-message"
               aria-invalid="true"
-              class="css-1gurbk-RadioInput"
+              class="css-o6md8t-RadioInput"
               data-testid="option-d"
               type="radio"
             />
@@ -670,7 +670,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
               class="css-ib2w54-boxStyles-RadioIndicator"
             >
               <span
-                class="css-1f428uy-boxStyles-RadioIndicator"
+                class="css-1sqol0e-boxStyles-RadioIndicator"
               />
             </span>
             <span

--- a/packages/react/src/radio/RadioIndicator.tsx
+++ b/packages/react/src/radio/RadioIndicator.tsx
@@ -49,7 +49,6 @@ export function RadioIndicator({
 				height="calc(100% - 0.5rem)"
 				highContrastOutline
 				css={{
-					display: 'none',
 					borderRadius: '100%',
 					backgroundColor: boxPalette.foregroundText,
 

--- a/packages/react/src/radio/RadioInput.tsx
+++ b/packages/react/src/radio/RadioInput.tsx
@@ -14,7 +14,8 @@ export const RadioInput = forwardRef<HTMLInputElement, RadioInputProps>(
 					// When this component is focused, outline the indicator (`RadioIndicator` and `CheckboxIndicator`)
 					'&:focus ~ span:first-of-type': packs.outline,
 					// When this component is checked, show the indicators active state
-					'&:checked ~ span > *': { display: 'block' },
+					'~ span > span': { opacity: 0 },
+					'&:checked ~ span > span': { opacity: 1 },
 				}}
 				{...props}
 			/>

--- a/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
+++ b/packages/react/src/radio/__snapshots__/Radio.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Radio renders correctly 1`] = `
     class="css-6pplfb-boxStyles-RadioContainer"
   >
     <input
-      class="css-1gurbk-RadioInput"
+      class="css-o6md8t-RadioInput"
       data-testid="example"
       name="my-radio"
       type="radio"
@@ -15,7 +15,7 @@ exports[`Radio renders correctly 1`] = `
       class="css-osss6w-boxStyles-RadioIndicator"
     >
       <span
-        class="css-1f428uy-boxStyles-RadioIndicator"
+        class="css-1sqol0e-boxStyles-RadioIndicator"
       />
     </span>
     <span


### PR DESCRIPTION
## Describe your changes

**Checkbox**

Updated CSS for toggling the display of the checkbox indicator which stops the checkbox from shifting slightly in certain browsers.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1291/components/checkbox)

**Radio** 

Updated CSS for toggling the display of the radio indicator for consistency with the `Checkbox` component.

**Note These changes have no effect on the accessibility of either of these components as the elements taht are being toggled on/off are already hidden from the accessibility tree.**

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1291/components/radio)

### Before

https://github.com/steelthreads/agds-next/assets/6265154/8c8b23b0-347b-480a-a2c4-b06800e4f878

### After

https://github.com/steelthreads/agds-next/assets/6265154/d4cf8e3b-6ee3-435a-84f2-189e4aee2b39

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).