### PR TITLE
dropdown-menu: Decrease gap between icon and label

### DIFF
--- a/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
@@ -83,7 +83,7 @@ export const DropdownMenuItem = forwardRefWithAs<'div', DropdownMenuItemProps>(
 				}}
 				{...props}
 			>
-				<Flex alignItems="center" gap={1}>
+				<Flex alignItems="center" gap={0.75}>
 					{Icon ? <Icon color="inherit" size="md" /> : null}
 					<span>{children}</span>
 				</Flex>

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <svg
           aria-hidden="true"
@@ -85,7 +85,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <svg
           aria-hidden="true"
@@ -129,7 +129,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <svg
           aria-hidden="true"
@@ -212,7 +212,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <span>
           About
@@ -227,7 +227,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <span>
           Contact
@@ -411,7 +411,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <span>
           Item 1
@@ -425,7 +425,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <span>
           Item 2
@@ -439,7 +439,7 @@ exports[`DropdownMenu renders correctly 1`] = `
       tabindex="-1"
     >
       <div
-        class="css-4cj67k-boxStyles"
+        class="css-16gtkc6-boxStyles"
       >
         <span>
           Item 3


### PR DESCRIPTION
## Describe your changes

Decreased the gap between icons and labels in the Dropdown Menu component from `1rem` to `0.75rem`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1301/storybook/index.html?path=/story/layout-dropdownmenu--icons-and-badges)

> No changeset required as this component has not been released yet

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).