### PR TITLE
app-layout: Decrease gap between icon and label

### DIFF
--- a/.changeset/purple-ravens-grow.md
+++ b/.changeset/purple-ravens-grow.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-app-layout: Decreased the gap in the sidebar between icons and labels from 1rem to 0.75rem
+app-layout: Decreased the gap between icons and labels in the sidebar from `1rem` to `0.75rem`

--- a/.changeset/purple-ravens-grow.md
+++ b/.changeset/purple-ravens-grow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Decreased the gap in the sidebar between icons and labels from 1rem to 0.75rem

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -116,7 +116,7 @@ function AppLayoutSidebarNavItemInner({
 				' a, button': {
 					display: 'flex',
 					alignItems: 'center',
-					gap: mapSpacing(1),
+					gap: mapSpacing(0.75),
 					width: '100%',
 					boxSizing: 'border-box',
 					paddingLeft: mapSpacing(1.5),
@@ -151,7 +151,7 @@ function AppLayoutSidebarNavItemInner({
 					'&:hover': {
 						background: boxPalette.backgroundShadeAlt,
 						color: boxPalette.foregroundText,
-						'& span:first-of-type': {
+						'& > span:first-of-type': {
 							textDecoration: 'underline',
 						},
 					},

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`AppLayout renders correctly 1`] = `
           class="css-o80hmi-boxStyles"
         >
           <li
-            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
+            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/"
@@ -195,7 +195,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1y1qeh5-AppLayoutSidebarNavItemInner"
+            class="css-tgjblb-AppLayoutSidebarNavItemInner"
           >
             <a
               aria-current="page"
@@ -222,7 +222,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
+            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/intelligence"
@@ -248,7 +248,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
+            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/compliance"
@@ -287,7 +287,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-1c7lu52-AppLayoutSidebarNavItemInner"
+            class="css-ol2a3a-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account/messages"
@@ -326,7 +326,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
+            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account/settings"
@@ -357,7 +357,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
+            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/help"
@@ -391,7 +391,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-1t06xnm-AppLayoutSidebarNavItemInner"
+            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
           >
             <button
               class="css-6e6ykx-BaseButton"


### PR DESCRIPTION
## Describe your changes

Decreased the gap between icons and labels in the app layout sidebar from `1rem` to `0.75rem`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1302/storybook/index.html?path=/story/layout-applayout--default)

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).