### PR TITLE
Update usage of `createPortal` to fix SSR issues

### DIFF
--- a/.changeset/four-parents-repeat.md
+++ b/.changeset/four-parents-repeat.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+filter-drawer: Update usage of `createPortal` to fix server side render issues
+
+modal: Update usage of `createPortal` to fix server side render issues

--- a/packages/react/src/filter-drawer/FilterDrawer.tsx
+++ b/packages/react/src/filter-drawer/FilterDrawer.tsx
@@ -11,6 +11,7 @@ import { createPortal } from 'react-dom';
 import { useTransition, animated, SpringValue } from '@react-spring/web';
 import {
 	boxPalette,
+	canUseDOM,
 	tokens,
 	useAriaModalPolyfill,
 	usePrefersReducedMotion,
@@ -60,6 +61,10 @@ export const FilterDrawer: FunctionComponent<FilterDrawerProps> = ({
 		config: { duration: 150 },
 		immediate: prefersReducedMotion,
 	});
+
+	// Since react portals can not be rendered on the server and this component is always closed by default
+	// This component doesn't need to be server side rendered
+	if (!canUseDOM()) return null;
 
 	return createPortal(
 		<Fragment>

--- a/packages/react/src/modal/Modal.tsx
+++ b/packages/react/src/modal/Modal.tsx
@@ -1,7 +1,7 @@
 import { Fragment, FunctionComponent, useEffect } from 'react';
 import { Global } from '@emotion/react';
 import { createPortal } from 'react-dom';
-import { useAriaModalPolyfill } from '../core';
+import { canUseDOM, useAriaModalPolyfill } from '../core';
 import { ModalCover } from './ModalCover';
 import { ModalDialog, ModalDialogProps } from './ModalDialog';
 
@@ -34,6 +34,10 @@ export const Modal: FunctionComponent<ModalProps> = ({
 	const { modalContainerRef } = useAriaModalPolyfill(isOpen);
 
 	if (!isOpen) return null;
+
+	// Since react portals can not be rendered on the server and this component is always closed by default
+	// This component doesn't need to be server side rendered
+	if (!canUseDOM()) return null;
 
 	return createPortal(
 		<Fragment>


### PR DESCRIPTION
## Describe your changes

Currently if you attempt to server side render the Filter drawer or Modal components, they will crash. This is due to the fact that they use react portals, which can not be rendered on the server.

Since these components are always closed by default, they don't need to be server side rendered. We can do this by making use  of the `canUseDOM` helper function we created for App layout.