### PR TITLE
app-layout: Made focusMode prop optional

### DIFF
--- a/.changeset/twelve-crabs-worry.md
+++ b/.changeset/twelve-crabs-worry.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Made focusMode prop optional

--- a/packages/react/src/app-layout/AppLayout.tsx
+++ b/packages/react/src/app-layout/AppLayout.tsx
@@ -8,10 +8,10 @@ import {
 
 export type AppLayoutProps = PropsWithChildren<{
 	/** Set to `true` while users are completing multi-page forms to reduce distractions. When true, the app layout sidebar will not be rendered. */
-	focusMode: boolean;
+	focusMode?: boolean;
 }>;
 
-export function AppLayout({ children, focusMode }: AppLayoutProps) {
+export function AppLayout({ children, focusMode = false }: AppLayoutProps) {
 	const [isMobileMenuOpen, openMobileMenu, closeMobileMenu] =
 		useTernaryState(false);
 	return (


### PR DESCRIPTION
## Describe your changes

Consumers of AppLayout must set focusMode to false, which seems unnecessary to me

## Checklist

### Updating existing component

- [ ] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
