### PR TITLE
app-layout: Reduce size of AppLayoutSidebar

### DIFF
--- a/packages/react/src/app-layout/AppLayoutSidebar.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.tsx
@@ -1,9 +1,10 @@
 import { Fragment } from 'react';
 import { findBestMatch, tokens } from '../core';
 import { Stack } from '../stack';
-import { AppLayoutSidebarNav, NavItem } from './AppLayoutSidebarNav';
+import { AppLayoutSidebarNav } from './AppLayoutSidebarNav';
 import { useAppLayoutContext } from './AppLayoutContext';
 import { AppLayoutSidebarDialog } from './AppLayoutSidebarDialog';
+import { NavItem } from './AppLayoutSidebarNavListItem';
 import {
 	APP_LAYOUT_DESKTOP_BREAKPOINT,
 	APP_LAYOUT_SIDEBAR_WIDTH,

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -1,25 +1,11 @@
-import { ComponentType, Fragment, PropsWithChildren, ReactNode } from 'react';
-import {
-	boxPalette,
-	LinkProps,
-	mapSpacing,
-	tokens,
-	useLinkComponent,
-} from '../core';
-import { Box, focusStyles } from '../box';
+import { Fragment } from 'react';
+import { boxPalette, tokens } from '../core';
+import { Box } from '../box';
 import { Flex } from '../flex';
-import { BaseButton, BaseButtonProps } from '../button';
-import { IconProps } from '../icon';
-
-type NavLink = Omit<LinkProps, 'children'>;
-
-type NavButton = Omit<BaseButtonProps, 'children'>;
-
-export type NavItem = (NavLink | NavButton) & {
-	label: ReactNode;
-	icon?: ComponentType<IconProps>;
-	endElement?: ReactNode;
-};
+import {
+	AppLayoutSidebarNavListItem,
+	NavItem,
+} from './AppLayoutSidebarNavListItem';
 
 export type AppLayoutSidebarNavProps = {
 	activePath?: string;
@@ -51,117 +37,6 @@ export function AppLayoutSidebarNav({
 				})}
 			</Flex>
 		</Flex>
-	);
-}
-
-type AppLayoutSidebarNavListItemProps = {
-	activePath?: string;
-	item: NavItem;
-};
-
-function AppLayoutSidebarNavListItem({
-	activePath,
-	item,
-}: AppLayoutSidebarNavListItemProps) {
-	const Link = useLinkComponent();
-	const { endElement, icon: Icon, label, ...restItemProps } = item;
-
-	if ('href' in item) {
-		const active = item.href === activePath;
-		return (
-			<AppLayoutSidebarNavItemInner
-				isActive={activePath === item.href}
-				hasEndElement={Boolean(endElement)}
-			>
-				<Link aria-current={active ? 'page' : undefined} {...restItemProps}>
-					{Icon ? <Icon color="inherit" /> : null}
-					<span>{label}</span>
-					{endElement}
-				</Link>
-			</AppLayoutSidebarNavItemInner>
-		);
-	}
-
-	return (
-		<AppLayoutSidebarNavItemInner
-			isActive={false}
-			hasEndElement={Boolean(endElement)}
-		>
-			<BaseButton {...restItemProps}>
-				{Icon ? <Icon color="inherit" /> : null}
-				<span>{label}</span>
-				{endElement}
-			</BaseButton>
-		</AppLayoutSidebarNavItemInner>
-	);
-}
-
-type AppLayoutSidebarNavItemInnerProps = PropsWithChildren<{
-	isActive: boolean;
-	hasEndElement: boolean;
-}>;
-
-function AppLayoutSidebarNavItemInner({
-	isActive,
-	children,
-	hasEndElement,
-}: AppLayoutSidebarNavItemInnerProps) {
-	return (
-		<li
-			css={{
-				' a': {
-					textDecoration: 'none',
-				},
-
-				' a, button': {
-					display: 'flex',
-					alignItems: 'center',
-					gap: mapSpacing(0.75),
-					width: '100%',
-					boxSizing: 'border-box',
-					paddingLeft: mapSpacing(1.5),
-					paddingRight: mapSpacing(1.5),
-					paddingTop: mapSpacing(1),
-					paddingBottom: mapSpacing(1),
-					color: boxPalette[isActive ? 'foregroundText' : 'foregroundAction'],
-
-					...(isActive && {
-						position: 'relative',
-						fontWeight: tokens.fontWeight.bold,
-						background: boxPalette.backgroundShadeAlt,
-						color: boxPalette.foregroundText,
-						'&:before': {
-							content: "''",
-							position: 'absolute',
-							top: 0,
-							left: 0,
-							bottom: 0,
-							borderLeftWidth: tokens.borderWidth.xl,
-							borderLeftStyle: 'solid',
-							borderLeftColor: boxPalette.foregroundAction,
-						},
-					}),
-
-					...(hasEndElement && {
-						'& > :last-child': {
-							marginLeft: 'auto',
-						},
-					}),
-
-					'&:hover': {
-						background: boxPalette.backgroundShadeAlt,
-						color: boxPalette.foregroundText,
-						'& > span:first-of-type': {
-							textDecoration: 'underline',
-						},
-					},
-
-					...focusStyles,
-				},
-			}}
-		>
-			{children}
-		</li>
 	);
 }
 

--- a/packages/react/src/app-layout/AppLayoutSidebarNavListItem.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNavListItem.stories.tsx
@@ -1,0 +1,85 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { VisuallyHidden } from '../a11y';
+import { Box } from '../box';
+import { EmailIcon } from '../icon';
+import { FactoryIcon } from '../icon/icons/FactoryIcon';
+import { NotificationBadge } from '../notification-badge';
+import { AppLayoutSidebarNavListItem } from './AppLayoutSidebarNavListItem';
+import { APP_LAYOUT_SIDEBAR_WIDTH } from './utils';
+
+const meta: Meta<typeof AppLayoutSidebarNavListItem> = {
+	title: 'Layout/AppLayout/AppLayoutSidebarNavListItem',
+	component: AppLayoutSidebarNavListItem,
+	parameters: {
+		layout: 'fullscreen',
+	},
+	render: (args) => {
+		return (
+			<Box
+				css={{ minHeight: '100vh', width: APP_LAYOUT_SIDEBAR_WIDTH }}
+				background="bodyAlt"
+				borderRight
+				borderColor="muted"
+				flexGrow={1}
+			>
+				<AppLayoutSidebarNavListItem {...args} />
+			</Box>
+		);
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AppLayoutSidebarNavListItem>;
+
+export const Link: Story = {
+	args: {
+		item: {
+			label: 'Establishments',
+			icon: FactoryIcon,
+			href: '/establishments',
+		},
+	},
+};
+
+export const LinkWithNotifcations: Story = {
+	args: {
+		item: {
+			label: 'Messages',
+			icon: EmailIcon,
+			href: '/account/messages',
+			endElement: (
+				<span>
+					<NotificationBadge tone="action" value={6} max={99} aria-hidden />
+					<VisuallyHidden>, 6 unread</VisuallyHidden>
+				</span>
+			),
+		},
+	},
+};
+
+export const Button: Story = {
+	args: {
+		item: {
+			label: 'Establishments',
+			icon: FactoryIcon,
+			onClick: () => console.log('Clicked!'),
+		},
+	},
+};
+
+export const ButtonWithNotifcations: Story = {
+	args: {
+		item: {
+			label: 'Messages',
+			icon: EmailIcon,
+			onClick: () => console.log('Clicked!'),
+			endElement: (
+				<span>
+					<NotificationBadge tone="action" value={6} max={99} aria-hidden />
+					<VisuallyHidden>, 6 unread</VisuallyHidden>
+				</span>
+			),
+		},
+	},
+};

--- a/packages/react/src/app-layout/AppLayoutSidebarNavListItem.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNavListItem.tsx
@@ -1,0 +1,132 @@
+import { ComponentType, PropsWithChildren, ReactNode } from 'react';
+import {
+	boxPalette,
+	LinkProps,
+	mapSpacing,
+	tokens,
+	useLinkComponent,
+} from '../core';
+import { focusStyles } from '../box';
+import { BaseButton, BaseButtonProps } from '../button';
+import { IconProps } from '../icon';
+
+type NavLink = Omit<LinkProps, 'children'>;
+
+type NavButton = Omit<BaseButtonProps, 'children'>;
+
+export type NavItem = (NavLink | NavButton) & {
+	label: ReactNode;
+	icon?: ComponentType<IconProps>;
+	endElement?: ReactNode;
+};
+
+type AppLayoutSidebarNavListItemProps = {
+	activePath?: string;
+	item: NavItem;
+};
+
+export function AppLayoutSidebarNavListItem({
+	activePath,
+	item,
+}: AppLayoutSidebarNavListItemProps) {
+	const Link = useLinkComponent();
+	const { endElement, icon: Icon, label, ...restItemProps } = item;
+
+	if ('href' in item) {
+		const active = item.href === activePath;
+		return (
+			<AppLayoutSidebarNavItemInner
+				isActive={activePath === item.href}
+				hasEndElement={Boolean(endElement)}
+			>
+				<Link aria-current={active ? 'page' : undefined} {...restItemProps}>
+					{Icon ? <Icon color="inherit" /> : null}
+					<span>{label}</span>
+					{endElement}
+				</Link>
+			</AppLayoutSidebarNavItemInner>
+		);
+	}
+
+	return (
+		<AppLayoutSidebarNavItemInner
+			isActive={false}
+			hasEndElement={Boolean(endElement)}
+		>
+			<BaseButton {...restItemProps}>
+				{Icon ? <Icon color="inherit" /> : null}
+				<span>{label}</span>
+				{endElement}
+			</BaseButton>
+		</AppLayoutSidebarNavItemInner>
+	);
+}
+
+type AppLayoutSidebarNavItemInnerProps = PropsWithChildren<{
+	isActive: boolean;
+	hasEndElement: boolean;
+}>;
+
+function AppLayoutSidebarNavItemInner({
+	isActive,
+	children,
+	hasEndElement,
+}: AppLayoutSidebarNavItemInnerProps) {
+	return (
+		<li
+			css={{
+				' a': {
+					textDecoration: 'none',
+				},
+
+				' a, button': {
+					display: 'flex',
+					alignItems: 'center',
+					gap: mapSpacing(0.75),
+					width: '100%',
+					boxSizing: 'border-box',
+					paddingLeft: mapSpacing(1.5),
+					paddingRight: mapSpacing(1.5),
+					paddingTop: mapSpacing(1),
+					paddingBottom: mapSpacing(1),
+					color: boxPalette[isActive ? 'foregroundText' : 'foregroundAction'],
+
+					...(isActive && {
+						position: 'relative',
+						fontWeight: tokens.fontWeight.bold,
+						background: boxPalette.backgroundShadeAlt,
+						color: boxPalette.foregroundText,
+						'&:before': {
+							content: "''",
+							position: 'absolute',
+							top: 0,
+							left: 0,
+							bottom: 0,
+							borderLeftWidth: tokens.borderWidth.xl,
+							borderLeftStyle: 'solid',
+							borderLeftColor: boxPalette.foregroundAction,
+						},
+					}),
+
+					...(hasEndElement && {
+						'& > :last-child': {
+							marginLeft: 'auto',
+						},
+					}),
+
+					'&:hover': {
+						background: boxPalette.backgroundShadeAlt,
+						color: boxPalette.foregroundText,
+						'& > span:first-of-type': {
+							textDecoration: 'underline',
+						},
+					},
+
+					...focusStyles,
+				},
+			}}
+		>
+			{children}
+		</li>
+	);
+}

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AppLayout renders correctly 1`] = `
 <div>
   <div
-    class="css-4lqw0h-AppLayoutGrid"
+    class="css-jlzmfo-AppLayoutGrid"
   >
     <header
       class="css-7czsu9-dark-boxStyles-AppLayoutHeader"
@@ -156,7 +156,7 @@ exports[`AppLayout renders correctly 1`] = `
       </div>
     </header>
     <aside
-      class="css-odyicp-boxStyles-AppLayoutSidebar"
+      class="css-4plgz3-boxStyles-AppLayoutSidebar"
     >
       <nav
         aria-label="main"

--- a/packages/react/src/app-layout/utils.ts
+++ b/packages/react/src/app-layout/utils.ts
@@ -1,4 +1,4 @@
 // The breakpoint where we show the sidebar in a two column layout
 export const APP_LAYOUT_DESKTOP_BREAKPOINT = 'xl';
 
-export const APP_LAYOUT_SIDEBAR_WIDTH = '17.5rem'; // 280 px
+export const APP_LAYOUT_SIDEBAR_WIDTH = '16rem'; // 256 px


### PR DESCRIPTION
## Describe your changes

This PR reduces the width of the AppLayoutSidebar from 280px to 256px while not compromising the contents. This is in response to feedback that the AppLayoutSidebar is too thick for screens slightly larger than 1200px (the xl breakpoint where the AppLayoutSidebar first appears).

**NOTE:** We are planning to not merge this until the next time Ag.common is due for a release, to ensure this change is consumed consistently across the Export Service.

[Link to preview](https://design-system.agriculture.gov.au/pr-preview/pr-1319/storybook/iframe.html?args=&id=templates-single-page-form--in-app-form-page&viewMode=story)

<img width="1010" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/571e4617-46b4-4dae-9dfb-26c16218d9c9">

To improve testing, I have also extracted the `ApplLayoutSidebarNavItem` component to it's own file, and created Storybook stories for it.

<img width="594" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/37b911fb-9d4a-4037-8c84-83262538118b">


## Checklist

### Updating existing component

- [ ] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
