### PR TITLE
TableHeaderSortable: Show icons persistently

### DIFF
--- a/.changeset/lovely-phones-grow.md
+++ b/.changeset/lovely-phones-grow.md
@@ -2,8 +2,8 @@
 '@ag.ds-next/react': patch
 ---
 
-icon: Added `ChevronUpDownIcon`
+icon: Added `ArrowUpDownIcon`
 
-icon: Deprecated ChevronsUpDownIcon
+icon: Deprecated `ChevronsUpDownIcon`, use `ArrowUpDownIcon` instead. This will be removed in the next major version.
 
-table: Updated icons in TableHeaderSortable
+table: Updated icons in `TableHeaderSortable`

--- a/.changeset/lovely-phones-grow.md
+++ b/.changeset/lovely-phones-grow.md
@@ -2,4 +2,6 @@
 '@ag.ds-next/react': patch
 ---
 
+icon: Added `ChevronUpDownIcon`
+
 table: Updated icons in TableHeaderSortable

--- a/.changeset/lovely-phones-grow.md
+++ b/.changeset/lovely-phones-grow.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+table: Updated icons in TableHeaderSortable

--- a/.changeset/lovely-phones-grow.md
+++ b/.changeset/lovely-phones-grow.md
@@ -4,4 +4,6 @@
 
 icon: Added `ChevronUpDownIcon`
 
+icon: Deprecated ChevronsUpDownIcon
+
 table: Updated icons in TableHeaderSortable

--- a/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
@@ -353,6 +353,29 @@ exports[`Icon ChevronsRightIcon renders correctly 1`] = `
 </div>
 `;
 
+exports[`Icon ChevronsUpDownIcon renders correctly 1`] = `
+<div>
+  <svg
+    aria-hidden="true"
+    class="css-9s3cfn-Icon"
+    clip-rule="evenodd"
+    focusable="false"
+    height="24"
+    role="img"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M7.5 8L11.8232 3.67678C11.9209 3.57915 12.0791 3.57915 12.1768 3.67678L16.5 8"
+    />
+    <path
+      d="M16.5 16L12.1768 20.3232C12.0791 20.4209 11.9209 20.4209 11.8232 20.3232L7.5 16"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Icon CloseIcon renders correctly 1`] = `
 <div>
   <svg

--- a/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
@@ -353,29 +353,6 @@ exports[`Icon ChevronsRightIcon renders correctly 1`] = `
 </div>
 `;
 
-exports[`Icon ChevronsUpDownIcon renders correctly 1`] = `
-<div>
-  <svg
-    aria-hidden="true"
-    class="css-9s3cfn-Icon"
-    clip-rule="evenodd"
-    focusable="false"
-    height="24"
-    role="img"
-    viewBox="0 0 24 24"
-    width="24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <path
-      d="M7.5 8L11.8232 3.67678C11.9209 3.57915 12.0791 3.57915 12.1768 3.67678L16.5 8"
-    />
-    <path
-      d="M16.5 16L12.1768 20.3232C12.0791 20.4209 11.9209 20.4209 11.8232 20.3232L7.5 16"
-    />
-  </svg>
-</div>
-`;
-
 exports[`Icon CloseIcon renders correctly 1`] = `
 <div>
   <svg

--- a/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
@@ -119,6 +119,26 @@ exports[`Icon ArrowRightIcon renders correctly 1`] = `
 </div>
 `;
 
+exports[`Icon ArrowUpDownIcon renders correctly 1`] = `
+<div>
+  <svg
+    aria-hidden="true"
+    class="css-9s3cfn-Icon"
+    clip-rule="evenodd"
+    focusable="false"
+    height="24"
+    role="img"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="m17 16-4.646 4.646a.5.5 0 0 1-.708 0L7 16M7 7.793l4.646-4.646a.5.5 0 0 1 .708 0L17 7.793"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Icon ArrowUpIcon renders correctly 1`] = `
 <div>
   <svg

--- a/packages/react/src/icon/icons/ArrowUpDownIcon.tsx
+++ b/packages/react/src/icon/icons/ArrowUpDownIcon.tsx
@@ -1,0 +1,6 @@
+import { createIcon } from '../Icon';
+
+export const ArrowUpDownIcon = createIcon(
+	<path d="m17 16-4.646 4.646a.5.5 0 0 1-.708 0L7 16M7 7.793l4.646-4.646a.5.5 0 0 1 .708 0L17 7.793" />,
+	'ArrowUpDownIcon'
+);

--- a/packages/react/src/icon/icons/ChevronsUpDownIcon.tsx
+++ b/packages/react/src/icon/icons/ChevronsUpDownIcon.tsx
@@ -1,6 +1,11 @@
 import { Fragment } from 'react';
 import { createIcon } from '../Icon';
 
+/**
+ * @deprecated This icon has been deprecated.
+ * Use `ArrowUpDownIcon` instead.
+ * This will be removed in the next major version.
+ */
 export const ChevronsUpDownIcon = createIcon(
 	<Fragment>
 		<path d="M7.5 8L11.8232 3.67678C11.9209 3.57915 12.0791 3.57915 12.1768 3.67678L16.5 8" />

--- a/packages/react/src/icon/index.ts
+++ b/packages/react/src/icon/index.ts
@@ -4,6 +4,13 @@ export type IconProps = _IconProps;
 export { createIcon } from './Icon';
 export * from './utils';
 
+/**
+ * @deprecated This icon has been deprecated.
+ * Use `ArrowUpDownIcon` instead.
+ * This will be removed in the next major version.
+ */
+export { ChevronsUpDownIcon } from './icons/ChevronsUpDownIcon';
+
 export { AlertIcon } from './icons/AlertIcon';
 export { AlertFilledIcon } from './icons/AlertFilledIcon';
 export { ArrowUpIcon } from './icons/ArrowUpIcon';
@@ -21,7 +28,6 @@ export { ChevronLeftIcon } from './icons/ChevronLeftIcon';
 export { ChevronRightIcon } from './icons/ChevronRightIcon';
 export { ChevronsLeftIcon } from './icons/ChevronsLeftIcon';
 export { ChevronsRightIcon } from './icons/ChevronsRightIcon';
-export { ChevronsUpDownIcon } from './icons/ChevronsUpDownIcon';
 export { CloseIcon } from './icons/CloseIcon';
 export { CopyIcon } from './icons/CopyIcon';
 export { DeleteIcon } from './icons/DeleteIcon';

--- a/packages/react/src/icon/index.ts
+++ b/packages/react/src/icon/index.ts
@@ -4,13 +4,6 @@ export type IconProps = _IconProps;
 export { createIcon } from './Icon';
 export * from './utils';
 
-/**
- * @deprecated This icon has been deprecated.
- * Use `ArrowUpDownIcon` instead.
- * This will be removed in the next major version.
- */
-export { ChevronsUpDownIcon } from './icons/ChevronsUpDownIcon';
-
 export { AlertIcon } from './icons/AlertIcon';
 export { AlertFilledIcon } from './icons/AlertFilledIcon';
 export { ArrowUpIcon } from './icons/ArrowUpIcon';
@@ -28,6 +21,7 @@ export { ChevronLeftIcon } from './icons/ChevronLeftIcon';
 export { ChevronRightIcon } from './icons/ChevronRightIcon';
 export { ChevronsLeftIcon } from './icons/ChevronsLeftIcon';
 export { ChevronsRightIcon } from './icons/ChevronsRightIcon';
+export { ChevronsUpDownIcon } from './icons/ChevronsUpDownIcon';
 export { CloseIcon } from './icons/CloseIcon';
 export { CopyIcon } from './icons/CopyIcon';
 export { DeleteIcon } from './icons/DeleteIcon';

--- a/packages/react/src/icon/index.ts
+++ b/packages/react/src/icon/index.ts
@@ -10,6 +10,7 @@ export { ArrowUpIcon } from './icons/ArrowUpIcon';
 export { ArrowDownIcon } from './icons/ArrowDownIcon';
 export { ArrowLeftIcon } from './icons/ArrowLeftIcon';
 export { ArrowRightIcon } from './icons/ArrowRightIcon';
+export { ArrowUpDownIcon } from './icons/ArrowUpDownIcon';
 export { AvatarIcon } from './icons/AvatarIcon';
 export { CalendarIcon } from './icons/CalendarIcon';
 export { ChartBarIcon } from './icons/ChartBarIcon';

--- a/packages/react/src/icon/utils.tsx
+++ b/packages/react/src/icon/utils.tsx
@@ -14,7 +14,6 @@ import { ChevronRightIcon } from './icons/ChevronRightIcon';
 import { ChevronUpIcon } from './icons/ChevronUpIcon';
 import { ChevronsLeftIcon } from './icons/ChevronsLeftIcon';
 import { ChevronsRightIcon } from './icons/ChevronsRightIcon';
-import { ChevronsUpDownIcon } from './icons/ChevronsUpDownIcon';
 import { CloseIcon } from './icons/CloseIcon';
 import { CopyIcon } from './icons/CopyIcon';
 import { DeleteIcon } from './icons/DeleteIcon';
@@ -67,7 +66,6 @@ export const allIcons = {
 	ChevronUpIcon,
 	ChevronsLeftIcon,
 	ChevronsRightIcon,
-	ChevronsUpDownIcon,
 	CloseIcon,
 	CopyIcon,
 	DownloadIcon,

--- a/packages/react/src/icon/utils.tsx
+++ b/packages/react/src/icon/utils.tsx
@@ -14,6 +14,7 @@ import { ChevronRightIcon } from './icons/ChevronRightIcon';
 import { ChevronUpIcon } from './icons/ChevronUpIcon';
 import { ChevronsLeftIcon } from './icons/ChevronsLeftIcon';
 import { ChevronsRightIcon } from './icons/ChevronsRightIcon';
+import { ChevronsUpDownIcon } from './icons/ChevronsUpDownIcon';
 import { CloseIcon } from './icons/CloseIcon';
 import { CopyIcon } from './icons/CopyIcon';
 import { DeleteIcon } from './icons/DeleteIcon';
@@ -66,6 +67,7 @@ export const allIcons = {
 	ChevronUpIcon,
 	ChevronsLeftIcon,
 	ChevronsRightIcon,
+	ChevronsUpDownIcon,
 	CloseIcon,
 	CopyIcon,
 	DownloadIcon,

--- a/packages/react/src/icon/utils.tsx
+++ b/packages/react/src/icon/utils.tsx
@@ -4,6 +4,7 @@ import { ArrowDownIcon } from './icons/ArrowDownIcon';
 import { ArrowLeftIcon } from './icons/ArrowLeftIcon';
 import { ArrowRightIcon } from './icons/ArrowRightIcon';
 import { ArrowUpIcon } from './icons/ArrowUpIcon';
+import { ArrowUpDownIcon } from './icons/ArrowUpDownIcon';
 import { AvatarIcon } from './icons/AvatarIcon';
 import { ChartBarIcon } from './icons/ChartBarIcon';
 import { ChartLineIcon } from './icons/ChartLineIcon';
@@ -56,6 +57,7 @@ export const allIcons = {
 	ArrowLeftIcon,
 	ArrowRightIcon,
 	ArrowUpIcon,
+	ArrowUpDownIcon,
 	AvatarIcon,
 	ChartBarIcon,
 	ChartLineIcon,

--- a/packages/react/src/table/TableHeaderSortable.stories.tsx
+++ b/packages/react/src/table/TableHeaderSortable.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { TableHeaderSortable } from './TableHeaderSortable';
+
+const meta: Meta<typeof TableHeaderSortable> = {
+	title: 'Content/Table/TableHeaderSortable',
+	component: TableHeaderSortable,
+	args: {
+		children: 'Name',
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TableHeaderSortable>;
+
+export const Basic: Story = {
+	name: 'Not active sort',
+};
+
+export const Ascending: Story = {
+	name: 'Ascending sort',
+	args: {
+		sort: 'ASC',
+	},
+};
+
+export const Descending: Story = {
+	name: 'Descending sort',
+	args: {
+		sort: 'DESC',
+	},
+};

--- a/packages/react/src/table/TableHeaderSortable.test.tsx
+++ b/packages/react/src/table/TableHeaderSortable.test.tsx
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom';
+import 'html-validate/jest';
+import { cleanup, render } from '../../../../test-utils';
+import {
+	TableHeaderSortable,
+	TableHeaderSortableProps,
+	TableSortDirection,
+} from './TableHeaderSortable';
+
+afterEach(cleanup);
+
+function renderStatusBadge(props: TableHeaderSortableProps) {
+	return render(<TableHeaderSortable {...props}>Example</TableHeaderSortable>);
+}
+
+const sortDirs: (TableSortDirection | undefined)[] = ['ASC', 'DESC', undefined];
+
+describe('TableHeaderSortable', () => {
+	sortDirs.forEach((dir) => {
+		describe(`with sort direction ${dir}`, () => {
+			it('renders correctly', () => {
+				const { container } = renderStatusBadge({
+					sort: dir,
+				});
+				expect(container).toMatchSnapshot();
+			});
+		});
+	});
+});

--- a/packages/react/src/table/TableHeaderSortable.test.tsx
+++ b/packages/react/src/table/TableHeaderSortable.test.tsx
@@ -1,28 +1,47 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { cleanup, render } from '../../../../test-utils';
+import { Table } from './Table';
+import { TableHead } from './TableHead';
 import {
 	TableHeaderSortable,
 	TableHeaderSortableProps,
 	TableSortDirection,
 } from './TableHeaderSortable';
 
+expect.extend(toHaveNoViolations);
+
 afterEach(cleanup);
 
-function renderStatusBadge(props: TableHeaderSortableProps) {
-	return render(<TableHeaderSortable {...props}>Example</TableHeaderSortable>);
+function renderTableHeaderSortable(props: TableHeaderSortableProps) {
+	return render(
+		<Table>
+			<TableHead>
+				<tr>
+					<TableHeaderSortable {...props}>Example</TableHeaderSortable>
+				</tr>
+			</TableHead>
+		</Table>
+	);
 }
 
 const sortDirs: (TableSortDirection | undefined)[] = ['ASC', 'DESC', undefined];
 
 describe('TableHeaderSortable', () => {
-	sortDirs.forEach((dir) => {
-		describe(`with sort direction ${dir}`, () => {
+	sortDirs.forEach((sort) => {
+		describe(`with sort direction: ${sort}`, () => {
 			it('renders correctly', () => {
-				const { container } = renderStatusBadge({
-					sort: dir,
-				});
+				const { container } = renderTableHeaderSortable({ sort });
 				expect(container).toMatchSnapshot();
+			});
+
+			it('renders valid HTML with no a11y violations', async () => {
+				const { container } = renderTableHeaderSortable({ sort });
+				expect(container).toHTMLValidate({
+					extends: ['html-validate:recommended'],
+				});
+				expect(await axe(container)).toHaveNoViolations();
 			});
 		});
 	});

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -3,7 +3,7 @@ import { Box } from '../box';
 import { Flex } from '../flex';
 import { BaseButton } from '../button';
 import { boxPalette, ResponsiveProp } from '../core';
-import { ArrowDownIcon, ArrowUpIcon } from '../icon';
+import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '../icon';
 
 export type TableSortDirection = 'ASC' | 'DESC';
 
@@ -27,12 +27,13 @@ export const TableHeaderSortable = ({
 	textAlign = 'left',
 	width,
 }: PropsWithChildren<TableHeaderSortableProps>) => {
-	const Icon = sort === 'DESC' ? ArrowUpIcon : ArrowDownIcon;
+	const Icon = getSortIcon(sort);
+	const sortLabel = getSortLabel(sort);
 	return (
 		<Box
 			as="th"
 			scope="col"
-			aria-sort={getSortLabel(sort)}
+			aria-sort={sortLabel}
 			width={width}
 			{...(sort && {
 				borderBottom: true,
@@ -56,21 +57,14 @@ export const TableHeaderSortable = ({
 				focus
 				css={{
 					textDecoration: 'underline',
-					svg: {
-						display: sort ? 'block' : 'none',
-					},
 					'&:hover': {
 						backgroundColor: boxPalette.backgroundShade,
 						textDecoration: 'none',
-						svg: {
-							display: 'block',
-							transform: sort ? 'rotate(180deg)' : 'rotate(0deg)',
-						},
 					},
 				}}
 			>
 				{children}
-				<Icon size="sm" color="action" />
+				<Icon size="md" color="action" />
 			</Flex>
 		</Box>
 	);
@@ -79,4 +73,15 @@ export const TableHeaderSortable = ({
 const getSortLabel = (sort?: TableSortDirection) => {
 	if (sort === 'ASC') return 'ascending';
 	if (sort === 'DESC') return 'descending';
+};
+
+const getSortIcon = (sort?: TableSortDirection) => {
+	switch (sort) {
+		case 'ASC':
+			return ArrowDownIcon;
+		case 'DESC':
+			return ArrowUpIcon;
+		default:
+			return ArrowUpDownIcon;
+	}
 };

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react';
 import { Box } from '../box';
 import { Flex } from '../flex';
 import { BaseButton } from '../button';
-import { boxPalette, ResponsiveProp } from '../core';
+import { boxPalette, packs, ResponsiveProp } from '../core';
 import { ArrowDownIcon, ArrowUpIcon, ArrowUpDownIcon } from '../icon';
 
 export type TableSortDirection = 'ASC' | 'DESC';
@@ -56,7 +56,7 @@ export const TableHeaderSortable = ({
 				alignItems="center"
 				focus
 				css={{
-					textDecoration: 'underline',
+					...packs.underline,
 					svg: {
 						color: boxPalette.foregroundAction,
 					},

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -63,9 +63,9 @@ export const TableHeaderSortable = ({
 					'&:hover': {
 						backgroundColor: boxPalette.backgroundShade,
 						textDecoration: 'none',
-						'svg': {
+						svg: {
 							color: boxPalette.foregroundText,
-						}
+						},
 					},
 				}}
 			>

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -57,14 +57,20 @@ export const TableHeaderSortable = ({
 				focus
 				css={{
 					textDecoration: 'underline',
+					svg: {
+						color: boxPalette.foregroundAction,
+					},
 					'&:hover': {
 						backgroundColor: boxPalette.backgroundShade,
 						textDecoration: 'none',
+						'svg': {
+							color: boxPalette.foregroundText,
+						}
 					},
 				}}
 			>
 				{children}
-				<Icon size="md" color="action" />
+				<Icon size="md" color="inherit" />
 			</Flex>
 		</Box>
 	);

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`TableHeaderSortable with sort direction ASC renders correctly 1`] = `
     scope="col"
   >
     <button
-      class="css-t6se6b-BaseButton-boxStyles-TableHeaderSortable"
+      class="css-1f2j33r-BaseButton-boxStyles-TableHeaderSortable"
       type="button"
     >
       Example
       <svg
         aria-hidden="true"
-        class="css-dgj9fa-Icon"
+        class="css-qhpjst-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -43,13 +43,13 @@ exports[`TableHeaderSortable with sort direction DESC renders correctly 1`] = `
     scope="col"
   >
     <button
-      class="css-t6se6b-BaseButton-boxStyles-TableHeaderSortable"
+      class="css-1f2j33r-BaseButton-boxStyles-TableHeaderSortable"
       type="button"
     >
       Example
       <svg
         aria-hidden="true"
-        class="css-dgj9fa-Icon"
+        class="css-qhpjst-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -77,13 +77,13 @@ exports[`TableHeaderSortable with sort direction undefined renders correctly 1`]
     scope="col"
   >
     <button
-      class="css-t6se6b-BaseButton-boxStyles-TableHeaderSortable"
+      class="css-1f2j33r-BaseButton-boxStyles-TableHeaderSortable"
       type="button"
     >
       Example
       <svg
         aria-hidden="true"
-        class="css-dgj9fa-Icon"
+        class="css-qhpjst-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -8,13 +8,13 @@ exports[`TableHeaderSortable with sort direction ASC renders correctly 1`] = `
     scope="col"
   >
     <button
-      class="css-1bb77vf-BaseButton-boxStyles-TableHeaderSortable"
+      class="css-t6se6b-BaseButton-boxStyles-TableHeaderSortable"
       type="button"
     >
       Example
       <svg
         aria-hidden="true"
-        class="css-t181ux-Icon"
+        class="css-dgj9fa-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -43,13 +43,13 @@ exports[`TableHeaderSortable with sort direction DESC renders correctly 1`] = `
     scope="col"
   >
     <button
-      class="css-1bb77vf-BaseButton-boxStyles-TableHeaderSortable"
+      class="css-t6se6b-BaseButton-boxStyles-TableHeaderSortable"
       type="button"
     >
       Example
       <svg
         aria-hidden="true"
-        class="css-t181ux-Icon"
+        class="css-dgj9fa-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -77,13 +77,13 @@ exports[`TableHeaderSortable with sort direction undefined renders correctly 1`]
     scope="col"
   >
     <button
-      class="css-16z398q-BaseButton-boxStyles-TableHeaderSortable"
+      class="css-t6se6b-BaseButton-boxStyles-TableHeaderSortable"
       type="button"
     >
       Example
       <svg
         aria-hidden="true"
-        class="css-t181ux-Icon"
+        class="css-dgj9fa-Icon"
         clip-rule="evenodd"
         focusable="false"
         height="24"
@@ -93,10 +93,7 @@ exports[`TableHeaderSortable with sort direction undefined renders correctly 1`]
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M12 3L12 20"
-        />
-        <path
-          d="M17 16L12 21L7 16"
+          d="m17 16-4.646 4.646a.5.5 0 0 1-.708 0L7 16M7 7.793l4.646-4.646a.5.5 0 0 1 .708 0L17 7.793"
         />
       </svg>
     </button>

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -1,102 +1,132 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableHeaderSortable with sort direction ASC renders correctly 1`] = `
+exports[`TableHeaderSortable with sort direction: ASC renders correctly 1`] = `
 <div>
-  <th
-    aria-sort="ascending"
-    class="css-7wxia7-boxStyles-TableHeaderSortable"
-    scope="col"
+  <table
+    class="css-1lii0zf-boxStyles-Table"
   >
-    <button
-      class="css-1f2j33r-BaseButton-boxStyles-TableHeaderSortable"
-      type="button"
+    <thead
+      class="css-11khhn7-boxStyles"
     >
-      Example
-      <svg
-        aria-hidden="true"
-        class="css-qhpjst-Icon"
-        clip-rule="evenodd"
-        focusable="false"
-        height="24"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M12 3L12 20"
-        />
-        <path
-          d="M17 16L12 21L7 16"
-        />
-      </svg>
-    </button>
-  </th>
+      <tr>
+        <th
+          aria-sort="ascending"
+          class="css-7wxia7-boxStyles-TableHeaderSortable"
+          scope="col"
+        >
+          <button
+            class="css-19jhtto-BaseButton-boxStyles-TableHeaderSortable"
+            type="button"
+          >
+            Example
+            <svg
+              aria-hidden="true"
+              class="css-qhpjst-Icon"
+              clip-rule="evenodd"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 3L12 20"
+              />
+              <path
+                d="M17 16L12 21L7 16"
+              />
+            </svg>
+          </button>
+        </th>
+      </tr>
+    </thead>
+  </table>
 </div>
 `;
 
-exports[`TableHeaderSortable with sort direction DESC renders correctly 1`] = `
+exports[`TableHeaderSortable with sort direction: DESC renders correctly 1`] = `
 <div>
-  <th
-    aria-sort="descending"
-    class="css-7wxia7-boxStyles-TableHeaderSortable"
-    scope="col"
+  <table
+    class="css-1lii0zf-boxStyles-Table"
   >
-    <button
-      class="css-1f2j33r-BaseButton-boxStyles-TableHeaderSortable"
-      type="button"
+    <thead
+      class="css-11khhn7-boxStyles"
     >
-      Example
-      <svg
-        aria-hidden="true"
-        class="css-qhpjst-Icon"
-        clip-rule="evenodd"
-        focusable="false"
-        height="24"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M12 21V4"
-        />
-        <path
-          d="M7 8L12 3L17 8"
-        />
-      </svg>
-    </button>
-  </th>
+      <tr>
+        <th
+          aria-sort="descending"
+          class="css-7wxia7-boxStyles-TableHeaderSortable"
+          scope="col"
+        >
+          <button
+            class="css-19jhtto-BaseButton-boxStyles-TableHeaderSortable"
+            type="button"
+          >
+            Example
+            <svg
+              aria-hidden="true"
+              class="css-qhpjst-Icon"
+              clip-rule="evenodd"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 21V4"
+              />
+              <path
+                d="M7 8L12 3L17 8"
+              />
+            </svg>
+          </button>
+        </th>
+      </tr>
+    </thead>
+  </table>
 </div>
 `;
 
-exports[`TableHeaderSortable with sort direction undefined renders correctly 1`] = `
+exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`] = `
 <div>
-  <th
-    class="css-1vsi0cy-boxStyles-TableHeaderSortable"
-    scope="col"
+  <table
+    class="css-1lii0zf-boxStyles-Table"
   >
-    <button
-      class="css-1f2j33r-BaseButton-boxStyles-TableHeaderSortable"
-      type="button"
+    <thead
+      class="css-11khhn7-boxStyles"
     >
-      Example
-      <svg
-        aria-hidden="true"
-        class="css-qhpjst-Icon"
-        clip-rule="evenodd"
-        focusable="false"
-        height="24"
-        role="img"
-        viewBox="0 0 24 24"
-        width="24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="m17 16-4.646 4.646a.5.5 0 0 1-.708 0L7 16M7 7.793l4.646-4.646a.5.5 0 0 1 .708 0L17 7.793"
-        />
-      </svg>
-    </button>
-  </th>
+      <tr>
+        <th
+          class="css-1vsi0cy-boxStyles-TableHeaderSortable"
+          scope="col"
+        >
+          <button
+            class="css-19jhtto-BaseButton-boxStyles-TableHeaderSortable"
+            type="button"
+          >
+            Example
+            <svg
+              aria-hidden="true"
+              class="css-qhpjst-Icon"
+              clip-rule="evenodd"
+              focusable="false"
+              height="24"
+              role="img"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m17 16-4.646 4.646a.5.5 0 0 1-.708 0L7 16M7 7.793l4.646-4.646a.5.5 0 0 1 .708 0L17 7.793"
+              />
+            </svg>
+          </button>
+        </th>
+      </tr>
+    </thead>
+  </table>
 </div>
 `;

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableHeaderSortable with sort direction ASC renders correctly 1`] = `
+<div>
+  <th
+    aria-sort="ascending"
+    class="css-7wxia7-boxStyles-TableHeaderSortable"
+    scope="col"
+  >
+    <button
+      class="css-1bb77vf-BaseButton-boxStyles-TableHeaderSortable"
+      type="button"
+    >
+      Example
+      <svg
+        aria-hidden="true"
+        class="css-t181ux-Icon"
+        clip-rule="evenodd"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 3L12 20"
+        />
+        <path
+          d="M17 16L12 21L7 16"
+        />
+      </svg>
+    </button>
+  </th>
+</div>
+`;
+
+exports[`TableHeaderSortable with sort direction DESC renders correctly 1`] = `
+<div>
+  <th
+    aria-sort="descending"
+    class="css-7wxia7-boxStyles-TableHeaderSortable"
+    scope="col"
+  >
+    <button
+      class="css-1bb77vf-BaseButton-boxStyles-TableHeaderSortable"
+      type="button"
+    >
+      Example
+      <svg
+        aria-hidden="true"
+        class="css-t181ux-Icon"
+        clip-rule="evenodd"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 21V4"
+        />
+        <path
+          d="M7 8L12 3L17 8"
+        />
+      </svg>
+    </button>
+  </th>
+</div>
+`;
+
+exports[`TableHeaderSortable with sort direction undefined renders correctly 1`] = `
+<div>
+  <th
+    class="css-1vsi0cy-boxStyles-TableHeaderSortable"
+    scope="col"
+  >
+    <button
+      class="css-16z398q-BaseButton-boxStyles-TableHeaderSortable"
+      type="button"
+    >
+      Example
+      <svg
+        aria-hidden="true"
+        class="css-t181ux-Icon"
+        clip-rule="evenodd"
+        focusable="false"
+        height="24"
+        role="img"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 3L12 20"
+        />
+        <path
+          d="M17 16L12 21L7 16"
+        />
+      </svg>
+    </button>
+  </th>
+</div>
+`;


### PR DESCRIPTION
## Describe your changes

- Add ArrowUpDownIcon
- Changed TableHeaderSortable to show ArrowUpDownIcon if the column is not the active sort
- Change icon size to 24px
- Icon no longer changes direction while being hovered

[Link to preview](https://design-system.agriculture.gov.au/pr-preview/pr-1321/storybook/iframe.html?args=&id=patterns-data-filtering-and-sorting--medium&viewMode=story)

<img width="1298" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/d2f2bc26-ac2b-41db-8522-45e47842d60a">

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [x] Create stories for Storybook
- [x] Add necessary unit tests (HTML validation, snapshots etc)
- [x] Manually test component in various modern browsers
- [x] Manually test component using a screen reader
- [x] Run `yarn format` to ensure code is formatted correctly
- [x] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
