### PR TITLE
autocomplete: Wrap tests in act

### DIFF
--- a/packages/react/src/autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/autocomplete/Autocomplete.test.tsx
@@ -48,7 +48,9 @@ describe('Autocomplete', () => {
 				'valid-id': 'off',
 			},
 		});
-		expect(await axe(container)).toHaveNoViolations();
+		await act(async () => {
+			expect(await axe(container)).toHaveNoViolations();
+		});
 	});
 
 	it('can load and clear async options', async () => {


### PR DESCRIPTION
## Describe your changes

Follow up to #1322  - forgot to wrap the `Autocomplete` component tests in `act`.