### PR TITLE
Remove usages of set-output in CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache
@@ -64,7 +64,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache
@@ -121,7 +121,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ const config = {
 	testEnvironment: 'jsdom',
 	clearMocks: true,
 	verbose: true,
-	testTimeout: 10000,
+	testTimeout: 15000, // TODO: Rollback to 10000 when we have a better solution for the test timeout issue
 	collectCoverageFrom: [
 		'**/packages/**/*.{ts,tsx}',
 		'!**/dist/**',


### PR DESCRIPTION
## Describe your changes

[GitHub Actions is showing warnings](https://github.com/steelthreads/agds-next/actions/runs/5804406765) regarding the usage of 'set-output' in CI scripts.

I have followed [this blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) which details how to upgrade.

## Example warning
```
Linting (18)The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
--
Linting (18)The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

```

## Checklist

### Updating existing component

- [x] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review
- [ ] Document the component for the website (`docs/overview.mdx` and `docs/code.mdx` at a minimum)
- [ ] Create stories for Storybook
- [ ] Add necessary unit tests (HTML validation, snapshots etc)
- [ ] Manually test component in various modern browsers
- [ ] Manually test component using a screen reader
- [ ] Run `yarn format` to ensure code is formatted correctly
- [ ] Run `yarn lint` in the root of the repository to ensure linting tests are passing
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [ ] Run `yarn changeset` to create a changeset file. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
