### PR TITLE
combobox: Upgrade to version 8 of downshift

### DIFF
--- a/.changeset/twenty-donuts-smoke.md
+++ b/.changeset/twenty-donuts-smoke.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+combobox: Upgraded dependency on `downshift` to version 8, which implements ARIA version 1.2.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,7 +9,7 @@
 		"@floating-ui/react-dom": "^2.0.1",
 		"@react-spring/web": "^9.4.5",
 		"date-fns": "^2.28.0",
-		"downshift": "^7.4.1",
+		"downshift": "^8.1.0",
 		"react-day-picker": "^8.3.5",
 		"react-dropzone": "^12.0.5",
 		"react-focus-lock": "^2.8.1",

--- a/packages/react/src/autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/autocomplete/Autocomplete.test.tsx
@@ -62,9 +62,10 @@ describe('Autocomplete', () => {
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		if (!input) return;
 
-		// Focus the input
-		await act(async () => await input.focus());
-		expect(input).toHaveFocus();
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(input).toHaveAttribute('aria-expanded', 'false');
 
 		expect(loadOptions).not.toHaveBeenCalled();
 

--- a/packages/react/src/autocomplete/Autocomplete.test.tsx
+++ b/packages/react/src/autocomplete/Autocomplete.test.tsx
@@ -62,9 +62,9 @@ describe('Autocomplete', () => {
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		if (!input) return;
 
-		// Click the input, which should focus the element
-		await act(async () => await input.click());
-		await waitFor(() => expect(input).toHaveFocus());
+		// Focus the input
+		await act(async () => await input.focus());
+		expect(input).toHaveFocus();
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 
 		expect(loadOptions).not.toHaveBeenCalled();

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -33,11 +33,11 @@ exports[`Autocomplete renders correctly 1`] = `
       <input
         aria-activedescendant=""
         aria-autocomplete="list"
-        aria-controls="downshift-0-menu"
+        aria-controls="downshift-:r1:-menu"
         aria-describedby="field-combobox-input-:r0:-hint"
         aria-expanded="false"
         aria-invalid="false"
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         aria-required="false"
         autocomplete="off"
         class="css-8coje4-ComboboxBase"
@@ -47,9 +47,9 @@ exports[`Autocomplete renders correctly 1`] = `
         value=""
       />
       <ul
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         class="css-xh5q2i-boxStyles-Popover"
-        id="downshift-0-menu"
+        id="downshift-:r1:-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
       />

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -3,7 +3,13 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
-import { render, cleanup, act, renderHook } from '../../../../test-utils';
+import {
+	render,
+	cleanup,
+	act,
+	renderHook,
+	waitFor,
+} from '../../../../test-utils';
 import { Combobox, ComboboxProps } from './Combobox';
 import { STATE_OPTIONS, Option } from './test-utils';
 
@@ -51,9 +57,11 @@ describe('Combobox', () => {
 		expect(input).toBeInTheDocument();
 		if (!input) return;
 
-		// Focus the input and start type a search term
-		act(() => input.focus());
-		expect(input).toHaveFocus();
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(input).toHaveAttribute('aria-expanded', 'true');
+
 		await userEvent.type(input, 'capital');
 		expect(input.value).toBe('capital');
 

--- a/packages/react/src/combobox/ComboboxAsync.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.test.tsx
@@ -62,9 +62,9 @@ describe('ComboboxAsync', () => {
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		if (!input) return;
 
-		// Focus the input
-		await act(async () => await input.focus());
-		expect(input).toHaveFocus();
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
 		expect(input).toHaveAttribute('aria-expanded', 'true');
 
 		// Focusing the input should trigger `loadOptions`

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -90,10 +90,12 @@ export function ComboboxAsync<Option extends DefaultComboboxOption>({
 						...changes,
 						inputValue: state.selectedItem?.label ?? '',
 					};
-				case useCombobox.stateChangeTypes.InputFocus:
+				case useCombobox.stateChangeTypes.InputClick:
 					if (!isAutocomplete) return changes;
-					return { ...changes, isOpen: false };
-
+					return {
+						...changes,
+						isOpen: false,
+					};
 				case useCombobox.stateChangeTypes.InputChange:
 					if (!isAutocomplete) return changes;
 					return {

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -67,9 +67,9 @@ describe('ComboboxAsyncMulti', () => {
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		if (!input) return;
 
-		// Focus the input
-		await act(async () => await input.focus());
-		expect(input).toHaveFocus();
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
 		expect(input).toHaveAttribute('aria-expanded', 'true');
 
 		// Focusing the input should trigger `loadOptions`

--- a/packages/react/src/combobox/ComboboxAsyncMulti.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.tsx
@@ -126,11 +126,13 @@ export function ComboboxAsyncMulti<Option extends DefaultComboboxOption>({
 		onIsOpenChange,
 		onStateChange({ type, selectedItem: newSelectedItem }) {
 			switch (type) {
-				case useCombobox.stateChangeTypes.FunctionSelectItem:
+				case useCombobox.stateChangeTypes.InputKeyDownEnter:
 				case useCombobox.stateChangeTypes.ItemClick:
 				case useCombobox.stateChangeTypes.InputBlur:
-					if (newSelectedItem)
+					if (newSelectedItem) {
 						setSelectedItems([...selectedItems, newSelectedItem]);
+						setInputValue('');
+					}
 					break;
 				default:
 					break;

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -117,9 +117,10 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 						<ComboboxButtonContainer>
 							{showDropdownTrigger && (
 								<ComboboxDropdownTrigger
-									disabled={disabled}
-									isOpen={combobox.isOpen}
-									{...combobox.getToggleButtonProps()}
+									{...combobox.getToggleButtonProps({
+										isOpen: combobox.isOpen,
+										disabled,
+									})}
 								/>
 							)}
 							{hasBothButtons && <ComboboxButtonDivider />}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -199,9 +199,10 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 								</Fragment>
 							)}
 							<ComboboxDropdownTrigger
-								disabled={disabled}
-								isOpen={combobox.isOpen}
-								{...combobox.getToggleButtonProps()}
+								{...combobox.getToggleButtonProps({
+									isOpen: combobox.isOpen,
+									disabled,
+								})}
 							/>
 						</ComboboxButtonContainer>
 					</Flex>

--- a/packages/react/src/combobox/ComboboxMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.test.tsx
@@ -3,7 +3,13 @@ import 'html-validate/jest';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { useRef } from 'react';
-import { render, cleanup, renderHook, act } from '../../../../test-utils';
+import {
+	render,
+	cleanup,
+	renderHook,
+	act,
+	waitFor,
+} from '../../../../test-utils';
 import { ComboboxMulti, ComboboxMultiProps } from './ComboboxMulti';
 import { STATE_OPTIONS } from './test-utils';
 
@@ -65,9 +71,9 @@ describe('ComboboxMulti', () => {
 		expect(input).toHaveAttribute('aria-expanded', 'false');
 		if (!input) return;
 
-		// Focus the input
-		await act(async () => await input.focus());
-		expect(input).toHaveFocus();
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
 		expect(input).toHaveAttribute('aria-expanded', 'true');
 
 		// All options should be visible

--- a/packages/react/src/combobox/ComboboxMulti.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.tsx
@@ -120,8 +120,8 @@ export function ComboboxMulti<Option extends DefaultComboboxOption>({
 				case useCombobox.stateChangeTypes.InputBlur:
 					if (newSelectedItem) {
 						setSelectedItems([...selectedItems, newSelectedItem]);
+						setInputValue('');
 					}
-					setInputValue('');
 					break;
 				case useCombobox.stateChangeTypes.InputChange:
 					setInputValue(newInputValue);

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -33,11 +33,11 @@ exports[`Combobox renders correctly 1`] = `
       <input
         aria-activedescendant=""
         aria-autocomplete="list"
-        aria-controls="downshift-0-menu"
+        aria-controls="downshift-:r1:-menu"
         aria-describedby="field-combobox-input-:r0:-hint"
         aria-expanded="false"
         aria-invalid="false"
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         aria-required="false"
         autocomplete="off"
         class="css-8coje4-ComboboxBase"
@@ -50,11 +50,11 @@ exports[`Combobox renders correctly 1`] = `
         class="css-1733k8b-boxStyles-ComboboxButtonContainer"
       >
         <button
-          aria-controls="downshift-0-menu"
+          aria-controls="downshift-:r1:-menu"
           aria-expanded="false"
           aria-label="Toggle menu"
           class="css-q06sws-BaseButton-ComboboxIconButton"
-          id="downshift-0-toggle-button"
+          id="downshift-:r1:-toggle-button"
           tabindex="-1"
           type="button"
         >
@@ -76,9 +76,9 @@ exports[`Combobox renders correctly 1`] = `
         </button>
       </div>
       <ul
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         class="css-xh5q2i-boxStyles-Popover"
-        id="downshift-0-menu"
+        id="downshift-:r1:-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
       />

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -33,11 +33,11 @@ exports[`ComboboxAsync renders correctly 1`] = `
       <input
         aria-activedescendant=""
         aria-autocomplete="list"
-        aria-controls="downshift-0-menu"
+        aria-controls="downshift-:r1:-menu"
         aria-describedby="field-combobox-input-:r0:-hint"
         aria-expanded="false"
         aria-invalid="false"
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         aria-required="false"
         autocomplete="off"
         class="css-8coje4-ComboboxBase"
@@ -50,11 +50,11 @@ exports[`ComboboxAsync renders correctly 1`] = `
         class="css-1733k8b-boxStyles-ComboboxButtonContainer"
       >
         <button
-          aria-controls="downshift-0-menu"
+          aria-controls="downshift-:r1:-menu"
           aria-expanded="false"
           aria-label="Toggle menu"
           class="css-q06sws-BaseButton-ComboboxIconButton"
-          id="downshift-0-toggle-button"
+          id="downshift-:r1:-toggle-button"
           tabindex="-1"
           type="button"
         >
@@ -76,9 +76,9 @@ exports[`ComboboxAsync renders correctly 1`] = `
         </button>
       </div>
       <ul
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         class="css-xh5q2i-boxStyles-Popover"
-        id="downshift-0-menu"
+        id="downshift-:r1:-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
       />

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -39,11 +39,11 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-0-menu"
+            aria-controls="downshift-:r1:-menu"
             aria-describedby="field-combobox-input-:r0:-hint"
             aria-expanded="false"
             aria-invalid="false"
-            aria-labelledby="downshift-0-label"
+            aria-labelledby="downshift-:r1:-label"
             aria-required="false"
             autocomplete="off"
             class="css-1l74t3i"
@@ -57,11 +57,11 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
           class="css-1733k8b-boxStyles-ComboboxButtonContainer"
         >
           <button
-            aria-controls="downshift-0-menu"
+            aria-controls="downshift-:r1:-menu"
             aria-expanded="false"
             aria-label="Toggle menu"
             class="css-q06sws-BaseButton-ComboboxIconButton"
-            id="downshift-0-toggle-button"
+            id="downshift-:r1:-toggle-button"
             tabindex="-1"
             type="button"
           >
@@ -84,9 +84,9 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
         </div>
       </div>
       <ul
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         class="css-xh5q2i-boxStyles-Popover"
-        id="downshift-0-menu"
+        id="downshift-:r1:-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
       />

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -39,11 +39,11 @@ exports[`ComboboxMulti renders correctly 1`] = `
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-0-menu"
+            aria-controls="downshift-:r1:-menu"
             aria-describedby="field-combobox-input-:r0:-hint"
             aria-expanded="false"
             aria-invalid="false"
-            aria-labelledby="downshift-0-label"
+            aria-labelledby="downshift-:r1:-label"
             aria-required="false"
             autocomplete="off"
             class="css-1l74t3i"
@@ -57,11 +57,11 @@ exports[`ComboboxMulti renders correctly 1`] = `
           class="css-1733k8b-boxStyles-ComboboxButtonContainer"
         >
           <button
-            aria-controls="downshift-0-menu"
+            aria-controls="downshift-:r1:-menu"
             aria-expanded="false"
             aria-label="Toggle menu"
             class="css-q06sws-BaseButton-ComboboxIconButton"
-            id="downshift-0-toggle-button"
+            id="downshift-:r1:-toggle-button"
             tabindex="-1"
             type="button"
           >
@@ -84,9 +84,9 @@ exports[`ComboboxMulti renders correctly 1`] = `
         </div>
       </div>
       <ul
-        aria-labelledby="downshift-0-label"
+        aria-labelledby="downshift-:r1:-label"
         class="css-xh5q2i-boxStyles-Popover"
-        id="downshift-0-menu"
+        id="downshift-:r1:-menu"
         role="listbox"
         style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7791,10 +7791,10 @@ dotenv@^16.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
-downshift@^7.4.1:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-7.4.1.tgz#50114d4479e9bd5751a9fc3af72fb12b6178147f"
-  integrity sha512-HbzzY55YB/kbtnBQVds9fVPp9JBw913HAgGFlh4q5qNlzuwFJLyM7h0mkbBRAv3TmVaSPDdprM+sTMoQeIx04w==
+downshift@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-8.1.0.tgz#72023513256134723fe807a54168ebc64f9ddf6c"
+  integrity sha512-e9EBBLZvB2G73qT272x3hExttGCH1q1usbjirm+1aMcFXuzSWhgBdbnAHPlFI2rEq61cU/kDrEIMrY+ozMhvmg==
   dependencies:
     "@babel/runtime" "^7.14.8"
     compute-scroll-into-view "^2.0.4"


### PR DESCRIPTION
Upgraded dependency on `downshift` to version 8 – [View release notes](https://github.com/downshift-js/downshift/releases).

In version 8, downshift has implemented ARIA version 1.2. In this update, the combobox will opened when the input is *clicked* and not when the input is *focused*. This is why we've had to make a few changes to the component + tests.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1343/components/combobox)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
