### PR TITLE
app-layout: Revert recent UI changes

### DIFF
--- a/.changeset/purple-ravens-grow.md
+++ b/.changeset/purple-ravens-grow.md
@@ -1,5 +1,0 @@
----
-'@ag.ds-next/react': patch
----
-
-app-layout: Decreased the gap between icons and labels in the sidebar from `1rem` to `0.75rem`

--- a/.changeset/spotty-hairs-kiss.md
+++ b/.changeset/spotty-hairs-kiss.md
@@ -1,5 +1,0 @@
----
-'@ag.ds-next/react': patch
----
-
-app-layout: Decreased border left width of active item in sidebar from 8px to 4px

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -116,7 +116,7 @@ function AppLayoutSidebarNavItemInner({
 				' a, button': {
 					display: 'flex',
 					alignItems: 'center',
-					gap: mapSpacing(0.75),
+					gap: mapSpacing(1),
 					width: '100%',
 					boxSizing: 'border-box',
 					paddingLeft: mapSpacing(1.5),

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -136,7 +136,7 @@ function AppLayoutSidebarNavItemInner({
 							top: 0,
 							left: 0,
 							bottom: 0,
-							borderLeftWidth: tokens.borderWidth.xl,
+							borderLeftWidth: tokens.borderWidth.xxl,
 							borderLeftStyle: 'solid',
 							borderLeftColor: boxPalette.selected,
 						},

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -166,7 +166,7 @@ exports[`AppLayout renders correctly 1`] = `
           class="css-o80hmi-boxStyles"
         >
           <li
-            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
+            class="css-4cl6ms-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/"
@@ -195,7 +195,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-zghvvy-AppLayoutSidebarNavItemInner"
+            class="css-wr0h17-AppLayoutSidebarNavItemInner"
           >
             <a
               aria-current="page"
@@ -222,7 +222,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
+            class="css-4cl6ms-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/intelligence"
@@ -248,7 +248,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
+            class="css-4cl6ms-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/compliance"
@@ -287,7 +287,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-ol2a3a-AppLayoutSidebarNavItemInner"
+            class="css-oyhr1z-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account/messages"
@@ -326,7 +326,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
+            class="css-4cl6ms-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account/settings"
@@ -357,7 +357,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
+            class="css-4cl6ms-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/help"
@@ -391,7 +391,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-3hp7y0-AppLayoutSidebarNavItemInner"
+            class="css-4cl6ms-AppLayoutSidebarNavItemInner"
           >
             <button
               class="css-6e6ykx-BaseButton"

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -195,7 +195,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-9fl0nt-AppLayoutSidebarNavItemInner"
+            class="css-zghvvy-AppLayoutSidebarNavItemInner"
           >
             <a
               aria-current="page"


### PR DESCRIPTION
This reverts PR #1302 and PR #1309.

The reason for this is because if teams do not upgrade all at once, there will be layouts fits between the micro-frontends.

We will re-apply these changes when PR #1261 is merged and ready to be deployed.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1348)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

