### PR TITLE
checkbox: Add indeterminate state

### DIFF
--- a/.changeset/stale-bees-fail.md
+++ b/.changeset/stale-bees-fail.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+icon: Add new icon `MinusIcon`
+
+checkbox: Added support for indeterminate checkboxes via a new `indeterminate` prop

--- a/docs/components/designSystemComponents.tsx
+++ b/docs/components/designSystemComponents.tsx
@@ -108,6 +108,7 @@ export {
 	InstagramIcon,
 	LinkedInIcon,
 	MenuIcon,
+	MinusIcon,
 	PlusIcon,
 	PrintIcon,
 	ProgressBlockedIcon,

--- a/docs/playroom/snippets.ts
+++ b/docs/playroom/snippets.ts
@@ -515,7 +515,16 @@ items={[
 	{
 		group: 'Checkbox',
 		name: 'Basic',
-		code: `<Checkbox checked={false}>Label</Checkbox>`,
+		code: `<Checkbox>Label</Checkbox>`,
+	},
+	{
+		group: 'Checkbox',
+		name: 'Group',
+		code: `<ControlGroup>
+			<Checkbox>Phone</Checkbox>
+			<Checkbox>Tablet</Checkbox>
+			<Checkbox>Laptop</Checkbox>
+		</ControlGroup>`,
 	},
 	{
 		group: 'Radio',

--- a/packages/react/src/checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/checkbox/Checkbox.stories.tsx
@@ -4,6 +4,11 @@ import { Checkbox } from './Checkbox';
 const meta: Meta<typeof Checkbox> = {
 	title: 'forms/Checkbox',
 	component: Checkbox,
+	args: {
+		children: 'Example',
+		disabled: false,
+		size: 'md',
+	},
 };
 
 export default meta;
@@ -11,9 +16,19 @@ export default meta;
 type Story = StoryObj<typeof Checkbox>;
 
 export const Basic: Story = {
+	args: {},
+};
+
+export const Checked: Story = {
+	args: {
+		checked: true,
+	},
+};
+
+export const Indeterminate: Story = {
 	args: {
 		children: 'Example',
-		disabled: false,
+		indeterminate: true,
 	},
 };
 
@@ -21,7 +36,6 @@ export const Size: Story = {
 	args: {
 		size: 'sm',
 		children: 'Small example',
-		disabled: false,
 	},
 };
 
@@ -34,8 +48,6 @@ export const Disabled: Story = {
 
 export const Invalid: Story = {
 	args: {
-		children: 'Invalid',
 		invalid: true,
-		disabled: false,
 	},
 };

--- a/packages/react/src/checkbox/Checkbox.test.tsx
+++ b/packages/react/src/checkbox/Checkbox.test.tsx
@@ -79,7 +79,11 @@ describe('Checkbox', () => {
 
 	describe('indeterminate', () => {
 		it('renders valid HTML with no a11y violations', async () => {
-			const { container } = renderCheckbox({ indeterminate: true });
+			const { container } = renderCheckbox({
+				checked: false,
+				indeterminate: true,
+				onChange: jest.fn(),
+			});
 			expect(container).toHTMLValidate({
 				extends: ['html-validate:recommended'],
 			});
@@ -87,7 +91,22 @@ describe('Checkbox', () => {
 		});
 
 		it('renders correct attributes', () => {
-			renderCheckbox({ indeterminate: true });
+			renderCheckbox({
+				checked: false,
+				indeterminate: true,
+				onChange: jest.fn(),
+			});
+			const el = getCheckbox();
+			expect(el).not.toHaveAttribute('checked');
+			expect(el).toHaveAttribute('aria-checked', 'mixed');
+		});
+
+		it('overrides checked prop', () => {
+			renderCheckbox({
+				indeterminate: true,
+				checked: true,
+				onChange: jest.fn(),
+			});
 			const el = getCheckbox();
 			expect(el).not.toHaveAttribute('checked');
 			expect(el).toHaveAttribute('aria-checked', 'mixed');

--- a/packages/react/src/checkbox/Checkbox.test.tsx
+++ b/packages/react/src/checkbox/Checkbox.test.tsx
@@ -9,18 +9,35 @@ expect.extend(toHaveNoViolations);
 
 afterEach(cleanup);
 
-function CheckboxExample(props: CheckboxProps) {
-	return (
+function renderCheckbox(props?: CheckboxProps) {
+	return render(
 		<Checkbox data-testid="example" name="my-checkbox" {...props}>
 			My checkbox
 		</Checkbox>
 	);
 }
 
+function getCheckbox() {
+	return screen.getByTestId('example');
+}
+
 describe('Checkbox', () => {
-	it('renders correctly with minimal props', () => {
-		render(<CheckboxExample />);
-		const el = screen.getByTestId('example');
+	it('renders correctly', () => {
+		const { container } = renderCheckbox();
+		expect(container).toMatchSnapshot();
+	});
+
+	it('renders valid HTML with no a11y violations', async () => {
+		const { container } = renderCheckbox();
+		expect(container).toHTMLValidate({
+			extends: ['html-validate:recommended'],
+		});
+		expect(await axe(container)).toHaveNoViolations();
+	});
+
+	it('renders correct attributes', () => {
+		renderCheckbox();
+		const el = getCheckbox();
 		expect(el).toBeInTheDocument();
 		expect(el.tagName).toBe('INPUT');
 		expect(el).toHaveAttribute('type', 'checkbox');
@@ -29,28 +46,51 @@ describe('Checkbox', () => {
 		expect(el).toHaveAccessibleName('My checkbox');
 	});
 
-	it('renders correctly when invalid ', () => {
-		render(<CheckboxExample invalid />);
-		const el = screen.getByTestId('example');
-		expect(el).toHaveAttribute('aria-invalid', 'true');
+	it('responds when clicked', async () => {
+		renderCheckbox();
+		expect(getCheckbox()).not.toBeChecked();
+		await userEvent.click(getCheckbox());
+		expect(getCheckbox()).toBeChecked();
 	});
 
-	it('renders valid HTML with no a11y violations', async () => {
-		const { container } = render(<CheckboxExample />);
-		expect(container).toHTMLValidate({
-			extends: ['html-validate:recommended'],
+	describe('checked', () => {
+		it('renders correct attributes', () => {
+			renderCheckbox({ checked: true, onChange: jest.fn() });
+			const el = getCheckbox();
+			expect(el).toBeChecked();
 		});
-		expect(await axe(container)).toHaveNoViolations();
 	});
 
-	it('renders correctly', () => {
-		const { container } = render(<CheckboxExample />);
-		expect(container).toMatchSnapshot();
+	describe('invalid', () => {
+		it('renders valid HTML with no a11y violations', async () => {
+			const { container } = renderCheckbox({ invalid: true });
+			expect(container).toHTMLValidate({
+				extends: ['html-validate:recommended'],
+			});
+			expect(await axe(container)).toHaveNoViolations();
+		});
+
+		it('renders correct attributes', () => {
+			renderCheckbox({ invalid: true });
+			const el = getCheckbox();
+			expect(el).toHaveAttribute('aria-invalid', 'true');
+		});
 	});
 
-	it('responds to a change event', async () => {
-		render(<CheckboxExample />);
-		await userEvent.click(screen.getByTestId('example'));
-		expect(screen.getByTestId('example')).toBeChecked();
+	describe('indeterminate', () => {
+		it('renders valid HTML with no a11y violations', async () => {
+			const { container } = renderCheckbox({ indeterminate: true });
+			expect(container).toHTMLValidate({
+				extends: ['html-validate:recommended'],
+			});
+			expect(await axe(container)).toHaveNoViolations();
+		});
+
+		it('renders correct attributes', () => {
+			renderCheckbox({ indeterminate: true });
+			const el = getCheckbox();
+			expect(el).not.toHaveAttribute('checked');
+			expect(el).toHaveAttribute('aria-checked', 'mixed');
+		});
 	});
 });

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -49,6 +49,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 			invalid: invalidProp,
 			size = 'md',
 			indeterminate,
+			checked: checkedProp,
 			...props
 		},
 		forwardedRef
@@ -63,6 +64,9 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 			ref.current.indeterminate = Boolean(indeterminate);
 		}, [indeterminate]);
 
+		// `indeterminate` should override the `checked` prop
+		const checked = indeterminate ? false : checkedProp;
+
 		return (
 			<CheckboxContainer disabled={disabled}>
 				<CheckboxInput
@@ -73,6 +77,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 					aria-describedby={
 						invalid ? controlGroupContext?.messageId : undefined
 					}
+					checked={checked}
 					aria-checked={indeterminate ? 'mixed' : undefined}
 					{...props}
 				/>

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -1,4 +1,11 @@
-import { forwardRef, InputHTMLAttributes, PropsWithChildren } from 'react';
+import {
+	forwardRef,
+	InputHTMLAttributes,
+	PropsWithChildren,
+	useEffect,
+	useRef,
+} from 'react';
+import { mergeRefs } from '../core';
 import { useControlGroupContext } from '../control-group/ControlGroupProvider';
 import { CheckboxIndicator } from './CheckboxIndicator';
 import { CheckboxInput } from './CheckboxInput';
@@ -26,6 +33,7 @@ type BaseCheckboxProps = PropsWithChildren<{
 }>;
 
 export type CheckboxProps = BaseCheckboxProps & {
+	indeterminate?: boolean;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	/** The size of the input. */
@@ -34,15 +42,30 @@ export type CheckboxProps = BaseCheckboxProps & {
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 	function Checkbox(
-		{ children, disabled, invalid: invalidProp, size = 'md', ...props },
-		ref
+		{
+			children,
+			disabled,
+			invalid: invalidProp,
+			size = 'md',
+			indeterminate,
+			...props
+		},
+		forwardedRef
 	) {
+		const ref = useRef<HTMLInputElement>(null);
 		const controlGroupContext = useControlGroupContext();
 		const invalid = invalidProp || controlGroupContext?.invalid;
+
+		// `indeterminate` cannot be set using an HTML attribute
+		useEffect(() => {
+			if (!ref.current) return;
+			ref.current.indeterminate = Boolean(indeterminate);
+		}, [indeterminate]);
+
 		return (
 			<CheckboxContainer disabled={disabled}>
 				<CheckboxInput
-					ref={ref}
+					ref={mergeRefs([forwardedRef, ref])}
 					type="checkbox"
 					disabled={disabled}
 					aria-invalid={invalid ? 'true' : undefined}
@@ -51,7 +74,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 					}
 					{...props}
 				/>
-				<CheckboxIndicator disabled={disabled} invalid={invalid} size={size} />
+				<CheckboxIndicator
+					disabled={disabled}
+					invalid={invalid}
+					size={size}
+					indeterminate={indeterminate}
+				/>
 				<CheckboxLabel disabled={disabled} size={size}>
 					{children}
 				</CheckboxLabel>

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -33,6 +33,7 @@ type BaseCheckboxProps = PropsWithChildren<{
 }>;
 
 export type CheckboxProps = BaseCheckboxProps & {
+	/** Used to represent a group of checkboxes that has a mix of selected and unselected values. */
 	indeterminate?: boolean;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
@@ -72,6 +73,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 					aria-describedby={
 						invalid ? controlGroupContext?.messageId : undefined
 					}
+					aria-checked={indeterminate ? 'mixed' : undefined}
 					{...props}
 				/>
 				<CheckboxIndicator

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -58,7 +58,8 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 		const controlGroupContext = useControlGroupContext();
 		const invalid = invalidProp || controlGroupContext?.invalid;
 
-		// `indeterminate` cannot be set using an HTML attribute
+		//`indeterminate` is set using the HTMLInputElement object's indeterminate property via JavaScript (it cannot be set using an HTML attribute)
+		// Read more about this here https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes
 		useEffect(() => {
 			if (!ref.current) return;
 			ref.current.indeterminate = Boolean(indeterminate);

--- a/packages/react/src/checkbox/CheckboxIndicator.tsx
+++ b/packages/react/src/checkbox/CheckboxIndicator.tsx
@@ -1,16 +1,18 @@
 import { Flex } from '../flex';
 import { boxPalette, packs } from '../core';
-import { CheckIcon } from '../icon';
+import { CheckIcon, MinusIcon } from '../icon';
 import { CheckboxSize } from './utils';
 
 export type CheckboxIndicatorProps = {
 	disabled?: boolean;
+	indeterminate?: boolean;
 	invalid?: boolean;
 	size: CheckboxSize;
 };
 
 export const CheckboxIndicator = ({
 	disabled,
+	indeterminate,
 	invalid,
 	size,
 }: CheckboxIndicatorProps) => {
@@ -43,7 +45,11 @@ export const CheckboxIndicator = ({
 			}}
 			rounded
 		>
-			<CheckIcon size={size} weight="bold" />
+			{indeterminate ? (
+				<MinusIcon size={size} weight="bold" />
+			) : (
+				<CheckIcon size={size} weight="bold" />
+			)}
 		</Flex>
 	);
 };

--- a/packages/react/src/checkbox/CheckboxInput.tsx
+++ b/packages/react/src/checkbox/CheckboxInput.tsx
@@ -13,9 +13,11 @@ export const CheckboxInput = forwardRef<HTMLInputElement, ControlInputProps>(
 					...visuallyHiddenStyles,
 					// When this component is focused, outline the `CheckboxIndicator`
 					'&:focus ~ span:first-of-type': packs.outline,
-					// When this component is checked, show the indicators active state
+					// When this component is checked or indeterminate, show the indicators active state
 					'~ span > svg': { opacity: 0 },
-					'&:checked ~ span > svg': { opacity: 1 },
+					'&:checked ~ span > svg, &:indeterminate ~ span > svg': {
+						opacity: 1,
+					},
 				}}
 				{...props}
 			/>

--- a/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react/src/checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Checkbox renders correctly 1`] = `
     class="css-hp3wbe-boxStyles-CheckboxContainer"
   >
     <input
-      class="css-2fffox-CheckboxInput"
+      class="css-142kh0r-CheckboxInput"
       data-testid="example"
       name="my-checkbox"
       type="checkbox"

--- a/packages/react/src/checkbox/docs/overview.mdx
+++ b/packages/react/src/checkbox/docs/overview.mdx
@@ -122,7 +122,7 @@ Disabled checkboxes can be used to indicate inputs that are no longer valid or e
 
 ## Indeterminate
 
-An [indeterminate checkbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) is used to represent a group of checkboxes that has a mix of selected and unselected values.
+A [indeterminate checkbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) is used to represent a group of checkboxes that has a mix of selected and unselected values.
 
 When a checkbox is indeterminate, it overrides the checked state.
 

--- a/packages/react/src/checkbox/docs/overview.mdx
+++ b/packages/react/src/checkbox/docs/overview.mdx
@@ -114,7 +114,20 @@ Disabled checkboxes can be used to indicate inputs that are no longer valid or e
 	<Checkbox value="tablet" checked disabled>
 		Disabled and checked checkbox
 	</Checkbox>
+	<Checkbox value="laptop" indeterminate disabled>
+		Disabled and indeterminate checkbox
+	</Checkbox>
 </Stack>
+```
+
+## Indeterminate
+
+An [indeterminate checkbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) is used to represent a group of checkboxes that has a mix of selected and unselected values.
+
+When a checkbox is indeterminate, it overrides the checked state.
+
+```jsx live
+<Checkbox indeterminate>Indeterminate</Checkbox>
 ```
 
 ## Small checkboxes

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-a"
               type="checkbox"
             />
@@ -67,7 +67,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-b"
               type="checkbox"
             />
@@ -100,7 +100,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-c"
               type="checkbox"
             />
@@ -133,7 +133,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
             class="css-hp3wbe-boxStyles-CheckboxContainer"
           >
             <input
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-d"
               type="checkbox"
             />
@@ -246,7 +246,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-a"
               type="checkbox"
             />
@@ -281,7 +281,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-b"
               type="checkbox"
             />
@@ -316,7 +316,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-c"
               type="checkbox"
             />
@@ -351,7 +351,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
             <input
               aria-describedby="control-group-:r2:-message"
               aria-invalid="true"
-              class="css-2fffox-CheckboxInput"
+              class="css-142kh0r-CheckboxInput"
               data-testid="option-d"
               type="checkbox"
             />

--- a/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
+++ b/packages/react/src/icon/__snapshots__/Icon.test.tsx.snap
@@ -817,6 +817,29 @@ exports[`Icon MenuIcon renders correctly 1`] = `
 </div>
 `;
 
+exports[`Icon MinusIcon renders correctly 1`] = `
+<div>
+  <svg
+    aria-hidden="true"
+    class="css-9s3cfn-Icon"
+    clip-rule="evenodd"
+    focusable="false"
+    height="24"
+    role="img"
+    viewBox="0 0 24 24"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <line
+      x1="5"
+      x2="19"
+      y1="12"
+      y2="12"
+    />
+  </svg>
+</div>
+`;
+
 exports[`Icon PlusIcon renders correctly 1`] = `
 <div>
   <svg

--- a/packages/react/src/icon/icons/MinusIcon.tsx
+++ b/packages/react/src/icon/icons/MinusIcon.tsx
@@ -1,0 +1,6 @@
+import { createIcon } from '../Icon';
+
+export const MinusIcon = createIcon(
+	<line x1="5" y1="12" x2="19" y2="12" />,
+	'PlusIcon'
+);

--- a/packages/react/src/icon/index.ts
+++ b/packages/react/src/icon/index.ts
@@ -45,6 +45,7 @@ export { ProgressBlockedIcon } from './icons/ProgressBlockedIcon';
 export { ProgressDoingIcon } from './icons/ProgressDoingIcon';
 export { ExternalLinkIcon } from './icons/ExternalLinkIcon';
 export { MenuIcon } from './icons/MenuIcon';
+export { MinusIcon } from './icons/MinusIcon';
 export { SearchIcon } from './icons/SearchIcon';
 export { SettingsIcon } from './icons/SettingsIcon';
 export { SuccessIcon } from './icons/SuccessIcon';

--- a/packages/react/src/icon/utils.tsx
+++ b/packages/react/src/icon/utils.tsx
@@ -34,6 +34,7 @@ import { PlusIcon } from './icons/PlusIcon';
 import { InfoFilledIcon } from './icons/InfoFilledIcon';
 import { InstagramIcon } from './icons/InstagramIcon';
 import { MenuIcon } from './icons/MenuIcon';
+import { MinusIcon } from './icons/MinusIcon';
 import { LinkedInIcon } from './icons/LinkedInIcon';
 import { PrintIcon } from './icons/PrintIcon';
 import { ProgressBlockedIcon } from './icons/ProgressBlockedIcon';
@@ -88,6 +89,7 @@ export const allIcons = {
 	InstagramIcon,
 	LinkedInIcon,
 	MenuIcon,
+	MinusIcon,
 	PrintIcon,
 	PlusIcon,
 	ProgressBlockedIcon,


### PR DESCRIPTION
Added support for indeterminate checkboxes via a new `indeterminate` prop

An [indeterminate checkbox](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) is used to represent a group of checkboxes that has a mix of selected and unselected values.

When a checkbox is indeterminate, it overrides the checked state.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1351/components/checkbox)

## Screenshot 

<img width="819" alt="Screenshot 2023-08-29 at 11 44 23 am" src="https://github.com/steelthreads/agds-next/assets/6265154/598b1d17-2a6c-452f-a5c1-766f3a9c990e">

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets