### PR TITLE
prose: Update `mark` styles

### DIFF
--- a/.changeset/purple-glasses-switch.md
+++ b/.changeset/purple-glasses-switch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+patch: Updated `mark` styles

--- a/packages/react/src/prose/Prose.stories.tsx
+++ b/packages/react/src/prose/Prose.stories.tsx
@@ -163,7 +163,7 @@ const UnstyledContent = () => (
 		</p>
 
 		<p>
-			Now to the <mark>mark</mark> element. This has a few useful applications:
+			Now to the <code>mark</code> element. This has a few useful applications:
 		</p>
 
 		<ul>

--- a/packages/react/src/prose/Prose.stories.tsx
+++ b/packages/react/src/prose/Prose.stories.tsx
@@ -1,11 +1,35 @@
 import { Fragment } from 'react';
-import { ComponentMeta } from '@storybook/react';
-import { Prose } from './index';
+import { Meta, StoryObj } from '@storybook/react';
+import { Box } from '../box';
+import { Prose } from './Prose';
 
-export default {
+const meta: Meta<typeof Prose> = {
 	title: 'content/Prose',
 	component: Prose,
-} as ComponentMeta<typeof Prose>;
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Prose>;
+
+export const Basic: Story = {
+	render: () => (
+		<Prose>
+			<UnstyledContent />
+		</Prose>
+	),
+};
+
+export const BodyAlt: Story = {
+	name: 'On BodyAlt background',
+	render: () => (
+		<Box background="bodyAlt" padding={1.5}>
+			<Prose>
+				<UnstyledContent />
+			</Prose>
+		</Box>
+	),
+};
 
 const UnstyledContent = () => (
 	<Fragment>
@@ -139,7 +163,7 @@ const UnstyledContent = () => (
 		</p>
 
 		<p>
-			Now to the <code>mark</code> element. This has a few useful applications:
+			Now to the <mark>mark</mark> element. This has a few useful applications:
 		</p>
 
 		<ul>
@@ -220,10 +244,4 @@ const UnstyledContent = () => (
 
 		<p>And that&apos;s a wrap.</p>
 	</Fragment>
-);
-
-export const Basic = () => (
-	<Prose>
-		<UnstyledContent />
-	</Prose>
 );

--- a/packages/react/src/prose/Prose.tsx
+++ b/packages/react/src/prose/Prose.tsx
@@ -60,14 +60,6 @@ export const proseClass = css({
 	'[tabindex="0"]:focus, :target': packs.outline,
 
 	/**
-	 * `mark` styling.
-	 */
-	[`mark${notSelector}`]: {
-		color: boxPalette.backgroundBody,
-		backgroundColor: boxPalette.foregroundAction,
-	},
-
-	/**
 	 * Text selection styling
 	 */
 	'& ::selection': {


### PR DESCRIPTION
When using a `<mark>` element inside of our `Prose` component, we apply the `foregroundAction` token as the background color, and the `bodyBackground` token as the text color. These styles were taken from GOLD, but it does seem very odd.

### Preview changes

- [Body](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fdesign-system.agriculture.gov.au.mcas.ms%2Fpr-preview%2Fpr-1355%2Fstorybook%2Findex.html%3Fpath%3D%2Fstory%2Fcontent-prose--basic%26McasTsid%3D26110&McasCSRF=d716213ed644f002dc8ebd0b01d84b6957b9d0a27ce51d704f7db71633b34098)
- [Body Alt](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fdesign-system.agriculture.gov.au.mcas.ms%2Fpr-preview%2Fpr-1355%2Fstorybook%2Findex.html%3Fpath%3D%2Fstory%2Fcontent-prose--body-alt%26McasTsid%3D26110&McasCSRF=d716213ed644f002dc8ebd0b01d84b6957b9d0a27ce51d704f7db71633b34098)
- [Dark Body](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fdesign-system.agriculture.gov.au.mcas.ms%2Fpr-preview%2Fpr-1355%2Fstorybook%2Findex.html%3Fpath%3D%2Fstory%2Fcontent-prose--basic%26globals%3Dpalette%253Adark%26McasTsid%3D26110&McasCSRF=d716213ed644f002dc8ebd0b01d84b6957b9d0a27ce51d704f7db71633b34098)
- [Dark BodyAlt](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fdesign-system.agriculture.gov.au.mcas.ms%2Fpr-preview%2Fpr-1355%2Fstorybook%2Findex.html%3Fpath%3D%2Fstory%2Fcontent-prose--body-alt%26globals%3Dpalette%253Adark%26McasTsid%3D26110&McasCSRF=d716213ed644f002dc8ebd0b01d84b6957b9d0a27ce51d704f7db71633b34098)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.