### PR TITLE
core: Added xxl breakpoint token

### DIFF
--- a/.changeset/four-coats-invite.md
+++ b/.changeset/four-coats-invite.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+Core: Added xxl breakpoint token

--- a/packages/react/src/core/responsive.ts
+++ b/packages/react/src/core/responsive.ts
@@ -16,10 +16,13 @@ export const mq = facepaint([
 	tokens.mediaQuery.min.md,
 	tokens.mediaQuery.min.lg,
 	tokens.mediaQuery.min.xl,
+	tokens.mediaQuery.min.xxl,
 ]);
 
 type NamedBreakpoint = keyof typeof tokens.breakpoint;
-export const breakpointNames = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
+export const breakpointNames = Object.keys(
+	tokens.breakpoint
+) as NamedBreakpoint[];
 
 export function mapResponsiveProp<T>(
 	value: ResponsiveProp<T>,

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -16,12 +16,14 @@ const mediaQuery = {
 		md: `@media(min-width: ${breakpoint.md}px)`,
 		lg: `@media(min-width: ${breakpoint.lg}px)`,
 		xl: `@media(min-width: ${breakpoint.xl}px)`,
+		xxl: `@media(min-width: ${breakpoint.xxl}px)`,
 	},
 	max: {
 		xs: `@media(max-width: ${breakpoint.sm - 1}px)`,
 		sm: `@media(max-width: ${breakpoint.md - 1}px)`,
 		md: `@media(max-width: ${breakpoint.lg - 1}px)`,
 		lg: `@media(max-width: ${breakpoint.xl - 1}px)`,
+		xl: `@media(max-width: ${breakpoint.xxl - 1}px)`,
 	},
 };
 

--- a/packages/react/src/core/tokens.ts
+++ b/packages/react/src/core/tokens.ts
@@ -6,6 +6,7 @@ const breakpoint = {
 	md: 768,
 	lg: 992,
 	xl: 1200,
+	xxl: 1600,
 } as const;
 
 const mediaQuery = {


### PR DESCRIPTION
Created an xxl breakpoint to enable different layouts for wide screens - intended to enable more dense screens where needed.

There isn't any science behind the 1800px number (apart from it being a few hundred px larger than 1200), so it can be changed if needed.

- [Breakpoint docs](https://design-system.agriculture.gov.au/pr-preview/pr-1359/foundations/tokens/breakpoints)
- [Playroom with working xxl token](https://design-system.agriculture.gov.au/pr-preview/pr-1359/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPAOgOwAS8gBsIAnAXmGB333QGd5dMQBDMAFwEsJtmAaajXTpCjZnQCuYMDDp1%2BggL6KcAPkEBhHuxjZ2OJAHo06ddhCKgA)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
