### PR TITLE
control-group: Add wrapping

### DIFF
--- a/.changeset/perfect-terms-lay.md
+++ b/.changeset/perfect-terms-lay.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+control-group: Added flex wrapping so horizontal options can break into multiple lines if required.

--- a/packages/react/src/control-group/ControlGroup.tsx
+++ b/packages/react/src/control-group/ControlGroup.tsx
@@ -73,6 +73,7 @@ export const ControlGroup = ({
 						<Flex
 							gap={1}
 							flexDirection={block ? 'column' : 'row'}
+							flexWrap={block ? undefined : 'wrap'}
 							width="100%"
 							paddingTop={0.5}
 						>

--- a/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
+++ b/packages/react/src/control-group/__snapshots__/ControlGroup.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`ControlGroup  With Checkboxes renders correctly 1`] = `
         class="css-1ypnbyi-boxStyles-ControlGroup"
       >
         <div
-          class="css-1n3rct3-boxStyles"
+          class="css-1lk80kr-boxStyles"
         >
           <label
             class="css-hp3wbe-boxStyles-CheckboxContainer"
@@ -238,7 +238,7 @@ exports[`ControlGroup  With Checkboxes renders correctly when invalid 1`] = `
           </span>
         </div>
         <div
-          class="css-1n3rct3-boxStyles"
+          class="css-1lk80kr-boxStyles"
         >
           <label
             class="css-hp3wbe-boxStyles-CheckboxContainer"
@@ -415,7 +415,7 @@ exports[`ControlGroup  With Radios renders correctly 1`] = `
         class="css-1ypnbyi-boxStyles-ControlGroup"
       >
         <div
-          class="css-1n3rct3-boxStyles"
+          class="css-1lk80kr-boxStyles"
         >
           <label
             class="css-6pplfb-boxStyles-RadioContainer"
@@ -577,7 +577,7 @@ exports[`ControlGroup  With Radios renders correctly when invalid 1`] = `
           </span>
         </div>
         <div
-          class="css-1n3rct3-boxStyles"
+          class="css-1lk80kr-boxStyles"
         >
           <label
             class="css-6pplfb-boxStyles-RadioContainer"


### PR DESCRIPTION
Added flex wrapping so horizontal options can break into multiple lines if required.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1366/components/control-group)

## Screenshots

| Before | After |
|--------|--------|
| <img width="418" alt="Screenshot 2023-09-11 at 12 01 14 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/f78fa9ee-934f-4beb-b8bd-58737ce174fd"> | <img width="423" alt="Screenshot 2023-09-11 at 12 01 02 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/3caec3ef-0306-4a8a-90a0-1a9443faeaaf"> |
| <img width="424" alt="Screenshot 2023-09-11 at 12 01 49 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/7b32b3c1-2af0-41bc-88e3-ebaeffbddbae"> | <img width="420" alt="Screenshot 2023-09-11 at 12 02 01 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/fc947ead-8658-4d79-bf57-0f72ffba85d1"> | 

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
