### PR TITLE
dropdown-menu: Add `popoverOffset` prop

### DIFF
--- a/.changeset/twenty-falcons-dance.md
+++ b/.changeset/twenty-falcons-dance.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+dropdown-menu: Added new props `offset` and `matchReferenceWidth`
+
+dropdown-menu: Swapped from display style to conditional rendering to improve panel element anchoring

--- a/.changeset/twenty-falcons-dance.md
+++ b/.changeset/twenty-falcons-dance.md
@@ -4,4 +4,6 @@
 
 dropdown-menu: Added new props `offset` and `matchReferenceWidth`
 
+dropdown-menu: Updated padding of label element in `DropdownMenuGroup` 
+
 dropdown-menu: Swapped from display style to conditional rendering to improve panel element anchoring

--- a/.changeset/twenty-falcons-dance.md
+++ b/.changeset/twenty-falcons-dance.md
@@ -2,7 +2,7 @@
 '@ag.ds-next/react': minor
 ---
 
-dropdown-menu: Added new props `offset` and `matchReferenceWidth`
+dropdown-menu: Added new prop `offset`
 
 dropdown-menu: Updated padding of label element in `DropdownMenuGroup` 
 

--- a/packages/react/src/_popover/Popover.tsx
+++ b/packages/react/src/_popover/Popover.tsx
@@ -73,7 +73,6 @@ export function usePopover<RT extends ReferenceType = ReferenceType>(
 				padding: DEFAULT_OFFSET, // Prevents the floating element hit the edge of the screen
 				apply({ availableWidth, availableHeight, elements, rects }) {
 					Object.assign(elements.floating.style, {
-						maxWidth: `${availableWidth}px`,
 						maxHeight: `${
 							// Popovers can have a predefined max-height if there is enough room on the screen
 							maxHeight && availableHeight > maxHeight
@@ -81,9 +80,13 @@ export function usePopover<RT extends ReferenceType = ReferenceType>(
 								: availableHeight
 						}px`,
 						// https://floating-ui.com/docs/size#match-reference-width
-						...(matchReferenceWidth && {
-							width: `${rects.reference.width}px`,
-						}),
+						...(matchReferenceWidth
+							? {
+									width: `${rects.reference.width}px`,
+							  }
+							: {
+									maxWidth: `${availableWidth}px`,
+							  }),
 					});
 				},
 			}),
@@ -113,9 +116,19 @@ export function usePopover<RT extends ReferenceType = ReferenceType>(
 		};
 	}
 
+	function getOptions() {
+		return {
+			placement,
+			matchReferenceWidth,
+			maxHeight,
+			offset: offsetOption,
+		};
+	}
+
 	return {
 		getReferenceProps,
 		getPopoverProps,
+		getOptions,
 		referenceRef: refs.reference,
 		popoverRef: refs.floating,
 	};

--- a/packages/react/src/_popover/Popover.tsx
+++ b/packages/react/src/_popover/Popover.tsx
@@ -48,7 +48,7 @@ type UsePopoverOptions = {
 	maxHeight?: number;
 	/** If true, the popover element will match the width of the reference element. */
 	matchReferenceWidth?: boolean;
-	/** Used to control the distance between the reference element and popover element. */
+	/** Used to control the vertical distance between the reference element and popover element. Value is in pixels. */
 	offset?: number;
 };
 

--- a/packages/react/src/_popover/Popover.tsx
+++ b/packages/react/src/_popover/Popover.tsx
@@ -45,6 +45,7 @@ type UsePopoverOptions = {
 	placement?: Placement;
 	matchReferenceWidth?: boolean;
 	maxHeight?: number;
+	offset?: number;
 };
 
 export function usePopover<RT extends ReferenceType = ReferenceType>(
@@ -54,20 +55,22 @@ export function usePopover<RT extends ReferenceType = ReferenceType>(
 		placement = 'bottom-start',
 		matchReferenceWidth = false,
 		maxHeight,
+		offset: offsetOption = DEFAULT_OFFSET,
 	} = options || {};
+
 	const { refs, floatingStyles } = useFloating<RT>({
 		placement,
 		middleware: [
 			// Adds distance between the reference and floating element
 			// https://floating-ui.com/docs/offset
-			offset(DEFAULT_OFFSET),
+			offset(offsetOption),
 			// Changes the placement of the floating element in order to keep it in view
 			// https://floating-ui.com/docs/flip
 			flip(),
 			// Allows you to change the size of the floating element
 			// https://floating-ui.com/docs/size
 			size({
-				padding: DEFAULT_OFFSET,
+				padding: DEFAULT_OFFSET, // Prevents the floating element hit the edge of the screen
 				apply({ availableWidth, availableHeight, elements, rects }) {
 					Object.assign(elements.floating.style, {
 						maxWidth: `${availableWidth}px`,

--- a/packages/react/src/_popover/Popover.tsx
+++ b/packages/react/src/_popover/Popover.tsx
@@ -42,9 +42,13 @@ export const Popover = forwardRefWithAs<'div', PopoverProps>(function Popover(
 const DEFAULT_OFFSET = 8;
 
 type UsePopoverOptions = {
+	/** The placement of the popover element in relation to the reference element. */
 	placement?: Placement;
-	matchReferenceWidth?: boolean;
+	/** The maximum height of the popover element. */
 	maxHeight?: number;
+	/** If true, the popover element will match the width of the reference element. */
+	matchReferenceWidth?: boolean;
+	/** Used to control the distance between the reference element and popover element. */
 	offset?: number;
 };
 
@@ -116,19 +120,9 @@ export function usePopover<RT extends ReferenceType = ReferenceType>(
 		};
 	}
 
-	function getOptions() {
-		return {
-			placement,
-			matchReferenceWidth,
-			maxHeight,
-			offset: offsetOption,
-		};
-	}
-
 	return {
 		getReferenceProps,
 		getPopoverProps,
-		getOptions,
 		referenceRef: refs.reference,
 		popoverRef: refs.floating,
 	};

--- a/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
@@ -128,11 +128,7 @@ export const Placement: StoryObj = {
 		return (
 			<Stack gap={2} alignItems="center">
 				{placements.map((placement) => (
-					<DropdownMenu
-						key={placement}
-						popoverPlacement={placement}
-						matchReferenceWidth={true}
-					>
+					<DropdownMenu key={placement} popoverPlacement={placement}>
 						<DropdownMenuButton variant="primary">
 							{placement}
 						</DropdownMenuButton>

--- a/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
@@ -438,31 +438,8 @@ export const Overflow: StoryObj = {
 export const Offset: StoryObj = {
 	render: function Render() {
 		return (
-			<DropdownMenu offset={-8}>
+			<DropdownMenu popoverOffset={-8}>
 				<DropdownMenuButton variant="primary">
-					Toggle dropdown menu
-				</DropdownMenuButton>
-				<DropdownMenuPanel>
-					<DropdownMenuItem onClick={() => console.log('Profile')}>
-						Profile
-					</DropdownMenuItem>
-					<DropdownMenuItem onClick={() => console.log('Messages')}>
-						Messages
-					</DropdownMenuItem>
-					<DropdownMenuItem onClick={() => console.log('Account settings')}>
-						Account settings
-					</DropdownMenuItem>
-				</DropdownMenuPanel>
-			</DropdownMenu>
-		);
-	},
-};
-
-export const MatchReferenceWith: StoryObj = {
-	render: function Render() {
-		return (
-			<DropdownMenu matchReferenceWidth={true}>
-				<DropdownMenuButton variant="primary" css={{ width: '40rem' }}>
 					Toggle dropdown menu
 				</DropdownMenuButton>
 				<DropdownMenuPanel>

--- a/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
@@ -439,6 +439,52 @@ export const Overflow: StoryObj = {
 	},
 };
 
+export const Offset: StoryObj = {
+	render: function Render() {
+		return (
+			<DropdownMenu offset={-8}>
+				<DropdownMenuButton variant="primary">
+					Toggle dropdown menu
+				</DropdownMenuButton>
+				<DropdownMenuPanel>
+					<DropdownMenuItem onClick={() => console.log('Profile')}>
+						Profile
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => console.log('Messages')}>
+						Messages
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => console.log('Account settings')}>
+						Account settings
+					</DropdownMenuItem>
+				</DropdownMenuPanel>
+			</DropdownMenu>
+		);
+	},
+};
+
+export const MatchReferenceWith: StoryObj = {
+	render: function Render() {
+		return (
+			<DropdownMenu matchReferenceWidth={true}>
+				<DropdownMenuButton variant="primary" css={{ width: '40rem' }}>
+					Toggle dropdown menu
+				</DropdownMenuButton>
+				<DropdownMenuPanel>
+					<DropdownMenuItem onClick={() => console.log('Profile')}>
+						Profile
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => console.log('Messages')}>
+						Messages
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => console.log('Account settings')}>
+						Account settings
+					</DropdownMenuItem>
+				</DropdownMenuPanel>
+			</DropdownMenu>
+		);
+	},
+};
+
 export const Complex: StoryObj = {
 	render: function Render() {
 		return (

--- a/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
@@ -128,8 +128,14 @@ export const Placement: StoryObj = {
 		return (
 			<Stack gap={2} alignItems="center">
 				{placements.map((placement) => (
-					<DropdownMenu key={placement} popoverPlacement={placement}>
-						<DropdownMenuButton>{placement}</DropdownMenuButton>
+					<DropdownMenu
+						key={placement}
+						popoverPlacement={placement}
+						matchReferenceWidth={true}
+					>
+						<DropdownMenuButton variant="primary">
+							{placement}
+						</DropdownMenuButton>
 						<DropdownMenuPanel>
 							<DropdownMenuItem>Profile</DropdownMenuItem>
 							<DropdownMenuItem>Messages</DropdownMenuItem>

--- a/packages/react/src/dropdown-menu/DropdownMenu.test.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.test.tsx
@@ -27,6 +27,17 @@ expect.extend(toHaveNoViolations);
 
 afterEach(cleanup);
 
+async function getDropdownMenuButton() {
+	return await screen.findByRole('button');
+}
+
+async function openDropdownMenu() {
+	const menuButton = await getDropdownMenuButton();
+	menuButton.focus();
+	expect(menuButton).toHaveFocus();
+	await userEvent.click(menuButton);
+}
+
 function renderBasicDropdownMenu() {
 	return render(
 		<DropdownMenu>
@@ -41,13 +52,15 @@ function renderBasicDropdownMenu() {
 }
 
 describe('DropdownMenu', () => {
-	it('renders correctly', () => {
+	it('renders correctly', async () => {
 		const { container } = renderBasicDropdownMenu();
+		await openDropdownMenu();
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders valid HTML with no a11y violations', async () => {
 		const { container } = renderBasicDropdownMenu();
+		await openDropdownMenu();
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 			rules: {
@@ -64,21 +77,21 @@ describe('DropdownMenu', () => {
 	it('renders the correct basic aria attributes', async () => {
 		renderBasicDropdownMenu();
 
-		const menuButton = await screen.findByRole('button');
-		const menuList = await screen.findByRole('menu', { hidden: true });
+		const menuButton = await getDropdownMenuButton();
 
 		expect(menuButton).toHaveAttribute('aria-haspopup', 'true');
 		expect(menuButton).toHaveAttribute('aria-expanded', 'false');
+
+		// Open the dropdown menu
+		await openDropdownMenu();
+		const menuList = await screen.findByRole('menu');
+
+		expect(menuButton).toHaveAttribute('aria-expanded', 'true');
 		expect(menuButton).toHaveAttribute('aria-controls', menuList.id);
 
 		expect(menuList).toHaveAttribute('role', 'menu');
 		expect(menuList).toHaveAttribute('tabIndex', '-1');
 		expect(menuList).toHaveAttribute('aria-labelledby', menuButton.id);
-
-		// Open the dropdown menu
-		await userEvent.click(menuButton);
-
-		expect(menuButton).toHaveAttribute('aria-expanded', 'true');
 
 		// Close the dropdown menu
 		await userEvent.keyboard('{Escape}');
@@ -89,7 +102,7 @@ describe('DropdownMenu', () => {
 	it('focuses the correct element when opening/closing', async () => {
 		renderBasicDropdownMenu();
 
-		const menuButton = await screen.findByRole('button');
+		const menuButton = await getDropdownMenuButton();
 
 		// Open the dropdown menu
 		await userEvent.click(menuButton);
@@ -115,11 +128,10 @@ describe('DropdownMenu', () => {
 			</DropdownMenu>
 		);
 
-		const menuButton = await screen.findByRole('button');
-		const menuList = await screen.findByRole('menu', { hidden: true });
-
 		// Open the dropdown menu
-		await userEvent.click(menuButton);
+		await openDropdownMenu();
+
+		const menuList = await screen.findByRole('menu');
 
 		// aria-activedescendant should be empty
 		expect(menuList).not.toHaveAttribute('aria-activedescendant');
@@ -161,11 +173,10 @@ describe('DropdownMenu', () => {
 			</DropdownMenu>
 		);
 
-		const menuButton = await screen.findByRole('button');
-		const menuList = await screen.findByRole('menu', { hidden: true });
-
 		// Open the dropdown menu
-		await userEvent.click(menuButton);
+		await openDropdownMenu();
+
+		const menuList = await screen.findByRole('menu');
 
 		// aria-activedescendant should be empty
 		expect(menuList).not.toHaveAttribute('aria-activedescendant');
@@ -192,18 +203,14 @@ describe('DropdownMenu', () => {
 			</DropdownMenu>
 		);
 
-		const menuButton = await screen.findByRole('button');
-
-		// Open the dropdown menu
-		menuButton.focus();
-		expect(menuButton).toHaveFocus();
-		await userEvent.click(menuButton);
+		await openDropdownMenu();
 
 		// Once the dropdown menu is opened, the menu list should be focused
 		const firstListItem = await screen.findByText('Item 1');
 		await userEvent.click(firstListItem);
 
 		// When closing the dropdown menu, the the trigger should be focused again
+		const menuButton = await getDropdownMenuButton();
 		expect(menuButton).toHaveFocus();
 
 		expect(onClick1).toHaveBeenCalledTimes(1);
@@ -227,7 +234,7 @@ describe('DropdownMenu', () => {
 			</DropdownMenu>
 		);
 
-		const menuButton = await screen.findByRole('button');
+		const menuButton = await getDropdownMenuButton();
 
 		expect(menuButton).toHaveTextContent('Open');
 
@@ -278,13 +285,15 @@ function renderDecorativeDropdownMenu() {
 }
 
 describe('DropdownMenu Decorative', () => {
-	it('renders correctly', () => {
+	it('renders correctly', async () => {
 		const { container } = renderDecorativeDropdownMenu();
+		await openDropdownMenu();
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders valid HTML with no a11y violations', async () => {
 		const { container } = renderDecorativeDropdownMenu();
+		await openDropdownMenu();
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 			rules: {
@@ -313,11 +322,13 @@ function renderDropdownMenuLinks() {
 describe('DropdownMenu Links', () => {
 	it('renders correctly', async () => {
 		const { container } = renderDropdownMenuLinks();
+		await openDropdownMenu();
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders valid HTML with no a11y violations', async () => {
 		const { container } = renderDropdownMenuLinks();
+		await openDropdownMenu();
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 			rules: {
@@ -330,10 +341,10 @@ describe('DropdownMenu Links', () => {
 
 	it('basic attributes render correctly', async () => {
 		renderDropdownMenuLinks();
+		await openDropdownMenu();
 
 		const [firstListItem, secondListItem] = await screen.findAllByRole(
-			'menuitem',
-			{ hidden: true }
+			'menuitem'
 		);
 
 		expect(firstListItem).toBeInTheDocument();
@@ -360,9 +371,10 @@ describe('DropdownMenu Links', () => {
 			</DropdownMenu>
 		);
 
+		await openDropdownMenu();
+
 		const [firstListItem, secondListItem] = await screen.findAllByRole(
-			'menuitem',
-			{ hidden: true }
+			'menuitem'
 		);
 
 		expect(firstListItem).toBeInTheDocument();
@@ -417,11 +429,13 @@ function renderDropdownMenuRadio() {
 describe('DropdownMenu Radio Group', () => {
 	it('renders correctly', async () => {
 		const { container } = renderDropdownMenuRadio();
+		await openDropdownMenu();
 		expect(container).toMatchSnapshot();
 	});
 
 	it('renders valid HTML with no a11y violations', async () => {
 		const { container } = renderDropdownMenuRadio();
+		await openDropdownMenu();
 		expect(container).toHTMLValidate({
 			extends: ['html-validate:recommended'],
 			rules: {
@@ -435,8 +449,10 @@ describe('DropdownMenu Radio Group', () => {
 	it('renders the correct basic aria attributes', async () => {
 		renderDropdownMenuRadio();
 
+		await openDropdownMenu();
+
 		const [firstListItem, secondListItem, thirdListItem] =
-			await screen.findAllByRole('menuitemradio', { hidden: true });
+			await screen.findAllByRole('menuitemradio');
 
 		expect(firstListItem).toBeInTheDocument();
 		expect(firstListItem).toHaveAttribute('aria-checked', 'false');
@@ -489,12 +505,8 @@ describe('DropdownMenu Radio Group', () => {
 			</DropdownMenu>
 		);
 
-		const menuButton = await screen.findByRole('button');
-
-		// Open the dropdown menu
-		menuButton.focus();
-		expect(menuButton).toHaveFocus();
-		await userEvent.click(menuButton);
+		const menuButton = await getDropdownMenuButton();
+		await openDropdownMenu();
 
 		// Once the dropdown menu is opened, the menu list should be focused
 		const firstListItem = await screen.findByText('Antfix');

--- a/packages/react/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.tsx
@@ -15,18 +15,15 @@ export type DropdownMenuProps = {
 	popoverPlacement?: DropdownMenuPopoverPlacement;
 	/** The max height of the dropdown panel popover. */
 	popoverMaxHeight?: number;
-	/** If true, the dropdown menu panel will match the width of the dropdown menu button. */
-	matchReferenceWidth?: boolean;
 	/** Used to control the distance between the dropdown menu button and dropdown menu panel. */
-	offset?: number;
+	popoverOffset?: number;
 };
 
 export function DropdownMenu({
 	children,
-	matchReferenceWidth,
 	popoverPlacement = 'bottom-start',
 	popoverMaxHeight,
-	offset,
+	popoverOffset,
 }: DropdownMenuProps) {
 	const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -36,8 +33,7 @@ export function DropdownMenu({
 	const popover = usePopover<HTMLButtonElement>({
 		placement: popoverPlacement,
 		maxHeight: popoverMaxHeight,
-		matchReferenceWidth,
-		offset,
+		offset: popoverOffset,
 	});
 
 	function openMenu() {

--- a/packages/react/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.tsx
@@ -15,12 +15,18 @@ export type DropdownMenuProps = {
 	popoverPlacement?: DropdownMenuPopoverPlacement;
 	/** The max height of the dropdown panel popover. */
 	popoverMaxHeight?: number;
+	/** If true, the dropdown menu panel will match the width of the dropdown menu button. */
+	matchReferenceWidth?: boolean;
+	/** Used to control the distance between the dropdown menu button and dropdown menu panel. */
+	offset?: number;
 };
 
 export function DropdownMenu({
 	children,
+	matchReferenceWidth,
 	popoverPlacement = 'bottom-start',
 	popoverMaxHeight,
+	offset,
 }: DropdownMenuProps) {
 	const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -30,6 +36,8 @@ export function DropdownMenu({
 	const popover = usePopover<HTMLButtonElement>({
 		placement: popoverPlacement,
 		maxHeight: popoverMaxHeight,
+		matchReferenceWidth,
+		offset,
 	});
 
 	function openMenu() {

--- a/packages/react/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.tsx
@@ -15,7 +15,7 @@ export type DropdownMenuProps = {
 	popoverPlacement?: DropdownMenuPopoverPlacement;
 	/** The max height of the dropdown panel popover. */
 	popoverMaxHeight?: number;
-	/** Used to control the distance between the dropdown menu button and dropdown menu panel. */
+	/** Used to control the vertical distance between the reference element and popover element. Value is in pixels. */
 	popoverOffset?: number;
 };
 

--- a/packages/react/src/dropdown-menu/DropdownMenuGroup.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuGroup.tsx
@@ -16,8 +16,9 @@ export function DropdownMenuGroup({
 		<div role="group" aria-labelledby={id}>
 			<Text
 				display="block"
-				padding={1}
-				paddingBottom={0}
+				paddingX={1}
+				paddingTop={1.5}
+				paddingBottom={0.5}
 				lineHeight="heading"
 				fontWeight="bold"
 				fontSize="xs"

--- a/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
@@ -47,7 +47,6 @@ export function DropdownMenuPanel({
 	const { onKeyDown } = useKeydownNavigation();
 
 	const { style, ref: popoverRef } = popover.getPopoverProps();
-	const { matchReferenceWidth } = popover.getOptions();
 
 	if (!isMenuOpen) return null;
 
@@ -65,7 +64,7 @@ export function DropdownMenuPanel({
 			onKeyDown={onKeyDown}
 			palette={palette}
 			flexDirection="column"
-			minWidth={matchReferenceWidth ? undefined : '18rem'}
+			minWidth="18rem"
 			focus
 			style={style}
 		>

--- a/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
@@ -59,7 +59,7 @@ export function DropdownMenuPanel({
 			onKeyDown={onKeyDown}
 			palette={palette}
 			flexDirection="column"
-			width={matchReferenceWidth ? undefined : '18rem'}
+			minWidth={matchReferenceWidth ? undefined : '18rem'}
 			focus
 			style={style}
 		>

--- a/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
@@ -42,6 +42,8 @@ export function DropdownMenuPanel({
 
 	const { style, ref: popoverRef } = popover.getPopoverProps();
 
+	if (!isMenuOpen) return null;
+
 	return (
 		<Popover
 			as={Flex}
@@ -55,16 +57,10 @@ export function DropdownMenuPanel({
 			aria-activedescendant={activeDescendantId}
 			onKeyDown={onKeyDown}
 			palette={palette}
+			width="18rem"
+			flexDirection="column"
 			focus
-			css={{
-				display: 'flex',
-				flexDirection: 'column',
-				minWidth: '18rem',
-			}}
-			style={{
-				...style,
-				...(!isMenuOpen && { display: 'none' }),
-			}}
+			style={style}
 		>
 			{children}
 		</Popover>

--- a/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
@@ -35,7 +35,13 @@ export function DropdownMenuPanel({
 
 	// When the dropdown is opened, the menu list should be focused
 	useEffect(() => {
-		if (isMenuOpen) panelRef.current?.focus();
+		if (isMenuOpen) {
+			panelRef.current?.focus({
+				// Stops the browser jumping to the top of the page when focusing the element
+				// https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+				preventScroll: true,
+			});
+		}
 	}, [panelRef, isMenuOpen]);
 
 	const { onKeyDown } = useKeydownNavigation();

--- a/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
@@ -41,6 +41,7 @@ export function DropdownMenuPanel({
 	const { onKeyDown } = useKeydownNavigation();
 
 	const { style, ref: popoverRef } = popover.getPopoverProps();
+	const { matchReferenceWidth } = popover.getOptions();
 
 	if (!isMenuOpen) return null;
 
@@ -57,8 +58,8 @@ export function DropdownMenuPanel({
 			aria-activedescendant={activeDescendantId}
 			onKeyDown={onKeyDown}
 			palette={palette}
-			width="18rem"
 			flexDirection="column"
+			width={matchReferenceWidth ? undefined : '18rem'}
 			focus
 			style={style}
 		>

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
 <div>
   <button
     aria-controls="dropdown-menu-:ru:-panel"
-    aria-expanded="false"
+    aria-expanded="true"
     aria-haspopup="true"
     class="css-1clbjuu-BaseButton-Button"
     id="dropdown-menu-:ru:-button"
@@ -14,7 +14,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       <span
         class="css-oobk4c-Button"
       >
-        Open
+        Close
       </span>
       <span
         aria-live="assertive"
@@ -32,16 +32,16 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <polyline
-        points="6 9 12 15 18 9"
+        points="18 15 12 9 6 15"
       />
     </svg>
   </button>
   <div
     aria-labelledby="dropdown-menu-:ru:-button"
-    class="css-o0kjrt-boxStyles-boxStyles-Popover-DropdownMenuPanel"
+    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:ru:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
     tabindex="-1"
   >
     <div
@@ -164,7 +164,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
 <div>
   <button
     aria-controls="dropdown-menu-:r16:-panel"
-    aria-expanded="false"
+    aria-expanded="true"
     aria-haspopup="true"
     class="css-1clbjuu-BaseButton-Button"
     id="dropdown-menu-:r16:-button"
@@ -192,16 +192,16 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <polyline
-        points="6 9 12 15 18 9"
+        points="18 15 12 9 6 15"
       />
     </svg>
   </button>
   <div
     aria-labelledby="dropdown-menu-:r16:-button"
-    class="css-o0kjrt-boxStyles-boxStyles-Popover-DropdownMenuPanel"
+    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r16:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
     tabindex="-1"
   >
     <a
@@ -242,7 +242,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
 <div>
   <button
     aria-controls="dropdown-menu-:r1i:-panel"
-    aria-expanded="false"
+    aria-expanded="true"
     aria-haspopup="true"
     class="css-1clbjuu-BaseButton-Button"
     id="dropdown-menu-:r1i:-button"
@@ -270,16 +270,16 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <polyline
-        points="6 9 12 15 18 9"
+        points="18 15 12 9 6 15"
       />
     </svg>
   </button>
   <div
     aria-labelledby="dropdown-menu-:r1i:-button"
-    class="css-o0kjrt-boxStyles-boxStyles-Popover-DropdownMenuPanel"
+    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r1i:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
     tabindex="-1"
   >
     <div
@@ -287,7 +287,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
       role="group"
     >
       <span
-        class="css-190t308-boxStyles-Text"
+        class="css-1xlltnd-boxStyles-Text"
         id="dropdown-menu-:r1i:-group-:r1j:"
       >
         Businesses
@@ -364,7 +364,7 @@ exports[`DropdownMenu renders correctly 1`] = `
 <div>
   <button
     aria-controls="dropdown-menu-:r0:-panel"
-    aria-expanded="false"
+    aria-expanded="true"
     aria-haspopup="true"
     class="css-1clbjuu-BaseButton-Button"
     id="dropdown-menu-:r0:-button"
@@ -392,16 +392,16 @@ exports[`DropdownMenu renders correctly 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <polyline
-        points="6 9 12 15 18 9"
+        points="18 15 12 9 6 15"
       />
     </svg>
   </button>
   <div
     aria-labelledby="dropdown-menu-:r0:-button"
-    class="css-o0kjrt-boxStyles-boxStyles-Popover-DropdownMenuPanel"
+    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r0:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; display: none; transform: translate(0px, 0px);"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
     tabindex="-1"
   >
     <div

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:ru:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <div
@@ -201,7 +201,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r16:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <a
@@ -279,7 +279,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
     class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r1i:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <div
@@ -401,7 +401,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     class="css-1p1tvpk-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r0:-panel"
     role="menu"
-    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-width: -16px; max-height: -16px;"
+    style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <div

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:ru:-button"
-    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
+    class="css-mbg1mh-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:ru:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
@@ -198,7 +198,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:r16:-button"
-    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
+    class="css-mbg1mh-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r16:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
@@ -276,7 +276,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:r1i:-button"
-    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
+    class="css-mbg1mh-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r1i:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
@@ -398,7 +398,7 @@ exports[`DropdownMenu renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:r0:-button"
-    class="css-1p1tvpk-boxStyles-boxStyles-Popover"
+    class="css-mbg1mh-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r0:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"

--- a/packages/react/src/dropdown-menu/docs/overview.mdx
+++ b/packages/react/src/dropdown-menu/docs/overview.mdx
@@ -301,6 +301,52 @@ For dropdown menus with many items, consider setting a maximum height using the 
 </Stack>
 ```
 
+## Offset
+
+Use the `offset` prop control the distance between the button and panel.
+
+```jsx live
+<DropdownMenu offset={-8}>
+	<DropdownMenuButton variant="primary">
+		Toggle dropdown menu
+	</DropdownMenuButton>
+	<DropdownMenuPanel>
+		<DropdownMenuItem onClick={() => console.log('Profile')}>
+			Profile
+		</DropdownMenuItem>
+		<DropdownMenuItem onClick={() => console.log('Messages')}>
+			Messages
+		</DropdownMenuItem>
+		<DropdownMenuItem onClick={() => console.log('Account settings')}>
+			Account settings
+		</DropdownMenuItem>
+	</DropdownMenuPanel>
+</DropdownMenu>
+```
+
+## Matching reference width
+
+Use the `matchReferenceWidth` prop to make the panel width match the width of the button.
+
+```jsx live
+<DropdownMenu matchReferenceWidth={true}>
+	<DropdownMenuButton variant="primary" block>
+		Toggle dropdown menu
+	</DropdownMenuButton>
+	<DropdownMenuPanel>
+		<DropdownMenuItem onClick={() => console.log('Profile')}>
+			Profile
+		</DropdownMenuItem>
+		<DropdownMenuItem onClick={() => console.log('Messages')}>
+			Messages
+		</DropdownMenuItem>
+		<DropdownMenuItem onClick={() => console.log('Account settings')}>
+			Account settings
+		</DropdownMenuItem>
+	</DropdownMenuPanel>
+</DropdownMenu>
+```
+
 ## Accessing state
 
 If you need to access the internal state of the menu, you can provide a render callback to `DropdownMenu`. This is useful if you want to change the appearance of the dropdown menu button based on whether the dropdown menu is opened or closed.

--- a/packages/react/src/dropdown-menu/docs/overview.mdx
+++ b/packages/react/src/dropdown-menu/docs/overview.mdx
@@ -303,34 +303,11 @@ For dropdown menus with many items, consider setting a maximum height using the 
 
 ## Offset
 
-Use the `offset` prop control the distance between the button and panel.
+Use the `popoverOffset` prop control the distance between the button and panel.
 
 ```jsx live
-<DropdownMenu offset={-8}>
+<DropdownMenu popoverOffset={-8}>
 	<DropdownMenuButton variant="primary">
-		Toggle dropdown menu
-	</DropdownMenuButton>
-	<DropdownMenuPanel>
-		<DropdownMenuItem onClick={() => console.log('Profile')}>
-			Profile
-		</DropdownMenuItem>
-		<DropdownMenuItem onClick={() => console.log('Messages')}>
-			Messages
-		</DropdownMenuItem>
-		<DropdownMenuItem onClick={() => console.log('Account settings')}>
-			Account settings
-		</DropdownMenuItem>
-	</DropdownMenuPanel>
-</DropdownMenu>
-```
-
-## Matching reference width
-
-Use the `matchReferenceWidth` prop to make the panel width match the width of the button.
-
-```jsx live
-<DropdownMenu matchReferenceWidth={true}>
-	<DropdownMenuButton variant="primary" block>
 		Toggle dropdown menu
 	</DropdownMenuButton>
 	<DropdownMenuPanel>

--- a/packages/react/src/dropdown-menu/docs/overview.mdx
+++ b/packages/react/src/dropdown-menu/docs/overview.mdx
@@ -303,7 +303,7 @@ For dropdown menus with many items, consider setting a maximum height using the 
 
 ## Offset
 
-Use the `popoverOffset` prop control the distance between the button and panel.
+Use the `popoverOffset` prop to control the vertical distance between the button and panel. This value needs to be specified in pixels
 
 ```jsx live
 <DropdownMenu popoverOffset={-8}>


### PR DESCRIPTION
This is required for PR #1261

- Added new prop `popoverOffset` which can be used to control the distance between the button and panel.
- Updated padding of label element in `DropdownMenuGroup`, as requested by @adhamdannawayaff 
- Swapped from display style to conditional rendering to improve panel element anchoring as recommend by [Floating UI](https://floating-ui.com/docs/react#anchoring)


[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1367/components/dropdown-menu)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
