### PR TITLE
details: Add new `onBodyAlt` prop

### DIFF
--- a/.changeset/brown-islands-sip.md
+++ b/.changeset/brown-islands-sip.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+details: Added new prop `onBodyAlt`. If the Details component is placed on a page with bodyAlt background, set the `onBodyAlt` prop to true.

--- a/packages/react/src/details/Details.stories.tsx
+++ b/packages/react/src/details/Details.stories.tsx
@@ -1,28 +1,39 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
+import { Box } from '../box';
 import { Text } from '../text';
 import { Details } from './Details';
 
-export default {
+const meta: Meta<typeof Details> = {
 	title: 'content/Details',
 	component: Details,
-} as ComponentMeta<typeof Details>;
+	args: {
+		label: 'Details',
+		iconBefore: false,
+		onBodyAlt: false,
+		children: (
+			<Text as="p">
+				This is a small paragraph of text that is supplementary to the main page
+				content.
+			</Text>
+		),
+	},
+};
 
-export const Basic: ComponentStory<typeof Details> = (args) => (
-	<Details {...args}>
-		<Text as="p">
-			This is a small paragraph of text that is supplementary to the main page
-			content.
-		</Text>
-	</Details>
-);
-Basic.args = { label: 'Details' };
+export default meta;
 
-export const WithIcon: ComponentStory<typeof Details> = (args) => (
-	<Details {...args}>
-		<Text as="p">
-			This is a small paragraph of text that is supplementary to the main page
-			content.
-		</Text>
-	</Details>
-);
-WithIcon.args = { label: 'Details', iconBefore: true };
+type Story = StoryObj<typeof Details>;
+
+export const Basic: Story = {};
+
+export const WithIcon: Story = {
+	args: { iconBefore: true },
+};
+
+export const OnBodyAlt: Story = {
+	args: { onBodyAlt: true },
+	render: (args) => (
+		<Box background="bodyAlt" padding={1.5}>
+			<Details {...args} />
+		</Box>
+	),
+};

--- a/packages/react/src/details/Details.tsx
+++ b/packages/react/src/details/Details.tsx
@@ -5,6 +5,8 @@ import { Flex } from '../flex';
 import { InfoIcon, ChevronDownIcon } from '../icon';
 
 export type DetailsProps = PropsWithChildren<{
+	/** If the Details component is placed on a page with `bodyAlt` background, set this prop to `true`. */
+	onBodyAlt?: boolean;
 	/** If true, the InfoIcon will be shown. */
 	iconBefore?: boolean;
 	/** The label that will be present in the trigger. */
@@ -12,7 +14,10 @@ export type DetailsProps = PropsWithChildren<{
 }>;
 
 export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
-	function Details({ children, iconBefore = false, label = 'Details' }, ref) {
+	function Details(
+		{ children, onBodyAlt = false, iconBefore = false, label = 'Details' },
+		ref
+	) {
 		return (
 			<details
 				ref={ref}
@@ -48,7 +53,7 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
 					/>
 				</Flex>
 				<Box
-					background="shade"
+					background={onBodyAlt ? 'shadeAlt' : 'shade'}
 					padding={1.5}
 					borderLeft
 					borderLeftWidth="xl"

--- a/packages/react/src/details/docs/overview.mdx
+++ b/packages/react/src/details/docs/overview.mdx
@@ -44,3 +44,18 @@ Setting the `iconBefore` prop to `true` will render the `InfoIcon` before the la
 	</Text>
 </Details>
 ```
+
+## On Body Alt
+
+If the Details component is placed on a page with `bodyAlt` background, set the `onBodyAlt` prop to `true`.
+
+```jsx live
+<Box background="bodyAlt" padding={1.5}>
+	<Details label="Details" iconBefore onBodyAlt>
+		<Text as="p">
+			This is a small paragraph of text that is supplementary to the main page
+			content.
+		</Text>
+	</Details>
+</Box>
+```

--- a/packages/react/src/details/docs/overview.mdx
+++ b/packages/react/src/details/docs/overview.mdx
@@ -47,7 +47,7 @@ Setting the `iconBefore` prop to `true` will render the `InfoIcon` before the la
 
 ## On Body Alt
 
-If the Details component is placed on a page with `bodyAlt` background, set the `onBodyAlt` prop to `true`.
+If the Details component is placed on a page with `bodyAlt` background, set the `onBodyAlt` prop to `true`. This ensures the correct shade background token is used by the component.
 
 ```jsx live
 <Box background="bodyAlt" padding={1.5}>


### PR DESCRIPTION
Added new prop `onBodyAlt` to the Details component. If the Details component is placed on a page with `bodyAlt` background, set the `onBodyAlt` prop to `true`.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1370/components/details)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

