### PR TITLE
dropdown-menu: Improve handling of long labels

### DIFF
--- a/.changeset/kind-monkeys-vanish.md
+++ b/.changeset/kind-monkeys-vanish.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+dropdown-menu: Improve handling of menu items with long labels

--- a/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenu.stories.tsx
@@ -467,14 +467,14 @@ export const Complex: StoryObj = {
 					<DropdownMenuGroup label="Businesses">
 						<DropdownMenuItemRadio
 							checked={true}
-							secondaryText="Sydney"
+							secondaryText="ABN 00 000 000 000"
 							endElement={<IndicatorDot />}
 						>
 							Antfix
 						</DropdownMenuItemRadio>
 						<DropdownMenuItemRadio
 							checked={false}
-							secondaryText="Brisbane"
+							secondaryText="ABN 00 000 000 000"
 							endElement={
 								<Fragment>
 									<NotificationBadge
@@ -489,7 +489,10 @@ export const Complex: StoryObj = {
 						>
 							Ashfield
 						</DropdownMenuItemRadio>
-						<DropdownMenuItemRadio checked={false} secondaryText="Canberra">
+						<DropdownMenuItemRadio
+							checked={false}
+							secondaryText="ABN 00 000 000 000"
+						>
 							Redfern
 						</DropdownMenuItemRadio>
 						<DropdownMenuGroupLink href="#">View all</DropdownMenuGroupLink>
@@ -511,6 +514,61 @@ export const Complex: StoryObj = {
 						}
 					>
 						Messages
+					</DropdownMenuItem>
+					<DropdownMenuItem icon={SettingsIcon}>
+						Account settings
+					</DropdownMenuItem>
+					<DropdownMenuDivider />
+					<DropdownMenuItem icon={ExitIcon}>Sign out</DropdownMenuItem>
+				</DropdownMenuPanel>
+			</DropdownMenu>
+		);
+	},
+};
+
+export const LongLabels: StoryObj = {
+	render: function Render() {
+		const businessNames = [
+			'Blandit iaculis iaculis quis ante diam viverra elementum ui risus nec luctus purus tortor lacus malesuada consectetur',
+			'Iaculis tortor duis ante nec risus elementum id ui',
+			'APurus tortor lacus malesuada phasellus ipsum ex duis libero ante id',
+		];
+		return (
+			<DropdownMenu>
+				<DropdownMenuButton>Toggle dropdown menu</DropdownMenuButton>
+				<DropdownMenuPanel>
+					<DropdownMenuGroup label="Businesses">
+						{businessNames.map((name) => (
+							<DropdownMenuItemRadio
+								key={name}
+								checked={true}
+								secondaryText="ABN 00 000 000 000"
+								endElement={<IndicatorDot />}
+							>
+								{name}
+							</DropdownMenuItemRadio>
+						))}
+						<DropdownMenuGroupLink href="#">View all</DropdownMenuGroupLink>
+					</DropdownMenuGroup>
+					<DropdownMenuDivider />
+					<DropdownMenuItem icon={AvatarIcon}>
+						Phasellus ipsum ex duis libero ante
+					</DropdownMenuItem>
+					<DropdownMenuItem
+						icon={EmailIcon}
+						endElement={
+							<Fragment>
+								<NotificationBadge
+									value={100}
+									max={99}
+									tone="action"
+									aria-hidden
+								/>
+								<VisuallyHidden>, 100 unread</VisuallyHidden>
+							</Fragment>
+						}
+					>
+						APurus tortor lacus malesuada phasellus ipsum ex duis libero ante
 					</DropdownMenuItem>
 					<DropdownMenuItem icon={SettingsIcon}>
 						Account settings

--- a/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
@@ -66,6 +66,7 @@ export const DropdownMenuItem = forwardRefWithAs<'div', DropdownMenuItemProps>(
 				background="body"
 				gap={1}
 				padding={1}
+				width="18rem"
 				link
 				focus
 				css={{

--- a/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItem.tsx
@@ -8,6 +8,7 @@ import {
 import { boxPalette, forwardRefWithAs, mergeRefs, packs } from '../core';
 import { Flex } from '../flex';
 import { IconProps } from '../icon';
+import { Text } from '../text';
 import { useDropdownMenuContext } from './DropdownMenuContext';
 import { useDropdownMenuItemId } from './utils';
 
@@ -79,16 +80,18 @@ export const DropdownMenuItem = forwardRefWithAs<'div', DropdownMenuItemProps>(
 
 					'&:hover': {
 						backgroundColor: boxPalette.backgroundShade,
-						'& > div > span': packs.underline,
+						'& > div:first-of-type > span': packs.underline,
 					},
 				}}
 				{...props}
 			>
 				<Flex alignItems="center" gap={0.75}>
-					{Icon ? <Icon color="inherit" size="md" /> : null}
-					<span>{children}</span>
+					{Icon ? (
+						<Icon color="inherit" size="md" css={{ flexShrink: 0 }} />
+					) : null}
+					<Text color="inherit">{children}</Text>
 				</Flex>
-				{endElement}
+				<div css={{ flexShrink: 0 }}>{endElement}</div>
 			</Flex>
 		);
 	}

--- a/packages/react/src/dropdown-menu/DropdownMenuItemRadio.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItemRadio.tsx
@@ -57,6 +57,7 @@ export function DropdownMenuItemRadio({
 			background="body"
 			gap={1}
 			padding={1}
+			width="18rem"
 			css={{
 				cursor: 'pointer',
 
@@ -103,7 +104,7 @@ export function DropdownMenuItemRadio({
 					{secondaryText}
 				</Text>
 			</Stack>
-			{endElement}
+			<div css={{ flexShrink: 0 }}>{endElement}</div>
 		</Flex>
 	);
 }

--- a/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuPanel.tsx
@@ -64,7 +64,6 @@ export function DropdownMenuPanel({
 			onKeyDown={onKeyDown}
 			palette={palette}
 			flexDirection="column"
-			minWidth="18rem"
 			focus
 			style={style}
 		>

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -38,14 +38,14 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:ru:-button"
-    class="css-mbg1mh-boxStyles-boxStyles-Popover"
+    class="css-1191aff-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:ru:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <div
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:rv:"
       role="menuitem"
       tabindex="-1"
@@ -55,7 +55,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="css-qhpjst-Icon"
+          class="css-1qwfqs8-DropdownMenuItem"
           clip-rule="evenodd"
           focusable="false"
           height="24"
@@ -73,13 +73,18 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
             r="10.5"
           />
         </svg>
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Profile
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </div>
     <div
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r10:"
       role="menuitem"
       tabindex="-1"
@@ -89,7 +94,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="css-qhpjst-Icon"
+          class="css-1qwfqs8-DropdownMenuItem"
           clip-rule="evenodd"
           focusable="false"
           height="24"
@@ -102,28 +107,34 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
             d="M22 6C22 4.9 21.1 4 20 4H4C2.9 4 2 4.9 2 6M22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6M22 6L12 13L2 6"
           />
         </svg>
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Messages
         </span>
       </div>
-      <span
-        aria-hidden="true"
-        class="css-uouzcn-boxStyles-Text-NotificationBadge"
+      <div
+        class="css-azld6j-DropdownMenuItem"
       >
-        99+
-      </span>
-      <span
-        class="css-avudkd-VisuallyHidden"
-      >
-        , 100 unread
-      </span>
+        <span
+          aria-hidden="true"
+          class="css-uouzcn-boxStyles-Text-NotificationBadge"
+        >
+          99+
+        </span>
+        <span
+          class="css-avudkd-VisuallyHidden"
+        >
+          , 100 unread
+        </span>
+      </div>
     </div>
     <hr
       aria-hidden="true"
       class="css-1th2zfi-Divider"
     />
     <div
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:ru:-item-:r11:"
       role="menuitem"
       tabindex="-1"
@@ -133,7 +144,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="css-qhpjst-Icon"
+          class="css-1qwfqs8-DropdownMenuItem"
           clip-rule="evenodd"
           focusable="false"
           height="24"
@@ -151,10 +162,15 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
             d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
           />
         </svg>
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Account settings
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </div>
   </div>
 </div>
@@ -198,14 +214,14 @@ exports[`DropdownMenu Links renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:r16:-button"
-    class="css-mbg1mh-boxStyles-boxStyles-Popover"
+    class="css-1191aff-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r16:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <a
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       href="/about"
       id="dropdown-menu-:r16:-item-:r17:"
       role="menuitem"
@@ -214,13 +230,18 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       <div
         class="css-16gtkc6-boxStyles"
       >
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           About
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </a>
     <a
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       href="/contact"
       id="dropdown-menu-:r16:-item-:r18:"
       role="menuitem"
@@ -229,10 +250,15 @@ exports[`DropdownMenu Links renders correctly 1`] = `
       <div
         class="css-16gtkc6-boxStyles"
       >
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Contact
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </a>
   </div>
 </div>
@@ -276,7 +302,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:r1i:-button"
-    class="css-mbg1mh-boxStyles-boxStyles-Popover"
+    class="css-1191aff-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r1i:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
@@ -294,7 +320,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
       </span>
       <div
         aria-checked="false"
-        class="css-1us24yp-boxStyles-DropdownMenuItemRadio"
+        class="css-1e5dgxr-boxStyles-DropdownMenuItemRadio"
         id="item-1"
         role="menuitemradio"
       >
@@ -312,10 +338,13 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
             Sydney
           </span>
         </div>
+        <div
+          class="css-r8b31l-DropdownMenuItemRadio"
+        />
       </div>
       <div
         aria-checked="true"
-        class="css-4naupb-boxStyles-DropdownMenuItemRadio"
+        class="css-1yrn77q-boxStyles-DropdownMenuItemRadio"
         id="item-2"
         role="menuitemradio"
       >
@@ -333,10 +362,13 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
             Brisbane
           </span>
         </div>
+        <div
+          class="css-r8b31l-DropdownMenuItemRadio"
+        />
       </div>
       <div
         aria-checked="false"
-        class="css-1us24yp-boxStyles-DropdownMenuItemRadio"
+        class="css-1e5dgxr-boxStyles-DropdownMenuItemRadio"
         id="item-3"
         role="menuitemradio"
       >
@@ -354,6 +386,9 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
             Canberra
           </span>
         </div>
+        <div
+          class="css-r8b31l-DropdownMenuItemRadio"
+        />
       </div>
     </div>
   </div>
@@ -398,14 +433,14 @@ exports[`DropdownMenu renders correctly 1`] = `
   </button>
   <div
     aria-labelledby="dropdown-menu-:r0:-button"
-    class="css-mbg1mh-boxStyles-boxStyles-Popover"
+    class="css-1191aff-boxStyles-boxStyles-Popover"
     id="dropdown-menu-:r0:-panel"
     role="menu"
     style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 8px); max-height: -16px; max-width: -16px;"
     tabindex="-1"
   >
     <div
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r1:"
       role="menuitem"
       tabindex="-1"
@@ -413,13 +448,18 @@ exports[`DropdownMenu renders correctly 1`] = `
       <div
         class="css-16gtkc6-boxStyles"
       >
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Item 1
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </div>
     <div
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r2:"
       role="menuitem"
       tabindex="-1"
@@ -427,13 +467,18 @@ exports[`DropdownMenu renders correctly 1`] = `
       <div
         class="css-16gtkc6-boxStyles"
       >
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Item 2
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </div>
     <div
-      class="css-7ts4j-boxStyles-DropdownMenuItem"
+      class="css-17dk25j-boxStyles-DropdownMenuItem"
       id="dropdown-menu-:r0:-item-:r3:"
       role="menuitem"
       tabindex="-1"
@@ -441,10 +486,15 @@ exports[`DropdownMenu renders correctly 1`] = `
       <div
         class="css-16gtkc6-boxStyles"
       >
-        <span>
+        <span
+          class="css-1bvtrd1-boxStyles-Text"
+        >
           Item 3
         </span>
       </div>
+      <div
+        class="css-azld6j-DropdownMenuItem"
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
Improve handling of menu items with long labels. This is required for PR #1261.

| Before | After |
|--------|--------|
| <img width="1394" alt="Screenshot 2023-09-15 at 12 31 56 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/5be04058-7744-4d04-b00e-5d30b9b515f5"> | <img width="1406" alt="Screenshot 2023-09-15 at 12 31 02 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/2a37fb85-d042-4977-b1cb-142bfc3d1cdd"> |

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1372/storybook/index.html?path=/story/layout-dropdownmenu--long-labels)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
