### PR TITLE
docs: Remove unreleased from `list` and `dropdown-menu`

### DIFF
--- a/packages/react/src/dropdown-menu/docs/overview.mdx
+++ b/packages/react/src/dropdown-menu/docs/overview.mdx
@@ -4,7 +4,6 @@ description: A dropdown menu displays a list of actions when a trigger is presse
 group: Layout
 storybookPath: /story/layout-dropdownmenu--basic
 relatedComponents: ['combobox', 'select']
-unreleased: true
 ---
 
 ```jsx live

--- a/packages/react/src/list/docs/overview.mdx
+++ b/packages/react/src/list/docs/overview.mdx
@@ -3,7 +3,6 @@ title: List
 description: Lists are vertical groupings of related items that can be displayed either in an unordered or ordered format.
 group: Content
 storybookPath: /story/content-list-orderedlist--basic
-unreleased: true
 relatedComponents: ['text', 'prose', 'link-list']
 ---
 


### PR DESCRIPTION
We forgot to do this as part of the last release.