### PR TITLE
[WIP] ag-branding: Revisiting navy colors

### DIFF
--- a/packages/react/src/ag-branding/theme.ts
+++ b/packages/react/src/ag-branding/theme.ts
@@ -2,9 +2,8 @@ import { Theme } from '../core';
 
 const primitives = {
 	navy1: '#0A1629',
-	navy2: '#122440',
-	navy3: '#162846',
-	navy4: '#20365B',
+	navy2: '#162846',
+	navy3: '#20365B',
 };
 
 export const theme: Theme = {
@@ -22,8 +21,8 @@ export const theme: Theme = {
 	lightSystemInfoMuted: '#E5F6FF',
 	darkBackgroundBody: primitives.navy1,
 	darkBackgroundShade: primitives.navy2,
-	darkBackgroundBodyAlt: primitives.navy3,
-	darkBackgroundShadeAlt: primitives.navy4,
+	darkBackgroundBodyAlt: primitives.navy2,
+	darkBackgroundShadeAlt: primitives.navy3,
 	darkForegroundAction: '#9EE8FF',
 	darkSelected: '#9EE8FF', // use same color as action
 	darkSelectedMuted: '#162C50',

--- a/packages/react/src/ag-branding/theme.ts
+++ b/packages/react/src/ag-branding/theme.ts
@@ -2,8 +2,9 @@ import { Theme } from '../core';
 
 const primitives = {
 	navy1: '#0A1629',
-	navy2: '#162846',
-	navy3: '#20365B',
+	navy2: '#122440',
+	navy3: '#162846',
+	navy4: '#20365B',
 };
 
 export const theme: Theme = {
@@ -20,9 +21,9 @@ export const theme: Theme = {
 	lightSystemInfo: '#008BD1',
 	lightSystemInfoMuted: '#E5F6FF',
 	darkBackgroundBody: primitives.navy1,
-	darkBackgroundShade: primitives.navy2,
-	darkBackgroundBodyAlt: primitives.navy2,
-	darkBackgroundShadeAlt: primitives.navy3,
+	darkBackgroundShade: primitives.navy3,
+	darkBackgroundBodyAlt: primitives.navy3,
+	darkBackgroundShadeAlt: primitives.navy4,
 	darkForegroundAction: '#9EE8FF',
 	darkSelected: '#9EE8FF', // use same color as action
 	darkSelectedMuted: '#162C50',

--- a/packages/react/src/ag-branding/theme.ts
+++ b/packages/react/src/ag-branding/theme.ts
@@ -1,5 +1,12 @@
 import { Theme } from '../core';
 
+const primitives = {
+	navy1: '#0A1629',
+	navy2: '#122440',
+	navy3: '#162846',
+	navy4: '#20365B',
+};
+
 export const theme: Theme = {
 	lightForegroundAction: '#00558b',
 	lightAccent: '#F36C52',
@@ -13,10 +20,10 @@ export const theme: Theme = {
 	lightSystemWarningMuted: '#FFF2E5',
 	lightSystemInfo: '#008BD1',
 	lightSystemInfoMuted: '#E5F6FF',
-	darkBackgroundBody: '#0A1629',
-	darkBackgroundShade: '#122440',
-	darkBackgroundBodyAlt: '#162846',
-	darkBackgroundShadeAlt: '#20365B',
+	darkBackgroundBody: primitives.navy1,
+	darkBackgroundShade: primitives.navy2,
+	darkBackgroundBodyAlt: primitives.navy3,
+	darkBackgroundShadeAlt: primitives.navy4,
 	darkForegroundAction: '#9EE8FF',
 	darkSelected: '#9EE8FF', // use same color as action
 	darkSelectedMuted: '#162C50',

--- a/packages/react/src/ag-branding/theme.ts
+++ b/packages/react/src/ag-branding/theme.ts
@@ -14,8 +14,8 @@ export const theme: Theme = {
 	lightSystemInfo: '#008BD1',
 	lightSystemInfoMuted: '#E5F6FF',
 	darkBackgroundBody: '#0A1629',
-	darkBackgroundShade: '#162846',
-	darkBackgroundBodyAlt: '#162846',
+	darkBackgroundShade: '#122440',
+	darkBackgroundBodyAlt: '#1B3155',
 	darkBackgroundShadeAlt: '#20365B',
 	darkForegroundAction: '#9EE8FF',
 	darkSelected: '#9EE8FF', // use same color as action

--- a/packages/react/src/ag-branding/theme.ts
+++ b/packages/react/src/ag-branding/theme.ts
@@ -16,7 +16,7 @@ export const theme: Theme = {
 	darkBackgroundBody: '#0A1629',
 	darkBackgroundShade: '#122440',
 	darkBackgroundBodyAlt: '#1B3155',
-	darkBackgroundShadeAlt: '#20365B',
+	darkBackgroundShadeAlt: '#223A62',
 	darkForegroundAction: '#9EE8FF',
 	darkSelected: '#9EE8FF', // use same color as action
 	darkSelectedMuted: '#162C50',

--- a/packages/react/src/ag-branding/theme.ts
+++ b/packages/react/src/ag-branding/theme.ts
@@ -1,12 +1,5 @@
 import { Theme } from '../core';
 
-const primitives = {
-	navy1: '#0A1629',
-	navy2: '#122440',
-	navy3: '#162846',
-	navy4: '#20365B',
-};
-
 export const theme: Theme = {
 	lightForegroundAction: '#00558b',
 	lightAccent: '#F36C52',
@@ -20,10 +13,10 @@ export const theme: Theme = {
 	lightSystemWarningMuted: '#FFF2E5',
 	lightSystemInfo: '#008BD1',
 	lightSystemInfoMuted: '#E5F6FF',
-	darkBackgroundBody: primitives.navy1,
-	darkBackgroundShade: primitives.navy3,
-	darkBackgroundBodyAlt: primitives.navy3,
-	darkBackgroundShadeAlt: primitives.navy4,
+	darkBackgroundBody: '#0A1629',
+	darkBackgroundShade: '#162846',
+	darkBackgroundBodyAlt: '#162846',
+	darkBackgroundShadeAlt: '#20365B',
 	darkForegroundAction: '#9EE8FF',
 	darkSelected: '#9EE8FF', // use same color as action
 	darkSelectedMuted: '#162C50',


### PR DESCRIPTION
It was noticed by Caden that the hover color in main nav is slightly-different to the header background colour. Given how similar these colors are, it was unclear if the intention was for these objects to be the same shade or different.

In reality, the dark mode hover colour for main-nav is `shade`, while the background color for Header is `body-alt`. These two tokens have very similar HEX values in dark mode. It would be possible for us to delete one of the two similar hex colours, and share the same value across two tokens.

This PR proposes a change to the dark mode `shade` token, to be the same colour as `body-alt`. This means that shade is slightly lighter than it was before.

In theory, this should be fine, as shade should only be used on body, and shadeAlt should only be used on shade.

## Testing

The dark mode `shade` token has been made lighter, so we need to consider the changes to the following components:

| Component | Description of change |
|--------|--------|
| Main-nav | item hover color | 
| Callout | Background token for neutral tone |
| Accordion | open button background colour on hover |
| Sub-nav | item hover color | 
| Side-nav (mobile) | item hover color , mobile open button bg colour on hover | 
| Progress-indicator  | item hover color , mobile open button bg colour on hover | 
| Filter-sidebar (mobile) | open button background colour on hover | 

Here are some links for testing:

| Name of test | Preview | Live |
|--------|--------|--------|
| Kitchen sink (dark) | [View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1376/storybook/index.html?path=/story/testing-kitchen-sink--wesbsite-layout&globals=palette:dark) | [View live](https://design-system.agriculture.gov.au/storybook/index.html?path=/story/testing-kitchen-sink--wesbsite-layout&globals=palette:dark) |
| Kitchen sink (dark and bodyAlt) | [View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1376/storybook/index.html?path=/story/ttesting-kitchen-sink--wesbsite-layout&args=background:bodyAlt&globals=palette:dark) | [View live](https://design-system.agriculture.gov.au/storybook/index.html?path=/story/testing-kitchen-sink--wesbsite-layout&args=background:bodyAlt&globals=palette:dark) |
| Home page (dark) | [View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1376/storybook/index.html?path=/story/templates-home-page--home&globals=palette:dark) | [View live](https://design-system.agriculture.gov.au/storybook/index.html?path=/story/templates-home-page--home&globals=palette:dark) | 

## Checklist

**Preflight**

- [ ] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [ ] Describe the changes clearly in the PR description
- [ ] Read and check your code before tagging someone for review

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
