### PR TITLE
Add max workers to jest tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v2
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
@@ -44,7 +48,7 @@ jobs:
         run: yarn
 
       - name: Unit tests
-        run: yarn test
+        run: yarn test --max-workers ${{ steps.cpu-cores.outputs.count }}
 
   linting:
     name: Linting

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,9 @@ const config = {
 	testEnvironment: 'jsdom',
 	clearMocks: true,
 	verbose: true,
-	testTimeout: 15000, // TODO: Rollback to 10000 when we have a better solution for the test timeout issue
+	// Some of our tests using jest-axe can take a long time in CI
+	// We should rollback to 10000 once we have a better solution for test timeout issues
+	testTimeout: 20000,
 	collectCoverageFrom: [
 		'**/packages/**/*.{ts,tsx}',
 		'!**/dist/**',


### PR DESCRIPTION
After reading [Tests are Extremely Slow on Docker and/or Continuous Integration (CI) server](https://jestjs.io/docs/next/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server) on the Jest docs, I've implemented [`maxWorkers`](https://jestjs.io/docs/next/cli#--maxworkersnumstring) option.

Excerpt the Jest docs

> If you use GitHub Actions, you can use [github-actions-cpu-cores](https://github.com/SimenB/github-actions-cpu-cores) to detect number of CPUs, and pass that to Jest.

This change seems to improve our CI time by approx 60 seconds. The "Unit Tests" on this branch runs in 2 minutes, but on the main branch it takes around 3 minutes.
