### PR TITLE
switch/details: Update width of interactive element to match content

### DIFF
--- a/.changeset/green-radios-decide.md
+++ b/.changeset/green-radios-decide.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+details: Updated width of interactive element to match content
+
+switch: Updated width of interactive element to match content

--- a/packages/react/src/details/Details.tsx
+++ b/packages/react/src/details/Details.tsx
@@ -32,6 +32,7 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
 			>
 				<Flex
 					as="summary"
+					inline
 					link
 					focus
 					alignItems="center"

--- a/packages/react/src/details/__snapshots__/Details.test.tsx.snap
+++ b/packages/react/src/details/__snapshots__/Details.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Details renders correctly 1`] = `
     class="css-jx8h3p-Details"
   >
     <summary
-      class="css-q3yfak-boxStyles"
+      class="css-1k6zl6h-boxStyles"
     >
       Details
       <svg

--- a/packages/react/src/switch/Switch.tsx
+++ b/packages/react/src/switch/Switch.tsx
@@ -27,46 +27,49 @@ export const Switch = ({
 	checked,
 }: SwitchProps) => {
 	return (
-		<Flex
-			as="label"
-			gap={0.75}
-			alignItems="center"
-			css={{
-				cursor: 'pointer',
-				'&:hover': {
-					// Hover state for SwitchTrack
-					'& input:not(:focus) ~ span:first-of-type': {
-						borderColor: boxPalette.foregroundText,
-						backgroundColor: checked
-							? boxPalette.foregroundText
-							: boxPalette.backgroundShadeAlt,
-					},
-					// Hover state for SwitchThumb
-					'& input:not(:focus) ~ span:last-of-type': {
-						borderColor: boxPalette.foregroundText,
-						'& svg': {
-							stroke: checked ? boxPalette.foregroundText : undefined,
+		<Flex inline css={{ alignSelf: 'flex-start' }}>
+			<Flex
+				as="label"
+				gap={0.75}
+				alignItems="center"
+				css={{
+					alignSelf: 'flex-start',
+					cursor: 'pointer',
+					'&:hover': {
+						// Hover state for SwitchTrack
+						'& input:not(:focus) ~ span:first-of-type': {
+							borderColor: boxPalette.foregroundText,
+							backgroundColor: checked
+								? boxPalette.foregroundText
+								: boxPalette.backgroundShadeAlt,
+						},
+						// Hover state for SwitchThumb
+						'& input:not(:focus) ~ span:last-of-type': {
+							borderColor: boxPalette.foregroundText,
+							'& svg': {
+								stroke: checked ? boxPalette.foregroundText : undefined,
+							},
 						},
 					},
-				},
-			}}
-		>
-			<SwitchContainer size={size}>
-				<input
-					type="checkbox"
-					role="switch"
-					checked={checked}
-					onChange={() => onChange(!checked)}
-					css={{
-						...visuallyHiddenStyles,
-						// When this component is focused, outline the track
-						'&:focus-visible ~ span:first-of-type': packs.outline,
-					}}
-				/>
-				<SwitchTrack size={size} checked={checked} />
-				<SwitchThumb size={size} checked={checked} />
-			</SwitchContainer>
-			<Text>{label}</Text>
+				}}
+			>
+				<SwitchContainer size={size}>
+					<input
+						type="checkbox"
+						role="switch"
+						checked={checked}
+						onChange={() => onChange(!checked)}
+						css={{
+							...visuallyHiddenStyles,
+							// When this component is focused, outline the track
+							'&:focus-visible ~ span:first-of-type': packs.outline,
+						}}
+					/>
+					<SwitchTrack size={size} checked={checked} />
+					<SwitchThumb size={size} checked={checked} />
+				</SwitchContainer>
+				<Text>{label}</Text>
+			</Flex>
 		</Flex>
 	);
 };

--- a/packages/react/src/switch/Switch.tsx
+++ b/packages/react/src/switch/Switch.tsx
@@ -27,49 +27,47 @@ export const Switch = ({
 	checked,
 }: SwitchProps) => {
 	return (
-		<Flex inline css={{ alignSelf: 'flex-start' }}>
-			<Flex
-				as="label"
-				gap={0.75}
-				alignItems="center"
-				css={{
-					alignSelf: 'flex-start',
-					cursor: 'pointer',
-					'&:hover': {
-						// Hover state for SwitchTrack
-						'& input:not(:focus) ~ span:first-of-type': {
-							borderColor: boxPalette.foregroundText,
-							backgroundColor: checked
-								? boxPalette.foregroundText
-								: boxPalette.backgroundShadeAlt,
-						},
-						// Hover state for SwitchThumb
-						'& input:not(:focus) ~ span:last-of-type': {
-							borderColor: boxPalette.foregroundText,
-							'& svg': {
-								stroke: checked ? boxPalette.foregroundText : undefined,
-							},
+		<Flex
+			as="label"
+			gap={0.75}
+			alignItems="center"
+			css={{
+				width: 'fit-content',
+				cursor: 'pointer',
+				'&:hover': {
+					// Hover state for SwitchTrack
+					'& input:not(:focus) ~ span:first-of-type': {
+						borderColor: boxPalette.foregroundText,
+						backgroundColor: checked
+							? boxPalette.foregroundText
+							: boxPalette.backgroundShadeAlt,
+					},
+					// Hover state for SwitchThumb
+					'& input:not(:focus) ~ span:last-of-type': {
+						borderColor: boxPalette.foregroundText,
+						'& svg': {
+							stroke: checked ? boxPalette.foregroundText : undefined,
 						},
 					},
-				}}
-			>
-				<SwitchContainer size={size}>
-					<input
-						type="checkbox"
-						role="switch"
-						checked={checked}
-						onChange={() => onChange(!checked)}
-						css={{
-							...visuallyHiddenStyles,
-							// When this component is focused, outline the track
-							'&:focus-visible ~ span:first-of-type': packs.outline,
-						}}
-					/>
-					<SwitchTrack size={size} checked={checked} />
-					<SwitchThumb size={size} checked={checked} />
-				</SwitchContainer>
-				<Text>{label}</Text>
-			</Flex>
+				},
+			}}
+		>
+			<SwitchContainer size={size}>
+				<input
+					type="checkbox"
+					role="switch"
+					checked={checked}
+					onChange={() => onChange(!checked)}
+					css={{
+						...visuallyHiddenStyles,
+						// When this component is focused, outline the track
+						'&:focus-visible ~ span:first-of-type': packs.outline,
+					}}
+				/>
+				<SwitchTrack size={size} checked={checked} />
+				<SwitchThumb size={size} checked={checked} />
+			</SwitchContainer>
+			<Text>{label}</Text>
 		</Flex>
 	);
 };

--- a/packages/react/src/switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/react/src/switch/__snapshots__/Switch.test.tsx.snap
@@ -2,33 +2,29 @@
 
 exports[`Switch renders correctly 1`] = `
 <div>
-  <div
-    class="css-grt3i-boxStyles-Switch"
+  <label
+    class="css-131fe2s-boxStyles-Switch"
   >
-    <label
-      class="css-1en3fj9-boxStyles-Switch"
+    <span
+      class="css-o9fx7j-boxStyles-SwitchContainer"
     >
+      <input
+        class="css-1pfc16v-Switch"
+        role="switch"
+        type="checkbox"
+      />
       <span
-        class="css-o9fx7j-boxStyles-SwitchContainer"
-      >
-        <input
-          class="css-1pfc16v-Switch"
-          role="switch"
-          type="checkbox"
-        />
-        <span
-          class="css-k2d2eq-boxStyles-SwitchTrack"
-        />
-        <span
-          class="css-oj5g50-boxStyles-SwitchThumb"
-        />
-      </span>
+        class="css-k2d2eq-boxStyles-SwitchTrack"
+      />
       <span
-        class="css-6j1v6l-boxStyles-Text"
-      >
-        Show establishments
-      </span>
-    </label>
-  </div>
+        class="css-oj5g50-boxStyles-SwitchThumb"
+      />
+    </span>
+    <span
+      class="css-6j1v6l-boxStyles-Text"
+    >
+      Show establishments
+    </span>
+  </label>
 </div>
 `;

--- a/packages/react/src/switch/__snapshots__/Switch.test.tsx.snap
+++ b/packages/react/src/switch/__snapshots__/Switch.test.tsx.snap
@@ -2,29 +2,33 @@
 
 exports[`Switch renders correctly 1`] = `
 <div>
-  <label
-    class="css-9rj97c-boxStyles-Switch"
+  <div
+    class="css-grt3i-boxStyles-Switch"
   >
-    <span
-      class="css-o9fx7j-boxStyles-SwitchContainer"
+    <label
+      class="css-1en3fj9-boxStyles-Switch"
     >
-      <input
-        class="css-1pfc16v-Switch"
-        role="switch"
-        type="checkbox"
-      />
       <span
-        class="css-k2d2eq-boxStyles-SwitchTrack"
-      />
+        class="css-o9fx7j-boxStyles-SwitchContainer"
+      >
+        <input
+          class="css-1pfc16v-Switch"
+          role="switch"
+          type="checkbox"
+        />
+        <span
+          class="css-k2d2eq-boxStyles-SwitchTrack"
+        />
+        <span
+          class="css-oj5g50-boxStyles-SwitchThumb"
+        />
+      </span>
       <span
-        class="css-oj5g50-boxStyles-SwitchThumb"
-      />
-    </span>
-    <span
-      class="css-6j1v6l-boxStyles-Text"
-    >
-      Show establishments
-    </span>
-  </label>
+        class="css-6j1v6l-boxStyles-Text"
+      >
+        Show establishments
+      </span>
+    </label>
+  </div>
 </div>
 `;

--- a/packages/react/src/switch/docs/overview.mdx
+++ b/packages/react/src/switch/docs/overview.mdx
@@ -2,7 +2,7 @@
 title: Switch
 description: A Switch allows a user to immediately update interface settings.
 group: Forms
-storybookPath: /story/forms-switch--switch
+storybookPath: /story/forms-switch--basic
 figmaGalleryNodeId: 12444%3A100583
 relatedComponents: ['checkbox']
 ---


### PR DESCRIPTION
details: Updated width of interactive element to match content

switch: Updated width of interactive element to match content

[View Switch preview](https://design-system.agriculture.gov.au/pr-preview/pr-1382/components/switch)
[View Details preview](https://design-system.agriculture.gov.au/pr-preview/pr-1382/components/switch)

## Screenshots

### Before

<img width="1014" alt="Screenshot 2023-09-20 at 9 35 11 am" src="https://github.com/steelthreads/agds-next/assets/6265154/daf3729c-60bc-49ab-971e-2109c516c2e5">

### After

<img width="1118" alt="Screenshot 2023-09-20 at 9 38 29 am" src="https://github.com/steelthreads/agds-next/assets/6265154/6763f93b-8691-4407-98a3-9b566d4623c8">

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.