### PR TITLE
status-badge: Announce SVG

### DIFF
--- a/.changeset/brave-bobcats-sip.md
+++ b/.changeset/brave-bobcats-sip.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+status-badge: Made each icon in the `StatusBadge` component announceable by screen readers

--- a/packages/react/src/status-badge/StatusBadge.tsx
+++ b/packages/react/src/status-badge/StatusBadge.tsx
@@ -80,20 +80,28 @@ const toneMap = {
 	},
 	success: {
 		borderColor: boxPalette.systemSuccess,
-		icon: () => <SuccessIcon color="success" />,
+		icon: () => (
+			<SuccessIcon color="success" aria-hidden="false" aria-label="Success" />
+		),
 	},
 	error: {
 		borderColor: boxPalette.systemError,
-		icon: () => <AlertIcon color="error" />,
+		icon: () => (
+			<AlertIcon color="error" aria-hidden="false" aria-label="Error" />
+		),
 	},
 
 	info: {
 		borderColor: boxPalette.systemInfo,
-		icon: () => <InfoIcon color="info" />,
+		icon: () => (
+			<InfoIcon color="info" aria-hidden="false" aria-label="Information" />
+		),
 	},
 	warning: {
 		borderColor: boxPalette.systemWarning,
-		icon: () => <WarningIcon color="warning" />,
+		icon: () => (
+			<WarningIcon color="warning" aria-hidden="false" aria-label="Warning" />
+		),
 	},
 } as const;
 

--- a/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/packages/react/src/status-badge/__snapshots__/StatusBadge.test.tsx.snap
@@ -6,10 +6,11 @@ exports[`StatusBadge weight: regular tone: error renders correctly 1`] = `
     class="css-16xnn81-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Error"
       class="css-1h89p7b-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -41,10 +42,11 @@ exports[`StatusBadge weight: regular tone: info renders correctly 1`] = `
     class="css-11uollg-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Information"
       class="css-1curl5b-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -98,10 +100,11 @@ exports[`StatusBadge weight: regular tone: success renders correctly 1`] = `
     class="css-1j8vzzn-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Success"
       class="css-1esj8rc-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -132,10 +135,11 @@ exports[`StatusBadge weight: regular tone: warning renders correctly 1`] = `
     class="css-1mxhjjp-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Warning"
       class="css-qz15ef-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -170,10 +174,11 @@ exports[`StatusBadge weight: subtle tone: error renders correctly 1`] = `
     class="css-1ab91q-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Error"
       class="css-1h89p7b-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -205,10 +210,11 @@ exports[`StatusBadge weight: subtle tone: info renders correctly 1`] = `
     class="css-1ab91q-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Information"
       class="css-1curl5b-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -262,10 +268,11 @@ exports[`StatusBadge weight: subtle tone: success renders correctly 1`] = `
     class="css-1ab91q-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Success"
       class="css-1esj8rc-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"
@@ -296,10 +303,11 @@ exports[`StatusBadge weight: subtle tone: warning renders correctly 1`] = `
     class="css-1ab91q-boxStyles-StatusBadge"
   >
     <svg
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="Warning"
       class="css-qz15ef-Icon"
       clip-rule="evenodd"
-      focusable="false"
+      focusable="true"
       height="24"
       role="img"
       viewBox="0 0 24 24"


### PR DESCRIPTION
Made each icon in the `StatusBadge` component announceable by screen readers

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1383/components/status-badge)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.