### PR TITLE
Upgrade NextJS

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -19,7 +19,6 @@ const config: StorybookConfig = {
 		'@storybook/addon-links',
 		'@storybook/addon-a11y',
 		{ name: '@storybook/addon-essentials', options: { background: false } },
-		'storybook-addon-next-router',
 	],
 	stories: [
 		'../packages/*/src/**/*.stories.@(ts|tsx)',
@@ -40,6 +39,11 @@ const config: StorybookConfig = {
 			define: {
 				...config.define,
 				'process.env': {},
+			},
+			resolve: {
+				alias: {
+					'next/router': 'next-router-mock',
+				},
 			},
 			optimizeDeps: {
 				...config.optimizeDeps,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,4 @@
 import { Preview } from '@storybook/react';
-import { RouterContext } from 'next/dist/shared/lib/router-context';
 import { Box } from '../packages/react/src/box';
 import { Core } from '../packages/react/src/core';
 import { theme as agriculture } from '../packages/react/src/ag-branding';
@@ -88,9 +87,6 @@ const parameters = {
 	},
 	viewport: {
 		viewports: makeViewports(),
-	},
-	nextRouter: {
-		Provider: RouterContext.Provider,
 	},
 };
 

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -9,6 +9,7 @@ const basePath = process.env.BASE_PATH ?? undefined;
 const nextConfig = {
 	reactStrictMode: true,
 	basePath,
+	output: 'export',
 	env: {
 		NEXT_PUBLIC_GITHUB_PR_PREVIEW_NUMBER: process.env.GITHUB_PR_PREVIEW_NUMBER,
 		NEXT_PUBLIC_BASE_PATH: basePath,

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
 	"repository": "https://github.com/steelthreads/agds-next/tree/main/docs",
 	"license": "MIT",
 	"scripts": {
-		"build": "yarn generate-component-props && next build && next-sitemap && next export",
+		"build": "yarn generate-component-props && next build && next-sitemap",
 		"dev": "yarn generate-component-props && next dev",
 		"dev:watch": "next-remote-watch ../packages",
 		"generate-component-props": "node scripts/generateComponentProps.js",
@@ -22,7 +22,7 @@
 		"@types/gtag.js": "^0.0.12",
 		"clipboard-copy": "^4.0.1",
 		"gray-matter": "^4.0.3",
-		"next": "^13.4.12",
+		"next": "^13.5.1",
 		"next-mdx-remote": "^4.4.1",
 		"next-remote-watch": "^2.0.0",
 		"next-sitemap": "^3.1.32",

--- a/example-form/next.config.js
+++ b/example-form/next.config.js
@@ -1,6 +1,6 @@
 const withPreconstruct = require('@preconstruct/next');
 
-const basePath = [process.env.BASE_PATH, '/example-form']
+const basePath = [process.env.BASE_PATH, 'example-form']
 	.filter(Boolean)
 	.join('/');
 
@@ -9,7 +9,7 @@ const nextConfig = {
 	reactStrictMode: true,
 	basePath,
 	output: 'export',
-	distDir: '../docs/public/example-site',
+	distDir: '../docs/public/example-form',
 };
 
 module.exports = withPreconstruct(nextConfig);

--- a/example-form/next.config.js
+++ b/example-form/next.config.js
@@ -1,8 +1,6 @@
 const withPreconstruct = require('@preconstruct/next');
 
-const basePath = [process.env.BASE_PATH, 'example-form']
-	.filter(Boolean)
-	.join('/');
+const basePath = `${process.env.BASE_PATH ?? ''}/example-form`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/example-form/next.config.js
+++ b/example-form/next.config.js
@@ -8,6 +8,8 @@ const basePath = [process.env.BASE_PATH, '/example-form']
 const nextConfig = {
 	reactStrictMode: true,
 	basePath,
+	output: 'export',
+	distDir: '../docs/public/example-site',
 };
 
 module.exports = withPreconstruct(nextConfig);

--- a/example-form/package.json
+++ b/example-form/package.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"main": "index.js",
 	"scripts": {
-		"build": "next build && next export -o ../docs/public/example-form",
+		"build": "next build",
 		"dev": "next dev",
 		"lint": "next lint",
 		"start": "next start"
@@ -14,7 +14,7 @@
 		"@ag.ds-next/react": "^1.0.0",
 		"@hookform/resolvers": "^2.8.8",
 		"@preconstruct/next": "^4.0.0",
-		"next": "^13.4.12",
+		"next": "^13.5.1",
 		"react": "18.1.0",
 		"react-dom": "18.1.0",
 		"react-hook-form": "^7.27.1",

--- a/example-site/next.config.js
+++ b/example-site/next.config.js
@@ -8,6 +8,8 @@ const basePath = [process.env.BASE_PATH, '/example-site']
 const nextConfig = {
 	reactStrictMode: true,
 	basePath,
+	output: 'export',
+	distDir: '../docs/public/example-site',
 	experimental: {
 		/**
 		 * WARNING: If you are a consumer of the design system reading this you DO NOT need this config in your project.

--- a/example-site/next.config.js
+++ b/example-site/next.config.js
@@ -1,8 +1,6 @@
 const withPreconstruct = require('@preconstruct/next');
 
-const basePath = [process.env.BASE_PATH, 'example-site']
-	.filter(Boolean)
-	.join('/');
+const basePath = `${process.env.BASE_PATH ?? ''}/example-site`;
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/example-site/next.config.js
+++ b/example-site/next.config.js
@@ -1,6 +1,6 @@
 const withPreconstruct = require('@preconstruct/next');
 
-const basePath = [process.env.BASE_PATH, '/example-site']
+const basePath = [process.env.BASE_PATH, 'example-site']
 	.filter(Boolean)
 	.join('/');
 

--- a/example-site/package.json
+++ b/example-site/package.json
@@ -5,7 +5,7 @@
 	"license": "MIT",
 	"main": "index.js",
 	"scripts": {
-		"build": "next build && next export -o ../docs/public/example-site",
+		"build": "next build",
 		"dev": "next dev",
 		"lint": "next lint",
 		"start": "next start"
@@ -15,7 +15,7 @@
 		"@hookform/resolvers": "^2.8.8",
 		"@preconstruct/next": "^4.0.0",
 		"@types/gtag.js": "^0.0.12",
-		"next": "^13.4.12",
+		"next": "^13.5.1",
 		"react": "18.1.0",
 		"react-dom": "18.1.0",
 		"react-hook-form": "^7.27.1",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"jest": "^29.6.2",
 		"jest-axe": "^8.0.0",
 		"jest-environment-jsdom": "^29.6.2",
+		"next-router-mock": "^0.9.9",
 		"plop": "^3.1.1",
 		"prettier": "^3.0.0",
 		"prettier-plugin-packagejson": "^2.4.5",
@@ -86,7 +87,6 @@
 		"react-dom": "18.1.0",
 		"rimraf": "^3.0.2",
 		"storybook": "^7.4.0",
-		"storybook-addon-next-router": "^4.0.2",
 		"swr": "^1.3.0",
 		"typescript": "^4.7.4",
 		"vite": "^4.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12335,6 +12335,11 @@ next-remote-watch@^2.0.0:
     commander "^5.0.0"
     express "^4.17.1"
 
+next-router-mock@^0.9.9:
+  version "0.9.9"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.9.tgz#03191be49b1ede31d7475596fb0d86766d6a696f"
+  integrity sha512-2o50zr+5pWj0zzcvBEWNHDlmWmlDExPdX5OuXKW2aCxV85XUA6MlELr0n0f0wtXj5dUVZ8qspHj6YwF7KZHrbA==
+
 next-sitemap@^3.1.32:
   version "3.1.32"
   resolved "https://registry.yarnpkg.com/next-sitemap/-/next-sitemap-3.1.32.tgz#e4a7227cab23b5e5c68bc54d335b86d3ff1e05f8"
@@ -14826,13 +14831,6 @@ store2@^2.14.2:
   resolved "https://registry.yarnpkg.com/store2/-/store2-2.14.2.tgz#56138d200f9fe5f582ad63bc2704dbc0e4a45068"
   integrity sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==
 
-storybook-addon-next-router@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/storybook-addon-next-router/-/storybook-addon-next-router-4.0.2.tgz#fb45a4b7d9c4f92cd63b509f4d378c51164aca7d"
-  integrity sha512-0rjGAl7HziW4ecDq+VU03H1dwkw5f6phqA+PMquPzdowNVl29ejVwVadLMGlovG6x2snaxMGxtySR2c5bwegSw==
-  dependencies:
-    tslib "2.4.0"
-
 storybook@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/storybook/-/storybook-7.4.0.tgz#f1b64222e3d474bc6e258eb7e48c675685829873"
@@ -15419,11 +15417,6 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
-  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
-
 tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -15433,6 +15426,11 @@ tslib@^2.0.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+
+tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^2.5.0:
   version "2.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,10 +3436,10 @@
     pump "^3.0.0"
     tar-fs "^2.1.1"
 
-"@next/env@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.12.tgz#0b88115ab817f178bf9dc0c5e7b367277595b58d"
-  integrity sha512-RmHanbV21saP/6OEPBJ7yJMuys68cIf8OBBWd7+uj40LdpmswVAwe1uzeuFyUsd6SfeITWT3XnQfn6wULeKwDQ==
+"@next/env@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/env/-/env-13.5.1.tgz#337f5f3d325250f91ed23d783cbf8297800ee7d3"
+  integrity sha512-CIMWiOTyflFn/GFx33iYXkgLSQsMQZV4jB91qaj/TfxGaGOXxn8C1j72TaUSPIyN7ziS/AYG46kGmnvuk1oOpg==
 
 "@next/eslint-plugin-next@13.4.12":
   version "13.4.12"
@@ -3448,50 +3448,50 @@
   dependencies:
     glob "7.1.7"
 
-"@next/swc-darwin-arm64@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.12.tgz#326c830b111de8a1a51ac0cbc3bcb157c4c4f92c"
-  integrity sha512-deUrbCXTMZ6ZhbOoloqecnUeNpUOupi8SE2tx4jPfNS9uyUR9zK4iXBvH65opVcA/9F5I/p8vDXSYbUlbmBjZg==
+"@next/swc-darwin-arm64@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.1.tgz#dc21234afce27910a8d141e6a7ab5e821725dc94"
+  integrity sha512-Bcd0VFrLHZnMmJy6LqV1CydZ7lYaBao8YBEdQUVzV8Ypn/l5s//j5ffjfvMzpEQ4mzlAj3fIY+Bmd9NxpWhACw==
 
-"@next/swc-darwin-x64@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.12.tgz#dd5c49fc092a8ffe4f30b7aa9bf6c5d2e40bbfa1"
-  integrity sha512-WRvH7RxgRHlC1yb5oG0ZLx8F7uci9AivM5/HGGv9ZyG2Als8Ij64GC3d+mQ5sJhWjusyU6T6V1WKTUoTmOB0zQ==
+"@next/swc-darwin-x64@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.1.tgz#29591ac96cc839903918621cf2d8f79c40cba3ca"
+  integrity sha512-uvTZrZa4D0bdWa1jJ7X1tBGIxzpqSnw/ATxWvoRO9CVBvXSx87JyuISY+BWsfLFF59IRodESdeZwkWM2l6+Kjg==
 
-"@next/swc-linux-arm64-gnu@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.12.tgz#816cbe9d26ce4670ea99d95b66041e483ed122d6"
-  integrity sha512-YEKracAWuxp54tKiAvvq73PUs9lok57cc8meYRibTWe/VdPB2vLgkTVWFcw31YDuRXdEhdX0fWS6Q+ESBhnEig==
+"@next/swc-linux-arm64-gnu@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.1.tgz#349ce2714dc87d1db6911758652f3b2b0810dd6f"
+  integrity sha512-/52ThlqdORPQt3+AlMoO+omicdYyUEDeRDGPAj86ULpV4dg+/GCFCKAmFWT0Q4zChFwsAoZUECLcKbRdcc0SNg==
 
-"@next/swc-linux-arm64-musl@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.12.tgz#670c8aee221628f65e5b299ee84db746e6c778b0"
-  integrity sha512-LhJR7/RAjdHJ2Isl2pgc/JaoxNk0KtBgkVpiDJPVExVWA1c6gzY57+3zWuxuyWzTG+fhLZo2Y80pLXgIJv7g3g==
+"@next/swc-linux-arm64-musl@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.1.tgz#3f8bc223db9100887ffda998ad963820f39d944b"
+  integrity sha512-L4qNXSOHeu1hEAeeNsBgIYVnvm0gg9fj2O2Yx/qawgQEGuFBfcKqlmIE/Vp8z6gwlppxz5d7v6pmHs1NB6R37w==
 
-"@next/swc-linux-x64-gnu@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.12.tgz#54c64e689f007ae463698dddc1c6637491c99cb4"
-  integrity sha512-1DWLL/B9nBNiQRng+1aqs3OaZcxC16Nf+mOnpcrZZSdyKHek3WQh6j/fkbukObgNGwmCoVevLUa/p3UFTTqgqg==
+"@next/swc-linux-x64-gnu@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.1.tgz#4503d43d27aa178efb4a5c9efe229faae37d67a8"
+  integrity sha512-QVvMrlrFFYvLtABk092kcZ5Mzlmsk2+SV3xYuAu8sbTuIoh0U2+HGNhVklmuYCuM3DAAxdiMQTNlRQmNH11udw==
 
-"@next/swc-linux-x64-musl@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.12.tgz#9cbddf4e542ef3d32284e0c36ce102facc015f8b"
-  integrity sha512-kEAJmgYFhp0VL+eRWmUkVxLVunn7oL9Mdue/FS8yzRBVj7Z0AnIrHpTIeIUl1bbdQq1VaoOztnKicAjfkLTRCQ==
+"@next/swc-linux-x64-musl@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.1.tgz#a6e81f0df0be2fac78392705f487036695cf7b10"
+  integrity sha512-bBnr+XuWc28r9e8gQ35XBtyi5KLHLhTbEvrSgcWna8atI48sNggjIK8IyiEBO3KIrcUVXYkldAzGXPEYMnKt1g==
 
-"@next/swc-win32-arm64-msvc@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.12.tgz#3467a4b25429ccf49fd416388c9d19c80a4f6465"
-  integrity sha512-GMLuL/loR6yIIRTnPRY6UGbLL9MBdw2anxkOnANxvLvsml4F0HNIgvnU3Ej4BjbqMTNjD4hcPFdlEow4XHPdZA==
+"@next/swc-win32-arm64-msvc@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.1.tgz#9d8517fe1dd6aa348c7be36b933ad8195f961294"
+  integrity sha512-EQGeE4S5c9v06jje9gr4UlxqUEA+zrsgPi6kg9VwR+dQHirzbnVJISF69UfKVkmLntknZJJI9XpWPB6q0Z7mTg==
 
-"@next/swc-win32-ia32-msvc@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.12.tgz#73494cd167191946833c680b28d6a42435d383a8"
-  integrity sha512-PhgNqN2Vnkm7XaMdRmmX0ZSwZXQAtamBVSa9A/V1dfKQCV1rjIZeiy/dbBnVYGdj63ANfsOR/30XpxP71W0eww==
+"@next/swc-win32-ia32-msvc@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.1.tgz#42e711d00642f538edaabf9535545697d093b2f7"
+  integrity sha512-1y31Q6awzofVjmbTLtRl92OX3s+W0ZfO8AP8fTnITcIo9a6ATDc/eqa08fd6tSpFu6IFpxOBbdevOjwYTGx/AQ==
 
-"@next/swc-win32-x64-msvc@13.4.12":
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.12.tgz#4a497edc4e8c5ee3c3eb27cf0eb39dfadff70874"
-  integrity sha512-Z+56e/Ljt0bUs+T+jPjhFyxYBcdY2RIq9ELFU+qAMQMteHo7ymbV7CKmlcX59RI9C4YzN8PgMgLyAoi916b5HA==
+"@next/swc-win32-x64-msvc@13.5.1":
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.1.tgz#34bc139cf37704d595fe84eb803b1578a539e35e"
+  integrity sha512-+9XBQizy7X/GuwNegq+5QkkxAPV7SBsIwapVRQd9WSvvU20YO23B3bZUpevdabi4fsd25y9RJDDncljy/V54ww==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -4775,10 +4775,10 @@
     "@types/react" "^16.14.34"
     file-system-cache "2.3.0"
 
-"@swc/helpers@0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.1.tgz#e9031491aa3f26bfcc974a67f48bd456c8a5357a"
-  integrity sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==
+"@swc/helpers@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.2.tgz#85ea0c76450b61ad7d10a37050289eded783c27d"
+  integrity sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==
   dependencies:
     tslib "^2.4.0"
 
@@ -12343,13 +12343,13 @@ next-sitemap@^3.1.32:
     "@corex/deepmerge" "^4.0.29"
     minimist "^1.2.6"
 
-next@^13.4.12:
-  version "13.4.12"
-  resolved "https://registry.yarnpkg.com/next/-/next-13.4.12.tgz#809b21ea0aabbe88ced53252c88c4a5bd5af95df"
-  integrity sha512-eHfnru9x6NRmTMcjQp6Nz0J4XH9OubmzOa7CkWL+AUrUxpibub3vWwttjduu9No16dug1kq04hiUUpo7J3m3Xw==
+next@^13.5.1:
+  version "13.5.1"
+  resolved "https://registry.yarnpkg.com/next/-/next-13.5.1.tgz#cf51e950017121f5404eedbde7d59d9ed310839b"
+  integrity sha512-GIudNR7ggGUZoIL79mSZcxbXK9f5pwAIPZxEM8+j2yLqv5RODg4TkmUlaKSYVqE1bPQueamXSqdC3j7axiTSEg==
   dependencies:
-    "@next/env" "13.4.12"
-    "@swc/helpers" "0.5.1"
+    "@next/env" "13.5.1"
+    "@swc/helpers" "0.5.2"
     busboy "1.6.0"
     caniuse-lite "^1.0.30001406"
     postcss "8.4.14"
@@ -12357,15 +12357,15 @@ next@^13.4.12:
     watchpack "2.4.0"
     zod "3.21.4"
   optionalDependencies:
-    "@next/swc-darwin-arm64" "13.4.12"
-    "@next/swc-darwin-x64" "13.4.12"
-    "@next/swc-linux-arm64-gnu" "13.4.12"
-    "@next/swc-linux-arm64-musl" "13.4.12"
-    "@next/swc-linux-x64-gnu" "13.4.12"
-    "@next/swc-linux-x64-musl" "13.4.12"
-    "@next/swc-win32-arm64-msvc" "13.4.12"
-    "@next/swc-win32-ia32-msvc" "13.4.12"
-    "@next/swc-win32-x64-msvc" "13.4.12"
+    "@next/swc-darwin-arm64" "13.5.1"
+    "@next/swc-darwin-x64" "13.5.1"
+    "@next/swc-linux-arm64-gnu" "13.5.1"
+    "@next/swc-linux-arm64-musl" "13.5.1"
+    "@next/swc-linux-x64-gnu" "13.5.1"
+    "@next/swc-linux-x64-musl" "13.5.1"
+    "@next/swc-win32-arm64-msvc" "13.5.1"
+    "@next/swc-win32-ia32-msvc" "13.5.1"
+    "@next/swc-win32-x64-msvc" "13.5.1"
 
 no-case@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
- Upgraded Next to version `13.15.0`
- Fixed deprecation warning about using [next export] by using ` output: 'export'` as mentioned [in the next docs](https://nextjs.org/docs/pages/building-your-application/deploying/static-exports#configuration)
- Removed usage of `storybook-addon-next-router` as we get deprecation warnings about this plugin, and it doesn't work very well with the next version of Next. This has been replaced by `next-router-mock`.