### PR TITLE
callout: Adjusted icon gap

### DIFF
--- a/packages/react/src/callout/Callout.tsx
+++ b/packages/react/src/callout/Callout.tsx
@@ -35,7 +35,7 @@ export const Callout = ({
 	tone = 'neutral',
 	variant = 'regular',
 }: CalloutProps) => {
-	const { gap, padding, flexDirection, titlePaddingTop } =
+	const { textGap, iconGap, padding, flexDirection, titlePaddingTop } =
 		calloutVariantMap[variant];
 	const { background, border, icon } = calloutToneMap(variant)[tone];
 
@@ -48,7 +48,7 @@ export const Callout = ({
 			as={as}
 			flexDirection={flexDirection}
 			rounded
-			gap={gap}
+			gap={iconGap}
 			background={onBodyAlt ? 'shadeAlt' : background}
 			borderColor={border}
 			padding={padding}
@@ -57,7 +57,7 @@ export const Callout = ({
 			highContrastOutline
 		>
 			{iconProp || icon ? <Flex flexShrink={0}>{iconProp || icon}</Flex> : null}
-			<Stack gap={gap} css={{ paddingTop: titlePaddingTop }}>
+			<Stack gap={textGap} css={{ paddingTop: titlePaddingTop }}>
 				{title ? <CalloutTitle variant={variant}>{title}</CalloutTitle> : null}
 				{children}
 			</Stack>

--- a/packages/react/src/callout/__snapshots__/Callout.test.tsx.snap
+++ b/packages/react/src/callout/__snapshots__/Callout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Callout renders correctly 1`] = `
 <div>
   <div
-    class="css-eaebe2-boxStyles"
+    class="css-1gkhklp-boxStyles"
   >
     <div
       class="css-1iiypnu-boxStyles-Callout"
@@ -166,7 +166,7 @@ exports[`Callout with feature variant and neutral tone renders correctly 1`] = `
 exports[`Callout with regular variant and info tone renders correctly 1`] = `
 <div>
   <div
-    class="css-vz3ah2-boxStyles"
+    class="css-15cw9y2-boxStyles"
   >
     <div
       class="css-vspen0-boxStyles"
@@ -213,7 +213,7 @@ exports[`Callout with regular variant and info tone renders correctly 1`] = `
 exports[`Callout with regular variant and neutral tone renders correctly 1`] = `
 <div>
   <div
-    class="css-eaebe2-boxStyles"
+    class="css-1gkhklp-boxStyles"
   >
     <div
       class="css-1iiypnu-boxStyles-Callout"

--- a/packages/react/src/callout/utils.tsx
+++ b/packages/react/src/callout/utils.tsx
@@ -25,7 +25,8 @@ export type CalloutTone = keyof ReturnType<typeof calloutToneMap>;
 
 export const calloutVariantMap = {
 	compact: {
-		gap: 0.5,
+		textGap: 0.5,
+		iconGap: 0.5,
 		padding: 1,
 		titleSize: 'sm',
 		titlePaddingTop: '0.125rem', // 2px
@@ -33,7 +34,8 @@ export const calloutVariantMap = {
 		flexDirection: 'row',
 	},
 	regular: {
-		gap: 1,
+		textGap: 1,
+		iconGap: 0.5,
 		padding: 1.5,
 		titleSize: 'md',
 		titlePaddingTop: undefined,
@@ -41,7 +43,8 @@ export const calloutVariantMap = {
 		flexDirection: 'row',
 	},
 	feature: {
-		gap: 1,
+		textGap: 1,
+		iconGap: 1,
 		padding: 1.5,
 		titleSize: 'xl',
 		titlePaddingTop: undefined,


### PR DESCRIPTION
Adjusted the gap in regular Callout between the icon and the text stack to be consistent with designs.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1385/components/callout)

<img width="1214" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/32a8c446-32ce-4cdf-a48e-5d93a21da77a">


## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
