### PR TITLE
app-layout: Fix large tables breaking layout

### DIFF
--- a/.changeset/happy-meals-watch.md
+++ b/.changeset/happy-meals-watch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Removed `overflow: hidden` from `AppLayoutContent` to support sticky elements. Added `min-width: 0` to fix large tables breaking layout on smaller devices.

--- a/packages/react/src/app-layout/AppLayoutContent.tsx
+++ b/packages/react/src/app-layout/AppLayoutContent.tsx
@@ -5,7 +5,12 @@ export type AppLayoutContentProps = PropsWithChildren<{}>;
 
 export function AppLayoutContent({ children }: AppLayoutContentProps) {
 	return (
-		<Flex flexDirection="column" css={{ overflow: 'hidden' }}>
+		<Flex
+			flexDirection="column"
+			// `min-width: 0` Fixes wide elements (like large tables) not respecting the width of their container
+			// https://css-tricks.com/flexbox-truncated-text/#aa-the-solution-is-min-width-0-on-the-flex-child
+			css={{ minWidth: `0` }}
+		>
 			{children}
 		</Flex>
 	);

--- a/packages/react/src/app-layout/AppLayoutSidebar.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.tsx
@@ -37,11 +37,7 @@ export function AppLayoutSidebar({ activePath, items }: AppLayoutSidebarProps) {
 					},
 				}}
 			>
-				<AppLayoutSidebarNav
-					activePath={bestMatch}
-					items={items}
-					css={{ position: 'sticky', top: 0 }}
-				/>
+				<AppLayoutSidebarNav activePath={bestMatch} items={items} />
 			</Stack>
 			{/* Mobile */}
 			<AppLayoutSidebarDialog>

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -427,7 +427,7 @@ exports[`AppLayout renders correctly 1`] = `
       </nav>
     </aside>
     <div
-      class="css-yurbt-boxStyles-AppLayoutContent"
+      class="css-zu5yim-boxStyles-AppLayoutContent"
     >
       <main
         class="css-z5n8zt-renderAppLayout"


### PR DESCRIPTION
Removed `overflow: hidden` from `AppLayoutContent` to support sticky elements. This is required in order for PR #1345.

I've also added `min-width: 0` to fix large tables and potentially other wide elements breaking the page layout on smaller devices. This was being achieved by `overflow-hidden` previously.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1388/playroom/index.html#?code=N4Igxg9gJgpiBcIA8BBADmgMgQwJ4QFcAXAPgB0A7AAitQx32IAkZtYAnSmmgC1agCWFAOYBeMiADKMdgDcBYGFQrYAtjAlduAZwIAjTEJjipM%2BYqqxtYdgLREBEakR7YiVSAQA2UKnqXYVF4CREReSl5OwjKa1NyRwhCiwEiYEIlUAPQkAL5avOwwAGYmAMSxNNladFh4hESSArB62JxxNCEwqtrJANr53P3t3DTAQdj%2BXvBUEjiTEgA0VDyFRdMS5SBLCk7TAOowetqdAJKQ1DkLAyNjXhMwUzMgcw%2BLy6vrIJvb5-uHx0QYGcnFRLtcqABdK7DGi9W73R6zBFvHYUaYAUQAHiFgRcoQMIXk4lU4jUGPUAMJOQEUUgDJCqbBCcgw2gABWw0SptJgtJZIxGSAAKhNwnt2NgMDJ%2BQLBSK9OEZbK5aKYBTJQ4nCQsWo0OFLG5sEhMvLwur7I4KErlTRhaqWGxrTbbUR2E7naMUOwJbgAHRFdgQVQACgoMAA7lQvT7gwBGAAMAEpfQBrGC4bTBxPJxloYPByBeAiqCiJqiiEhUYPgj2200wB0cKhp3DJQvFig5KjWCBoYwSQsSd217hUoslmu1431xvSyc27NEke2zKu4cC6f2-jrlUKmAAIWguB3AuA0bw-sDIbDkfPuDjSdT6cz2d9ufzgfDZYrVfnyqQrrNumySfjkJ42me3oXgGQahhGUZQfeCbJi2L45pK%2BbtiW36VtWrLLrQ9YUg8XhAa2wBYZ22qYrq%2BpQIam57sRXheOByqLn%2BsrGmunHcBx%2BEbiaqqHlAx5-oxiqThJMDipKfZuuCxocly1K8nSwzGoyzL0ugtSMEQABiEAQICCmskgKiyFQrQCNgAC0dyTCYRTGaZQ5SYYFApoY2hEH%2BwReT0wBDCO8KTJ8LxeG8KzFJ8mygtCoXjOFTyRdFHxPPFYICTcyUPBFyJbO8sWZRICW8WF%2BWpYVSwxWspUgOVOWQkuzo8BAtgAF7UtgUUCSSXGZJZ1rGrp5LEEZJlzqSmRjXUxDcjS6mjfQ83qVsIDhk0LjaAgvSEkAA)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
