### PR TITLE
multi-step-form example: Resolve layout bug

### DIFF
--- a/docs/content/templates/multi-page-form/MultiPageFormStep.tsx
+++ b/docs/content/templates/multi-page-form/MultiPageFormStep.tsx
@@ -7,7 +7,6 @@ import { DirectionButton } from '@ag.ds-next/react/direction-link';
 import { Divider } from '@ag.ds-next/react/divider';
 import { Button, ButtonGroup } from '@ag.ds-next/react/button';
 import { Text } from '@ag.ds-next/react/text';
-import { FormStack } from '@ag.ds-next/react/form-stack';
 import { Textarea } from '@ag.ds-next/react/textarea';
 import { PageTitle } from '../../../components/PageTitle';
 
@@ -27,7 +26,7 @@ export function MultiPageFormStep() {
 					</ContentBleed>
 				</Column>
 				<Column columnSpan={{ xs: 12, md: 8 }} columnStart={{ lg: 5 }}>
-					<Stack gap={3} alignItems="flex-start">
+					<Stack gap={3}>
 						<DirectionButton direction="left">Back</DirectionButton>
 						<PageTitle
 							pretext="Title of multi-page form"
@@ -41,15 +40,13 @@ export function MultiPageFormStep() {
 							}
 						/>
 						<Stack as="form" gap={3} noValidate>
-							<FormStack>
-								<Textarea
-									label="Text area field label"
-									hint="Hint text"
-									id="description"
-									required
-									block
-								/>
-							</FormStack>
+							<Textarea
+								label="Text area field label"
+								hint="Hint text"
+								id="description"
+								required
+								block
+							/>
 							<Divider />
 							<ButtonGroup>
 								<Button type="submit" variant="primary">


### PR DESCRIPTION
Resolve a layout bug in the multi-step form template example on mobile, which was constricting form contents.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1391/storybook/index.html?path=/story/templates-multi-page-form--form-page)

| Before | After |
|--------|--------|
| <img width="452" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/b6ca33d3-c626-485d-ba99-b91bc394460d"> | <img width="453" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/32e3d8da-5700-47df-a0df-c3a3acd1d949"> | 

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
