### PR TITLE
combobox: Improve a11y by fixing incorrect usage of `aria-describedby`

### DIFF
--- a/.changeset/few-days-behave.md
+++ b/.changeset/few-days-behave.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+field: Added new `labelId` prop

--- a/.changeset/tiny-chairs-enjoy.md
+++ b/.changeset/tiny-chairs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+combobox: Improved accessibility by ensuring that the popover listbox element is described correctly by the field label

--- a/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
+++ b/packages/react/src/autocomplete/__snapshots__/Autocomplete.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Autocomplete renders correctly 1`] = `
     <label
       class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
+      id="downshift-:r1:-label"
     >
       <span
         class="css-433uqb-boxStyles-Text"

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -82,4 +82,14 @@ describe('Combobox', () => {
 		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
 		expect(inputRef.current?.id).toBe(id);
 	});
+
+	it('listBox is described by the label correctly', async () => {
+		const { container } = renderCombobox();
+		const label = container.querySelector('label');
+		const listBox = container.querySelector('[role="listbox"]');
+		expect(label).toBeInTheDocument();
+		expect(label).toHaveTextContent('Find your state (optional)');
+		expect(listBox).toBeInTheDocument();
+		expect(listBox).toHaveAttribute('aria-labelledby', label?.id);
+	});
 });

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -91,9 +91,12 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 		},
 	});
 
+	const { id: labelId } = combobox.getLabelProps();
+
 	return (
 		<Field
 			label={label}
+			labelId={labelId}
 			hideOptionalLabel={hideOptionalLabel}
 			required={Boolean(required)}
 			hint={hint}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -139,9 +139,12 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 		? mergeRefs([inputRef, inputRefProp])
 		: inputRef;
 
+	const { id: labelId } = combobox.getLabelProps();
+
 	return (
 		<Field
 			label={label}
+			labelId={labelId}
 			hideOptionalLabel={hideOptionalLabel}
 			required={Boolean(required)}
 			hint={hint}

--- a/packages/react/src/combobox/ComboboxMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.test.tsx
@@ -99,4 +99,14 @@ describe('ComboboxMulti', () => {
 			STATE_OPTIONS.length - 1
 		);
 	});
+
+	it('listBox is described by the label correctly', async () => {
+		const { container } = renderComboboxMulti();
+		const label = container.querySelector('label');
+		const listBox = container.querySelector('[role="listbox"]');
+		expect(label).toBeInTheDocument();
+		expect(label).toHaveTextContent('Find your state (optional)');
+		expect(listBox).toBeInTheDocument();
+		expect(listBox).toHaveAttribute('aria-labelledby', label?.id);
+	});
 });

--- a/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/Combobox.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`Combobox renders correctly 1`] = `
     <label
       class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
+      id="downshift-:r1:-label"
     >
       <span
         class="css-433uqb-boxStyles-Text"

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsync.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ComboboxAsync renders correctly 1`] = `
     <label
       class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
+      id="downshift-:r1:-label"
     >
       <span
         class="css-433uqb-boxStyles-Text"

--- a/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxAsyncMulti.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ComboboxAsyncMulti renders correctly 1`] = `
     <label
       class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
+      id="downshift-:r1:-label"
     >
       <span
         class="css-433uqb-boxStyles-Text"

--- a/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
+++ b/packages/react/src/combobox/__snapshots__/ComboboxMulti.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`ComboboxMulti renders correctly 1`] = `
     <label
       class="css-79i25n-boxStyles"
       for="combobox-input-:r0:"
+      id="downshift-:r1:-label"
     >
       <span
         class="css-433uqb-boxStyles-Text"

--- a/packages/react/src/field/Field.stories.tsx
+++ b/packages/react/src/field/Field.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react';
 import { Field } from './Field';
 import { FieldContainer } from './FieldContainer';
 import { FieldLabel } from './FieldLabel';
@@ -6,84 +6,94 @@ import { FieldMessage } from './FieldMessage';
 import { FieldHint } from './FieldHint';
 import { useFieldA11yProps, useFieldIds } from './index';
 
-export default {
+const meta: Meta<typeof Field> = {
 	title: 'forms/Field',
 	component: Field,
-} as ComponentMeta<typeof Field>;
-
-const Template: ComponentStory<typeof Field> = (args) => (
-	<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
-);
-
-export const Basic = Template.bind({});
-Basic.args = {
-	label: 'Example',
+	render: (args) => (
+		<Field {...args}>{(a11yProps) => <input {...a11yProps} />}</Field>
+	),
 };
 
-export const Required = Template.bind({});
-Required.args = {
-	label: 'Example',
-	required: true,
+export default meta;
+
+type Story = StoryObj<typeof Field>;
+
+export const Basic: Story = {
+	args: {
+		label: 'Example',
+	},
 };
 
-export const Invalid = Template.bind({});
-Invalid.args = {
-	label: 'Example',
-	message: 'This field is invalid',
-	invalid: true,
+export const Required: Story = {
+	args: {
+		label: 'Example',
+		required: true,
+	},
 };
 
-export const SecondaryLabel = Template.bind({});
-SecondaryLabel.args = {
-	label: 'Example',
-	secondaryLabel: '(dd/mm/yyyy)',
+export const Invalid: Story = {
+	args: {
+		label: 'Example',
+		message: 'This field is invalid',
+		invalid: true,
+	},
 };
 
-export const HideOptionalLabel = Template.bind({});
-HideOptionalLabel.args = {
-	label: 'Example',
-	hideOptionalLabel: true,
+export const SecondaryLabel: Story = {
+	args: {
+		label: 'Example',
+		secondaryLabel: '(dd/mm/yyyy)',
+	},
 };
 
-export const Modular: ComponentStory<typeof Field> = ({
-	label,
-	hideOptionalLabel,
-	secondaryLabel,
-	hint,
-	message,
-	invalid,
-	required,
-}) => {
-	const { fieldId, messageId, hintId } = useFieldIds();
-	const a11yProps = useFieldA11yProps({
-		fieldId,
-		message,
-		messageId,
+export const HideOptionalLabel: Story = {
+	args: {
+		label: 'Example',
+		hideOptionalLabel: true,
+	},
+};
+
+export const Modular: Story = {
+	args: {
+		label: 'Example',
+		hint: 'Hint text',
+		message: 'Message',
+		invalid: true,
+	},
+	render: function Render({
+		label,
+		hideOptionalLabel,
+		secondaryLabel,
 		hint,
-		hintId,
+		message,
 		invalid,
-	});
-	return (
-		<FieldContainer invalid={invalid}>
-			<FieldLabel
-				htmlFor={fieldId}
-				required={required}
-				secondaryLabel={secondaryLabel}
-				hideOptionalLabel={hideOptionalLabel}
-			>
-				{label}
-			</FieldLabel>
-			{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
-			{message && invalid ? (
-				<FieldMessage id={messageId}>{message}</FieldMessage>
-			) : null}
-			<input {...a11yProps} />
-		</FieldContainer>
-	);
-};
-Modular.args = {
-	label: 'Example',
-	hint: 'Hint text',
-	message: 'Message',
-	invalid: true,
+		required,
+	}) {
+		const { fieldId, messageId, hintId } = useFieldIds();
+		const a11yProps = useFieldA11yProps({
+			fieldId,
+			message,
+			messageId,
+			hint,
+			hintId,
+			invalid,
+		});
+		return (
+			<FieldContainer invalid={invalid}>
+				<FieldLabel
+					htmlFor={fieldId}
+					required={required}
+					secondaryLabel={secondaryLabel}
+					hideOptionalLabel={hideOptionalLabel}
+				>
+					{label}
+				</FieldLabel>
+				{hint ? <FieldHint id={hintId}>{hint}</FieldHint> : null}
+				{message && invalid ? (
+					<FieldMessage id={messageId}>{message}</FieldMessage>
+				) : null}
+				<input {...a11yProps} />
+			</FieldContainer>
+		);
+	},
 };

--- a/packages/react/src/field/Field.test.tsx
+++ b/packages/react/src/field/Field.test.tsx
@@ -113,6 +113,13 @@ describe('Field', () => {
 		expect(inputEl.id).toBe(id);
 	});
 
+	it('uses labelID prop if provided ', () => {
+		const labelId = 'label-id';
+		renderField({ label, labelId });
+		const labelEl = getLabelElement();
+		expect(labelEl.id).toBe(labelId);
+	});
+
 	describe('Field a11yProps', () => {
 		it('provides the correct a11y props', () => {
 			renderField({ label, hint });

--- a/packages/react/src/field/Field.tsx
+++ b/packages/react/src/field/Field.tsx
@@ -9,12 +9,14 @@ export type FieldProps = {
 	children: ((a11yProps: A11yProps) => ReactNode) | ReactNode;
 	/** Provides extra information about the field. */
 	hint: string | undefined;
-	/** Defines an identifier (ID) which must be unique. */
+	/** Defines an identifier (ID) of the field, which must be unique. */
 	id?: string;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	/** Describes the purpose of the field. */
 	label: string;
+	/** Defines an identifier (ID) of the label element, which must be unique. */
+	labelId?: string;
 	/** Text to prepend to the default secondary label. */
 	secondaryLabel?: string;
 	/** If true, "(optional)" will never be appended to the label even when `required` is `false`. */
@@ -31,6 +33,7 @@ export const Field = ({
 	id,
 	invalid,
 	label,
+	labelId,
 	secondaryLabel,
 	hideOptionalLabel,
 	message,
@@ -51,6 +54,7 @@ export const Field = ({
 	return (
 		<FieldContainer invalid={invalid}>
 			<FieldLabel
+				id={labelId}
 				htmlFor={fieldId}
 				secondaryLabel={secondaryLabel}
 				hideOptionalLabel={hideOptionalLabel}

--- a/packages/react/src/field/FieldLabel.tsx
+++ b/packages/react/src/field/FieldLabel.tsx
@@ -4,6 +4,8 @@ import { Text } from '../text';
 
 export type FieldLabelProps = PropsWithChildren<{
 	as?: ElementType;
+	/** Defines an identifier (ID) which must be unique. */
+	id?: string;
 	/** The ID of the form element this label relates to. */
 	htmlFor?: string;
 	/** The CSS class name, typically generated from the `css` prop. */
@@ -20,6 +22,7 @@ export const FieldLabel = ({
 	as = 'label',
 	children,
 	className,
+	id,
 	htmlFor,
 	required,
 	secondaryLabel: secondaryLabelProp,
@@ -34,7 +37,7 @@ export const FieldLabel = ({
 			.join(' ');
 	}, [required, secondaryLabelProp, hideOptionalLabel]);
 	return (
-		<Box as={as} htmlFor={htmlFor} className={className}>
+		<Box as={as} id={id} htmlFor={htmlFor} className={className}>
 			<Text as="span" fontWeight="bold">
 				{children}
 			</Text>


### PR DESCRIPTION
### Combobox

Improved accessibility by ensuring that the popover listbox element is described correctly by the field label. This is currently a bug, and it's due to the fact that we don't pass the `labelId` supplied from downshift correctly.

This bug was actually picked up by testing the component using the [IBM Equal Access Accessibility Checker](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) chrome plugin.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1396/components/combobox)

---

### Field

Added new `labelId` prop so field labels can be given IDs

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1396/components/field)

---

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.