### PR TITLE
app-layout: Close sidebar when links are pressed

### DIFF
--- a/.changeset/chilly-poets-impress.md
+++ b/.changeset/chilly-poets-impress.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Updated mobile sidebar behaviour to ensure that the mobile sidebar is closed whenever a link or button is pressed.

--- a/.changeset/shiny-years-destroy.md
+++ b/.changeset/shiny-years-destroy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+core: Added `onClick` prop to `LinkProps`

--- a/packages/react/src/app-layout/AppLayout.stories.tsx
+++ b/packages/react/src/app-layout/AppLayout.stories.tsx
@@ -1,13 +1,23 @@
-import { Fragment, useMemo, useState } from 'react';
+import {
+	Fragment,
+	useMemo,
+	useState,
+	MouseEvent,
+	useRef,
+	forwardRef,
+	AnchorHTMLAttributes,
+} from 'react';
 import { Meta, StoryObj } from '@storybook/react';
 import { Logo } from '../ag-branding';
 import { PageContent } from '../content';
-import { tokens } from '../core';
+import { CoreProvider, mergeRefs, tokens, useTernaryState } from '../core';
 import { LinkList } from '../link-list';
 import { SkipLinks } from '../skip-link';
 import { Text } from '../text';
 import { Prose } from '../prose';
 import { GlobalAlert } from '../global-alert';
+import { Modal } from '../modal';
+import { Button, ButtonGroup } from '../button';
 import {
 	navigationItems,
 	ExampleAccountDropdown,
@@ -26,10 +36,25 @@ import {
 function AppLayoutTemplate({
 	focusMode = false,
 	namesLength = 'regular',
-}: AppLayoutProps & { namesLength?: 'regular' | 'short' | 'medium' | 'long' }) {
+	businessDetails,
+}: AppLayoutProps & {
+	namesLength?: 'regular' | 'short' | 'medium' | 'long';
+	businessDetails?: {
+		businesses: string[];
+		businessName: string;
+		setBusinessName: (businessName: string) => void;
+	};
+}) {
 	const year = useMemo(() => new Date().getFullYear(), []);
-	const businesses = exampleData.businessNames[namesLength];
-	const [businessName, setBusinessName] = useState(businesses[0]);
+
+	// State for managing selected business
+	// Use values in props if passed, otherwise use internal state
+	const businesses =
+		businessDetails?.businesses ?? exampleData.businessNames[namesLength];
+	const [_businessName, _setBusinessName] = useState(businesses[0]);
+	const businessName = businessDetails?.businessName ?? _businessName;
+	const setBusinessName = businessDetails?.setBusinessName ?? _setBusinessName;
+
 	return (
 		<Fragment>
 			<SkipLinks
@@ -44,7 +69,7 @@ function AppLayoutTemplate({
 					logo={<Logo />}
 					accountDetails={{
 						name: exampleData.userNames[namesLength],
-						secondaryText: 'My account',
+						secondaryText: businessName,
 						dropdown: (
 							<ExampleAccountDropdown
 								businesses={businesses}
@@ -140,6 +165,106 @@ export const Default: StoryObj<typeof AppLayout> = {
 
 export const FocusMode: StoryObj<typeof AppLayout> = {
 	args: { focusMode: true },
+};
+
+export const FocusModeWithModal: StoryObj<typeof AppLayout> = {
+	args: { focusMode: true },
+	render: function Render(args: AppLayoutProps) {
+		const { focusMode } = args;
+		// If true, the "Are you sure you want to leave this page" modal is open
+		const [isModalOpen, openModal, closeModal] = useTernaryState(false);
+
+		// The link the user wants to go to
+		const [destinationHref, setDestinationHref] = useState<string>();
+
+		// The business the user wants to switch to
+		const [destinationBusiness, setDestinationBusiness] = useState<string>();
+
+		const businesses = exampleData.businessNames.medium;
+		const [businessName, setBusinessName] = useState(businesses[0]);
+
+		// When a user attempts to change business, open the modal
+		function onBusinessChange(businessName: string) {
+			setDestinationBusiness(businessName);
+			openModal();
+		}
+
+		// When a user confirms they want to leave the page, change the page url or change the business
+		function onModalConfirm() {
+			if (destinationHref) {
+				window.location.href = destinationHref;
+				setDestinationHref(undefined);
+			} else if (destinationBusiness) {
+				setBusinessName(destinationBusiness);
+				setDestinationBusiness(undefined);
+			}
+			closeModal();
+		}
+
+		// This is a custom link component that demonstrates how to trigger a modal when a link is pressed
+		// The modal should only be triggered in focus mode, and only for internal links
+		const appLayoutLinkComponent = useMemo(() => {
+			return forwardRef<
+				HTMLAnchorElement,
+				AnchorHTMLAttributes<HTMLAnchorElement>
+			>(function LinkComponent(linkProps, ref) {
+				const internalRef = useRef<HTMLAnchorElement>(null);
+
+				function onClick(event: MouseEvent<HTMLAnchorElement>) {
+					if (!focusMode) {
+						linkProps.onClick?.(event);
+					} else {
+						linkProps.onClick?.(event);
+						if (linkProps.target !== '_blank') {
+							event.preventDefault();
+							setDestinationHref(linkProps.href);
+							openModal();
+						}
+					}
+				}
+
+				return (
+					<a
+						ref={mergeRefs([internalRef, ref])}
+						{...linkProps}
+						onClick={onClick}
+					/>
+				);
+			});
+		}, [focusMode, openModal]);
+
+		return (
+			<Fragment>
+				<CoreProvider linkComponent={appLayoutLinkComponent}>
+					<AppLayoutTemplate
+						{...args}
+						businessDetails={{
+							businesses,
+							businessName,
+							setBusinessName: onBusinessChange,
+						}}
+					/>
+				</CoreProvider>
+				<Modal
+					isOpen={isModalOpen}
+					onDismiss={closeModal}
+					title="Are you sure you want to leave this page?"
+					actions={
+						<ButtonGroup>
+							<Button onClick={() => onModalConfirm()}>Leave this page</Button>
+							<Button variant="secondary" onClick={closeModal}>
+								Stay on this page
+							</Button>
+						</ButtonGroup>
+					}
+				>
+					<Text as="p">
+						You will lose all changes made since your last save.
+					</Text>
+				</Modal>
+			</Fragment>
+		);
+	},
 };
 
 export const WithGlobalAlert: StoryObj<typeof AppLayout> = {

--- a/packages/react/src/app-layout/AppLayout.stories.tsx
+++ b/packages/react/src/app-layout/AppLayout.stories.tsx
@@ -192,7 +192,9 @@ export const FocusModeWithModal: StoryObj<typeof AppLayout> = {
 		// When a user confirms they want to leave the page, change the page url or change the business
 		function onModalConfirm() {
 			if (destinationHref) {
-				window.location.href = destinationHref;
+				// window.location.href = destinationHref;
+				// window.location.href is correct, but we are using a window.alert so we don't navigate away from storybook
+				window.alert(`Navigate to ${destinationHref}`);
 				setDestinationHref(undefined);
 			} else if (destinationBusiness) {
 				setBusinessName(destinationBusiness);

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -1,4 +1,10 @@
-import { ComponentType, Fragment, PropsWithChildren, ReactNode } from 'react';
+import {
+	Fragment,
+	ReactNode,
+	PropsWithChildren,
+	ComponentType,
+	MouseEvent,
+} from 'react';
 import {
 	boxPalette,
 	LinkProps,
@@ -12,6 +18,7 @@ import { Flex } from '../flex';
 import { BaseButton, BaseButtonProps } from '../button';
 import { IconProps } from '../icon';
 import { Stack } from '../stack';
+import { useAppLayoutContext } from './AppLayoutContext';
 
 type NavLink = Omit<LinkProps, 'children'>;
 
@@ -72,7 +79,19 @@ function AppLayoutSidebarNavListItem({
 	item,
 }: AppLayoutSidebarNavListItemProps) {
 	const Link = useLinkComponent();
+	const { closeMobileMenu } = useAppLayoutContext();
 	const { endElement, icon: Icon, label, ...restItemProps } = item;
+
+	function onClick(event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) {
+		// Close the mobile menu when a link or button has been pressed
+		closeMobileMenu();
+		// Important: Trigger the `onClick` prop if it exists, as we've overridden this prop with this function
+		if (typeof item.onClick === 'function') {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			item.onClick(event);
+		}
+	}
 
 	// Link list item
 	if ('href' in item) {
@@ -82,7 +101,11 @@ function AppLayoutSidebarNavListItem({
 				isActive={activePath === item.href}
 				hasEndElement={Boolean(endElement)}
 			>
-				<Link aria-current={active ? 'page' : undefined} {...restItemProps}>
+				<Link
+					aria-current={active ? 'page' : undefined}
+					{...(restItemProps as NavLink)}
+					onClick={onClick}
+				>
 					{Icon ? <Icon color="inherit" /> : null}
 					<span>{label}</span>
 					{endElement}
@@ -98,7 +121,7 @@ function AppLayoutSidebarNavListItem({
 				isActive={false}
 				hasEndElement={Boolean(endElement)}
 			>
-				<BaseButton {...restItemProps}>
+				<BaseButton {...(restItemProps as NavButton)} onClick={onClick}>
 					{Icon ? <Icon color="inherit" /> : null}
 					<span>{label}</span>
 					{endElement}

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -94,7 +94,7 @@ function AppLayoutSidebarNavListItem({
 	}
 
 	// Link list item
-	if ('href' in item) {
+	if (isItemLink(item)) {
 		const active = item.href === activePath;
 		return (
 			<AppLayoutSidebarNavItemInner
@@ -103,7 +103,7 @@ function AppLayoutSidebarNavListItem({
 			>
 				<Link
 					aria-current={active ? 'page' : undefined}
-					{...(restItemProps as NavLink)}
+					{...restItemProps}
 					onClick={onClick}
 				>
 					{Icon ? <Icon color="inherit" /> : null}
@@ -115,13 +115,13 @@ function AppLayoutSidebarNavListItem({
 	}
 
 	// Button list item
-	if ('onClick' in item) {
+	if (isItemButton(item)) {
 		return (
 			<AppLayoutSidebarNavItemInner
 				isActive={false}
 				hasEndElement={Boolean(endElement)}
 			>
-				<BaseButton {...(restItemProps as NavButton)} onClick={onClick}>
+				<BaseButton {...restItemProps} onClick={onClick}>
 					{Icon ? <Icon color="inherit" /> : null}
 					<span>{label}</span>
 					{endElement}
@@ -139,6 +139,12 @@ function AppLayoutSidebarNavListItem({
 		</AppLayoutSidebarNavItemInner>
 	);
 }
+
+const isItemLink = (item: Omit<NavItem, 'label'>): item is NavLink =>
+	'href' in item;
+
+const isItemButton = (item: Omit<NavItem, 'label'>): item is NavButton =>
+	'onClick' in item;
 
 type AppLayoutSidebarNavItemInnerProps = PropsWithChildren<{
 	isActive: boolean;

--- a/packages/react/src/core/CoreProvider.tsx
+++ b/packages/react/src/core/CoreProvider.tsx
@@ -26,6 +26,8 @@ export type LinkProps = PropsWithChildren<{
 	download?: NativeLinkProps['download'];
 	/** The URL that the hyperlink points to. */
 	href?: string;
+	/** Function to be fired following a click event of the link. */
+	onClick?: NativeLinkProps['onClick'];
 	/** The ID of the hyperlink. */
 	id?: string;
 	/** How much of the referrer to send when following the link. */

--- a/packages/react/src/dropdown-menu/DropdownMenuGroupLink.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuGroupLink.tsx
@@ -1,7 +1,10 @@
 import { fontGrid, LinkProps, mapSpacing } from '../core';
 import { DropdownMenuItemLink } from './DropdownMenuItemLink';
 
-export type DropdownMenuGroupLinkProps = LinkProps;
+export type DropdownMenuGroupLinkProps = Omit<LinkProps, 'onClick'> & {
+	/** Function to be fired following a click event of the item. */
+	onClick?: () => void;
+};
 
 export function DropdownMenuGroupLink(props: DropdownMenuGroupLinkProps) {
 	return (

--- a/packages/react/src/dropdown-menu/DropdownMenuItemLink.tsx
+++ b/packages/react/src/dropdown-menu/DropdownMenuItemLink.tsx
@@ -4,7 +4,9 @@ import { LinkProps, useLinkComponent } from '../core';
 import { IconProps } from '../icon';
 import { DropdownMenuItem } from './DropdownMenuItem';
 
-export type DropdownMenuItemLinkProps = LinkProps & {
+export type DropdownMenuItemLinkProps = Omit<LinkProps, 'onClick'> & {
+	/** Function to be fired following a click event of the item. */
+	onClick?: () => void;
 	/** Used to add an icon to the start of the item. */
 	icon?: ComponentType<IconProps>;
 	/** Used to add decorative elements to the end of the item such as Indicator dot or Notification badge. */

--- a/packages/react/src/main-nav/NavList.tsx
+++ b/packages/react/src/main-nav/NavList.tsx
@@ -55,7 +55,7 @@ export function NavList({
 						type={type}
 						hasEndElement={Boolean(endElement)}
 					>
-						<BaseButton {...item}>
+						<BaseButton {...(item as NavListButton)}>
 							<span>{label}</span>
 							{endElement}
 						</BaseButton>

--- a/packages/react/src/main-nav/NavList.tsx
+++ b/packages/react/src/main-nav/NavList.tsx
@@ -32,7 +32,7 @@ export function NavList({
 	return (
 		<NavListContainer aria-label={ariaLabel} type={type}>
 			{items?.map(({ label, endElement, ...item }, index) => {
-				if ('href' in item) {
+				if (isItemLink(item)) {
 					const active = item.href === activePath;
 					return (
 						<NavListItem
@@ -55,7 +55,7 @@ export function NavList({
 						type={type}
 						hasEndElement={Boolean(endElement)}
 					>
-						<BaseButton {...(item as NavListButton)}>
+						<BaseButton {...item}>
 							<span>{label}</span>
 							{endElement}
 						</BaseButton>
@@ -65,6 +65,9 @@ export function NavList({
 		</NavListContainer>
 	);
 }
+
+const isItemLink = (item: Omit<NavListItem, 'label'>): item is NavListLink =>
+	'href' in item;
 
 type NavListContainerProps = PropsWithChildren<{
 	'aria-label': string;


### PR DESCRIPTION
core: Added `onClick` prop to `LinkProps`. The onClick prop has technically always worked, but we've never added support via Typescript which we've done here

app-layout: Updated mobile sidebar behaviour to ensure that the mobile sidebar is closed whenever a link or button is pressed.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1404/storybook/index.html?path=/story/layout-applayout--focus-mode-with-modal)

## Screenshot

Below is a screenshot of what this PR fixes.

<img width="941" alt="Screenshot 2023-09-28 at 3 54 33 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/3159d906-0bee-4918-baed-a41254d497e1">

## Checklist




**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.