### PR TITLE
table-filtering: Rename useData to useFetchData and move to own file

### DIFF
--- a/.storybook/stories/DataFiltering/ListFiltering.stories.tsx
+++ b/.storybook/stories/DataFiltering/ListFiltering.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/react';
 import { DataProvider, SortAndFilterProvider } from './lib/contexts';
 import { useSortAndFilter } from './lib/useSortAndFilter';
-import { useData } from './lib/utils';
+import { useFetchData } from './lib/useFetchData';
 import { ListFiltering } from './ListFiltering';
 
 const meta: Meta = {
@@ -18,7 +18,7 @@ export const List = {
 	render: function Render() {
 		const sortAndFilter = useSortAndFilter();
 		const { filters, pagination, sort } = sortAndFilter;
-		const data = useData({ filters, pagination, sort });
+		const data = useFetchData({ filters, pagination, sort });
 
 		return (
 			<SortAndFilterProvider value={sortAndFilter}>

--- a/.storybook/stories/DataFiltering/TableFiltering.stories.tsx
+++ b/.storybook/stories/DataFiltering/TableFiltering.stories.tsx
@@ -3,7 +3,7 @@ import { TableFilteringLarge } from './TableFilteringLarge';
 import { TableFilteringSmall } from './TableFilteringSmall';
 import { TableFilteringMedium } from './TableFilteringMedium';
 import { useSortAndFilter } from './lib/useSortAndFilter';
-import { useData } from './lib/utils';
+import { useFetchData } from './lib/useFetchData';
 import { DataProvider, SortAndFilterProvider } from './lib/contexts';
 
 const meta: Meta = {
@@ -20,7 +20,7 @@ export const FilterSmall = {
 	render: function Render() {
 		const sortAndFilter = useSortAndFilter();
 		const { filters, pagination, sort } = sortAndFilter;
-		const data = useData({ filters, pagination, sort });
+		const data = useFetchData({ filters, pagination, sort });
 		return (
 			<SortAndFilterProvider value={sortAndFilter}>
 				<DataProvider value={data}>
@@ -36,7 +36,7 @@ export const FilterMedium = {
 	render: function Render() {
 		const sortAndFilter = useSortAndFilter();
 		const { filters, pagination, sort } = sortAndFilter;
-		const data = useData({ filters, pagination, sort });
+		const data = useFetchData({ filters, pagination, sort });
 		return (
 			<SortAndFilterProvider value={sortAndFilter}>
 				<DataProvider value={data}>
@@ -52,7 +52,7 @@ export const FilterLarge = {
 	render: function Render() {
 		const sortAndFilter = useSortAndFilter();
 		const { filters, pagination, sort } = sortAndFilter;
-		const data = useData({ filters, pagination, sort });
+		const data = useFetchData({ filters, pagination, sort });
 		return (
 			<SortAndFilterProvider value={sortAndFilter}>
 				<DataProvider value={data}>

--- a/.storybook/stories/DataFiltering/components/DataTable.stories.tsx
+++ b/.storybook/stories/DataFiltering/components/DataTable.stories.tsx
@@ -1,6 +1,6 @@
 import { DataProvider, SortAndFilterContext } from '../lib/contexts';
 import { useSortAndFilter } from '../lib/useSortAndFilter';
-import { useData } from '../lib/utils';
+import { useFetchData } from '../lib/useFetchData';
 import { DataTable } from './DataTable';
 
 export default {
@@ -13,7 +13,7 @@ export const Application = () => {
 	});
 	const { filters, pagination, sort } = sortAndFilter;
 
-	const { data, totalPages, totalItems, loading } = useData({
+	const { data, totalPages, totalItems, loading } = useFetchData({
 		filters,
 		pagination,
 		sort,

--- a/.storybook/stories/DataFiltering/lib/contexts.tsx
+++ b/.storybook/stories/DataFiltering/lib/contexts.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useContext } from 'react';
 import { SortAndFilter } from './useSortAndFilter';
-import { DashboardTableData } from './utils';
+import { DashboardTableData } from './useFetchData';
 
 // Sort and filter context
 export const SortAndFilterContext = createContext<SortAndFilter | undefined>(

--- a/.storybook/stories/DataFiltering/lib/useFetchData.ts
+++ b/.storybook/stories/DataFiltering/lib/useFetchData.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { BusinessForAuditWithIndex } from './generateBusinessData';
+import { getData, GetDataParams } from './getData';
+
+export type DashboardTableData = {
+	/** Whether the data is loading */
+	loading: boolean;
+	/** The loaded data */
+	data: BusinessForAuditWithIndex[];
+	/** The total number of pages in the search */
+	totalPages: number;
+	/** The total number of items found in the search */
+	totalItems: number;
+};
+
+/** In a real app, this function would fetch data from an API. */
+export function useFetchData({
+	sort,
+	filters,
+	pagination,
+}: GetDataParams): DashboardTableData {
+	const [loading, setLoading] = useState(false);
+	const [data, setData] = useState<BusinessForAuditWithIndex[]>([]);
+	const [totalPages, setTotalPages] = useState(0);
+	const [totalItems, setTotalItems] = useState(0);
+
+	useEffect(() => {
+		setLoading(true);
+		getData({ sort, filters, pagination }).then((response) => {
+			setData(response.data);
+			setTotalPages(response.totalPages);
+			setTotalItems(response.totalItems);
+			setLoading(false);
+		});
+	}, [sort, filters, pagination]);
+
+	return { loading, data, totalPages, totalItems };
+}

--- a/.storybook/stories/DataFiltering/lib/utils.ts
+++ b/.storybook/stories/DataFiltering/lib/utils.ts
@@ -1,45 +1,4 @@
-import { useEffect, useState } from 'react';
-import {
-	getData,
-	GetDataParams,
-	GetDataPagination,
-	GetDataFilters,
-} from './getData';
-import { BusinessForAuditWithIndex } from './generateBusinessData';
-
-export type DashboardTableData = {
-	/** Whether the data is loading */
-	loading: boolean;
-	/** The loaded data */
-	data: BusinessForAuditWithIndex[];
-	/** The total number of pages in the search */
-	totalPages: number;
-	/** The total number of items found in the search */
-	totalItems: number;
-};
-
-export function useData({
-	sort,
-	filters,
-	pagination,
-}: GetDataParams): DashboardTableData {
-	const [loading, setLoading] = useState(false);
-	const [data, setData] = useState<BusinessForAuditWithIndex[]>([]);
-	const [totalPages, setTotalPages] = useState(0);
-	const [totalItems, setTotalItems] = useState(0);
-
-	useEffect(() => {
-		setLoading(true);
-		getData({ sort, filters, pagination }).then((response) => {
-			setData(response.data);
-			setTotalPages(response.totalPages);
-			setTotalItems(response.totalItems);
-			setLoading(false);
-		});
-	}, [sort, filters, pagination]);
-
-	return { loading, data, totalPages, totalItems };
-}
+import { GetDataPagination, GetDataFilters } from './getData';
 
 export const generateTableCaption = ({
 	loading,

--- a/packages/react/src/filter-sidebar/FilterSidebar.stories.tsx
+++ b/packages/react/src/filter-sidebar/FilterSidebar.stories.tsx
@@ -4,7 +4,7 @@ import {
 	SortAndFilterProvider,
 } from '../../../../.storybook/stories/DataFiltering/lib/contexts';
 import { useSortAndFilter } from '../../../../.storybook/stories/DataFiltering/lib/useSortAndFilter';
-import { useData } from '../../../../.storybook/stories/DataFiltering/lib/utils';
+import { useFetchData } from '../../../../.storybook/stories/DataFiltering/lib/useFetchData';
 import { ListFiltering } from '../../../../.storybook/stories/DataFiltering/ListFiltering';
 import { Card, CardInner, CardLink } from '../card';
 import { Column, Columns } from '../columns';
@@ -131,7 +131,7 @@ export const Layout: Story = {
 const ListFilteringExample = () => {
 	const sortAndFilter = useSortAndFilter();
 	const { filters, pagination, sort } = sortAndFilter;
-	const data = useData({ filters, pagination, sort });
+	const data = useFetchData({ filters, pagination, sort });
 
 	return (
 		<SortAndFilterProvider value={sortAndFilter}>


### PR DESCRIPTION
While working with the table filtering code to build more examples, I found the name useData confusing. So I've renamed it to `useFetchData` and moved it to it's own file, in the same folder as `useSortAndFilter`

I did this in #1405 but thought making a seperate PR would be a good way to reduce the diff