### PR TITLE
table: Fix selectable rows when using fixed table layout

### DIFF
--- a/packages/react/src/table/Table.tsx
+++ b/packages/react/src/table/Table.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren, forwardRef } from 'react';
 import { Box } from '../box';
 import { boxPalette } from '../core';
+import { TableContext } from './TableContext';
 
 export type TableProps = PropsWithChildren<{
 	/** If true, alternating rows will have a different background colour. */
@@ -30,29 +31,31 @@ export const Table = forwardRef<HTMLTableElement, TableProps>(function Table(
 	ref
 ) {
 	return (
-		<Box
-			as="table"
-			ref={ref}
-			tabIndex={tabIndex}
-			fontSize="sm"
-			focus
-			width="100%"
-			display="table"
-			id={id}
-			css={{
-				borderCollapse: 'collapse',
-				borderSpacing: 0,
-				tableLayout,
-				...(striped && {
-					"tbody tr:nth-last-of-type(odd):not([aria-selected='true'])": {
-						backgroundColor: boxPalette.backgroundShade,
-					},
-				}),
-			}}
-			aria-labelledby={ariaLabelledby}
-			aria-describedby={ariaDescribedby}
-		>
-			{children}
-		</Box>
+		<TableContext.Provider value={{ tableLayout }}>
+			<Box
+				as="table"
+				ref={ref}
+				tabIndex={tabIndex}
+				fontSize="sm"
+				focus
+				width="100%"
+				display="table"
+				id={id}
+				css={{
+					borderCollapse: 'collapse',
+					borderSpacing: 0,
+					tableLayout,
+					...(striped && {
+						"tbody tr:nth-last-of-type(odd):not([aria-selected='true'])": {
+							backgroundColor: boxPalette.backgroundShade,
+						},
+					}),
+				}}
+				aria-labelledby={ariaLabelledby}
+				aria-describedby={ariaDescribedby}
+			>
+				{children}
+			</Box>
+		</TableContext.Provider>
 	);
 });

--- a/packages/react/src/table/TableContext.tsx
+++ b/packages/react/src/table/TableContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+
+export type TableContextType = {
+	tableLayout: 'auto' | 'fixed';
+};
+
+export const TableContext = createContext<TableContextType | undefined>(
+	undefined
+);
+
+export function useTableContext() {
+	const context = useContext(TableContext);
+
+	if (typeof context === 'undefined') {
+		throw Error('TableContext not found.');
+	}
+
+	return context;
+}

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren } from 'react';
 import { boxPalette, tokens } from '../core';
+import { useTableContext } from './TableContext';
 
 export type TableRowProps = PropsWithChildren<{
 	/** Indicates the current selected state of the table row. */
@@ -7,6 +8,7 @@ export type TableRowProps = PropsWithChildren<{
 }>;
 
 export function TableRow({ children, selected }: TableRowProps) {
+	const { tableLayout } = useTableContext();
 	return (
 		<tr
 			aria-selected={selected}
@@ -36,18 +38,15 @@ export function TableRow({ children, selected }: TableRowProps) {
 						borderTopWidth: 0,
 					},
 
+					// Chrome and Firefox doesn't support :after elements in fixed table layouts
+					// FIXME Once Chrome Firefox fixes this issue, this code should be removed
+					...(tableLayout === 'fixed' ? alternativeSelectedStyles : undefined),
+
 					// Safari does not support relative positioning on `tr` elements
-					// So we're using an outline instead of the :after element to prevent the outline from being rendered incorrectly
 					// FIXME Once safari fixes this issue, this code should be removed
 					// More info https://www.reddit.com/r/css/comments/s195xg/safari_alternative_to_positionrelative_on_tr/?rdt=41288
-					'@supports (-webkit-appearance: -apple-pay-button)': {
-						outlineWidth: '2px',
-						outlineStyle: 'solid',
-						outlineColor: boxPalette.selected,
-						outlineOffset: '-3px',
-
-						'&:after': { display: 'none' },
-					},
+					'@supports (-webkit-appearance: -apple-pay-button)':
+						alternativeSelectedStyles,
 				}),
 			}}
 		>
@@ -55,3 +54,12 @@ export function TableRow({ children, selected }: TableRowProps) {
 		</tr>
 	);
 }
+
+// Use an outline instead of an :after element
+const alternativeSelectedStyles = {
+	outlineWidth: '2px',
+	outlineStyle: 'solid',
+	outlineColor: boxPalette.selected,
+	outlineOffset: '-3px',
+	'&:after': { display: 'none' },
+};

--- a/packages/react/src/table/TableRow.tsx
+++ b/packages/react/src/table/TableRow.tsx
@@ -12,43 +12,49 @@ export function TableRow({ children, selected }: TableRowProps) {
 	return (
 		<tr
 			aria-selected={selected}
-			css={{
-				...(selected && {
-					position: 'relative',
-					backgroundColor: `${boxPalette.selectedMuted}`,
+			css={
+				selected
+					? {
+							...(tableLayout === 'auto' && {
+								position: 'relative',
+								backgroundColor: boxPalette.selectedMuted,
 
-					// Add outline
-					'&:after': {
-						content: '""',
-						pointerEvents: 'none',
-						position: 'absolute',
-						inset: 0,
-						borderWidth: tokens.borderWidth.md,
-						borderColor: boxPalette.selected,
-						borderStyle: 'solid',
-					},
+								// Add outline
+								'&:after': {
+									content: '""',
+									pointerEvents: 'none',
+									position: 'absolute',
+									inset: 0,
+									borderWidth: tokens.borderWidth.md,
+									borderColor: boxPalette.selected,
+									borderStyle: 'solid',
+								},
 
-					// Remove the border top (if next table row is selected)
-					":has(+ tr[aria-selected='true']):after": {
-						borderBottomWidth: 0,
-					},
+								// Remove the border top (if next table row is selected)
+								":has(+ tr[aria-selected='true']):after": {
+									borderBottomWidth: 0,
+								},
 
-					// Remove the border top from the next table row (if next table row is selected)
-					'+ tr:after': {
-						borderTopWidth: 0,
-					},
+								// Remove the border top from the next table row (if next table row is selected)
+								'+ tr:after': {
+									borderTopWidth: 0,
+								},
+							}),
 
-					// Chrome and Firefox doesn't support :after elements in fixed table layouts
-					// FIXME Once Chrome Firefox fixes this issue, this code should be removed
-					...(tableLayout === 'fixed' ? alternativeSelectedStyles : undefined),
+							// Chrome and Firefox doesn't support :after elements in fixed table layouts
+							// FIXME Once Chrome Firefox fixes this issue, these alternative styles should be removed
+							...(tableLayout === 'fixed'
+								? alternativeSelectedStyles
+								: undefined),
 
-					// Safari does not support relative positioning on `tr` elements
-					// FIXME Once safari fixes this issue, this code should be removed
-					// More info https://www.reddit.com/r/css/comments/s195xg/safari_alternative_to_positionrelative_on_tr/?rdt=41288
-					'@supports (-webkit-appearance: -apple-pay-button)':
-						alternativeSelectedStyles,
-				}),
-			}}
+							// Safari does not support relative positioning on `tr` elements
+							// FIXME Once safari fixes this issue, these alternative styles should be removed
+							// More info https://www.reddit.com/r/css/comments/s195xg/safari_alternative_to_positionrelative_on_tr/?rdt=41288
+							'@supports (-webkit-appearance: -apple-pay-button)':
+								alternativeSelectedStyles,
+					  }
+					: undefined
+			}
 		>
 			{children}
 		</tr>
@@ -57,6 +63,7 @@ export function TableRow({ children, selected }: TableRowProps) {
 
 // Use an outline instead of an :after element
 const alternativeSelectedStyles = {
+	backgroundColor: boxPalette.selectedMuted,
 	outlineWidth: '2px',
 	outlineStyle: 'solid',
 	outlineColor: boxPalette.selected,

--- a/packages/react/src/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/Table.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
         class="css-11khhn7-boxStyles"
       >
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-10w2jzf-boxStyles-TableHeader"
@@ -50,7 +50,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
         class="css-8u32cd-boxStyles"
       >
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -75,7 +75,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -100,7 +100,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -125,7 +125,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -150,7 +150,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -175,7 +175,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -200,7 +200,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"
@@ -225,7 +225,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
           </td>
         </tr>
         <tr
-          class="css-1tx0oac-TableRow"
+          class="css-0"
         >
           <th
             class="css-eaiq6e-boxStyles-TableCell"

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TableHeaderSortable with sort direction: ASC renders correctly 1`] = `
       class="css-11khhn7-boxStyles"
     >
       <tr
-        class="css-1tx0oac-TableRow"
+        class="css-0"
       >
         <th
           aria-sort="ascending"
@@ -56,7 +56,7 @@ exports[`TableHeaderSortable with sort direction: DESC renders correctly 1`] = `
       class="css-11khhn7-boxStyles"
     >
       <tr
-        class="css-1tx0oac-TableRow"
+        class="css-0"
       >
         <th
           aria-sort="descending"
@@ -103,7 +103,7 @@ exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`
       class="css-11khhn7-boxStyles"
     >
       <tr
-        class="css-1tx0oac-TableRow"
+        class="css-0"
       >
         <th
           class="css-1qjmip9-boxStyles-TableHeaderSortable"


### PR DESCRIPTION
We have encountered an issue with our new `<TableRow />` selectable styles when using the `<Table />` component with `tableLayout="fixed"`. You can preview this bug [here](https://design-system.agriculture.gov.au/storybook/index.html?path=/story/content-table--selectable-basic&args=tableLayout:fixed).

To resolve this, I implemented an alternative selectable style logic based on the `tableLayout` prop. To achieve this, a new `TableContext` was introduced so that the `<TableRow />` component has access to the `tableLayout` prop.

No changeset is required at this time since `TableRow` hasn't been released.

[View preview of bug fixed](https://design-system.agriculture.gov.au/pr-preview/pr-1407/storybook/index.html?path=/story/content-table--selectable-basic&args=tableLayout:fixed)

## Videos

https://github.com/steelthreads/agds-next/assets/6265154/0a57b422-baab-448a-944d-4deb69d76138

https://github.com/steelthreads/agds-next/assets/6265154/a49d1d7e-c2cd-48b1-a656-157f8187488d

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
