### PR TITLE
app-layout: Fix small dark mode issue

### DIFF
--- a/.changeset/quick-papayas-collect.md
+++ b/.changeset/quick-papayas-collect.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+app-layout: Fixed small issue in `AppLayoutSidebar` where the text color wasn't being applied correctly to text list items in dark mode 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@ Provide an overview of your changes here. Include screenshots, photos or links i
 - [ ] Manually test component in various devices (phone, tablet, desktop)
 - [ ] Manually test component using a keyboard
 - [ ] Manually test component using a screen reader
+- [ ] Manually tested in dark mode
 - [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
 - [ ] Add any necessary unit tests (HTML validation, snapshots etc)
 - [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

--- a/.storybook/stories/KitchenSink.tsx
+++ b/.storybook/stories/KitchenSink.tsx
@@ -283,7 +283,7 @@ function KitchenSink({ background }: KitchenSinkProps) {
 							/>
 
 							<SectionAlert tone="warning" title="This is a Section alert">
-								This is a description.
+								<Text as="p">This is a description.</Text>
 							</SectionAlert>
 
 							<Accordion>

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -130,10 +130,7 @@ function AppLayoutSidebarNavItemInner({
 	return (
 		<li
 			css={{
-				'> a': {
-					textDecoration: 'none',
-				},
-
+				// Styles shared between all list items (links, buttons and text)
 				'> a, > button, > span': {
 					width: '100%',
 					boxSizing: 'border-box',
@@ -148,17 +145,18 @@ function AppLayoutSidebarNavItemInner({
 					},
 				},
 
+				// Styles shared between interactive list items (links and buttons)
 				'> a, > button': {
 					position: 'relative',
 					display: 'flex',
 					alignItems: 'center',
 					gap: mapSpacing(0.75),
-					color: boxPalette[isActive ? 'foregroundText' : 'foregroundAction'],
-
+					color: isActive
+						? boxPalette.foregroundText
+						: boxPalette.foregroundAction,
 					...(isActive && {
 						fontWeight: tokens.fontWeight.bold,
 						background: boxPalette.backgroundShadeAlt,
-						color: boxPalette.foregroundText,
 						'&:before': {
 							content: "''",
 							position: 'absolute',
@@ -184,6 +182,16 @@ function AppLayoutSidebarNavItemInner({
 					},
 
 					...focusStyles,
+				},
+
+				// Styles specific to text list items
+				'> span': {
+					color: boxPalette.foregroundText,
+				},
+
+				// Styles specific to link list items
+				'> a': {
+					textDecoration: 'none',
 				},
 			}}
 		>

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -151,9 +151,7 @@ function AppLayoutSidebarNavItemInner({
 					display: 'flex',
 					alignItems: 'center',
 					gap: mapSpacing(0.75),
-					color: isActive
-						? boxPalette.foregroundText
-						: boxPalette.foregroundAction,
+					color: boxPalette[isActive ? 'foregroundText' : 'foregroundAction'],
 					...(isActive && {
 						fontWeight: tokens.fontWeight.bold,
 						background: boxPalette.backgroundShadeAlt,

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -226,7 +226,7 @@ exports[`AppLayout renders correctly 1`] = `
           class="css-o80hmi-boxStyles"
         >
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account"
@@ -263,7 +263,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <span
               class="css-1i7cdx8-boxStyles"
@@ -289,7 +289,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/"
@@ -318,7 +318,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-nfe4e4-AppLayoutSidebarNavItemInner"
+            class="css-qmt8p8-AppLayoutSidebarNavItemInner"
           >
             <a
               aria-current="page"
@@ -345,7 +345,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/intelligence"
@@ -371,7 +371,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/compliance"
@@ -410,7 +410,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-13mhly7-AppLayoutSidebarNavItemInner"
+            class="css-16x72y7-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account/messages"
@@ -449,7 +449,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/account/settings"
@@ -480,7 +480,7 @@ exports[`AppLayout renders correctly 1`] = `
             </a>
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
               href="/help"
@@ -514,7 +514,7 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-1qdaebs-AppLayoutSidebarNavItemInner"
+            class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <button
               class="css-6e6ykx-BaseButton"


### PR DESCRIPTION
app-layout: Fixed small issue in `AppLayoutSidebar` where the text color wasn't being applied correctly to text list items in dark mode 

<img width="1287" alt="Screenshot 2023-10-03 at 12 31 50 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/29b0ab89-800a-414a-ade5-b589dc4c47f3">

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1408/storybook/index.html?path=/story/testing-kitchen-sink--application-layout&globals=palette:dark)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.