### PR TITLE
app-layout: Fixed incorrect padding between sidebar navigation groups

### DIFF
--- a/.changeset/plenty-shrimps-smell.md
+++ b/.changeset/plenty-shrimps-smell.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+app-layout: Fixed incorrect padding between sidebar navigation groups

--- a/.changeset/plenty-shrimps-smell.md
+++ b/.changeset/plenty-shrimps-smell.md
@@ -2,4 +2,23 @@
 '@ag.ds-next/react': minor
 ---
 
-app-layout: Fixed incorrect padding between sidebar navigation groups
+app-layout: Extended the `items` prop in `AppLayoutSidebar` to accept an object with `options` and `items`. This allows consumers to control the padding between sidebar navigation groups.
+
+```tsx
+<AppLayoutSidebar
+	activePath="/"
+	items={[
+    // pass an object with `options` and `items`
+		{
+			options: { disableGroupPadding: true },
+			items: [{ label: 'Item A' }],
+		},
+    // pass an array of items 
+		[
+			{ label: 'Item B', href: '/b' },
+			{ label: 'Item C', href: '/c' },
+			{ label: 'Item D', href: '/c' },
+		],
+	]}
+/>
+```

--- a/packages/react/src/app-layout/AppLayoutSidebar.stories.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.stories.tsx
@@ -40,7 +40,8 @@ export const WithoutIcons: Story = {
 	args: {
 		activePath: '/establishments',
 		items: navigationItems('Antfix').map((group) => {
-			return group.map((item) => {
+			const groupItems = Array.isArray(group) ? group : group.items;
+			return groupItems.map((item) => {
 				return { ...item, icon: undefined };
 			});
 		}),

--- a/packages/react/src/app-layout/AppLayoutSidebar.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.tsx
@@ -13,7 +13,10 @@ export type AppLayoutSidebarProps = {
 	/** Used for highlighting the active element. */
 	activePath?: string;
 	/** Groups of navigation items to display. */
-	items: NavItem[][];
+	items: (
+		| NavItem[]
+		| { items: NavItem[]; options?: { disableGroupPadding: boolean } }
+	)[];
 };
 
 export function AppLayoutSidebar({ activePath, items }: AppLayoutSidebarProps) {

--- a/packages/react/src/app-layout/AppLayoutSidebar.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebar.tsx
@@ -21,7 +21,10 @@ export type AppLayoutSidebarProps = {
 
 export function AppLayoutSidebar({ activePath, items }: AppLayoutSidebarProps) {
 	const { focusMode } = useAppLayoutContext();
-	const bestMatch = findBestMatch(items.flat(), activePath);
+	const bestMatch = findBestMatch(
+		items.map((group) => (Array.isArray(group) ? group : group.items)).flat(),
+		activePath
+	);
 	return (
 		<Fragment>
 			{/* Desktop */}

--- a/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
+++ b/packages/react/src/app-layout/AppLayoutSidebarNav.tsx
@@ -25,7 +25,10 @@ export type NavItem = (NavLink | NavButton) & {
 
 export type AppLayoutSidebarNavProps = {
 	activePath?: string;
-	items: NavItem[][];
+	items: (
+		| NavItem[]
+		| { items: NavItem[]; options?: { disableGroupPadding: boolean } }
+	)[];
 	className?: string;
 };
 
@@ -36,24 +39,37 @@ export function AppLayoutSidebarNav({
 	return (
 		<Flex as="nav" flexDirection="column" aria-label="main" paddingBottom={1.5}>
 			<Flex as="ul" flexDirection="column">
-				{items.map((group, idx, arr) => {
-					const groupHasSingleItem = group.length === 1;
-					const nextGroupHasSingleItem = items[idx + 1]?.length === 1;
-					const isLastItem = idx === arr.length - 1;
+				{items.map((group, idx) => {
+					const isFirstItem = idx === 0;
+					const groupItems = Array.isArray(group) ? group : group.items;
+
+					const disableGroupPadding = Array.isArray(group)
+						? false
+						: Boolean(group.options?.disableGroupPadding);
+
+					const prevGroup = items[idx - 1];
+					const prevGroupDisableGroupPadding = prevGroup
+						? Array.isArray(prevGroup)
+							? false
+							: Boolean(prevGroup.options?.disableGroupPadding)
+						: false;
+
 					return (
 						<Fragment key={idx}>
-							{group.map((item, idx) => (
+							{!isFirstItem ? (
+								<AppLayoutSidebarNavDivider
+									// As the divider is placed at the start of each group, padding top is determined by the previous group
+									disablePaddingTop={prevGroupDisableGroupPadding}
+									disablePaddingBottom={disableGroupPadding}
+								/>
+							) : null}
+							{groupItems.map((item, idx) => (
 								<AppLayoutSidebarNavListItem
 									key={idx}
 									item={item}
 									activePath={activePath}
 								/>
 							))}
-							{!isLastItem ? (
-								<AppLayoutSidebarNavDivider
-									disablePaddingY={groupHasSingleItem || nextGroupHasSingleItem}
-								/>
-							) : null}
 						</Fragment>
 					);
 				})}
@@ -150,6 +166,7 @@ function AppLayoutSidebarNavItemInner({
 					position: 'relative',
 					display: 'flex',
 					alignItems: 'center',
+
 					gap: mapSpacing(0.75),
 					color: boxPalette[isActive ? 'foregroundText' : 'foregroundAction'],
 					...(isActive && {
@@ -199,12 +216,19 @@ function AppLayoutSidebarNavItemInner({
 }
 
 function AppLayoutSidebarNavDivider({
-	disablePaddingY,
+	disablePaddingTop,
+	disablePaddingBottom,
 }: {
-	disablePaddingY: boolean;
+	disablePaddingTop: boolean;
+	disablePaddingBottom: boolean;
 }) {
 	return (
-		<Box as="li" paddingY={disablePaddingY ? 0 : 1} aria-hidden="true">
+		<Box
+			as="li"
+			paddingTop={disablePaddingTop ? 0 : 1}
+			paddingBottom={disablePaddingBottom ? 0 : 1}
+			aria-hidden="true"
+		>
 			<hr
 				css={{
 					boxSizing: 'content-box',

--- a/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
+++ b/packages/react/src/app-layout/__snapshots__/AppLayout.test.tsx.snap
@@ -282,7 +282,7 @@ exports[`AppLayout renders correctly 1`] = `
           </li>
           <li
             aria-hidden="true"
-            class="css-1dz6j0b-boxStyles"
+            class="css-wizjf8-boxStyles"
           >
             <hr
               class="css-166wurb-AppLayoutSidebarNavDivider"
@@ -410,76 +410,6 @@ exports[`AppLayout renders correctly 1`] = `
             />
           </li>
           <li
-            class="css-16x72y7-AppLayoutSidebarNavItemInner"
-          >
-            <a
-              href="/account/messages"
-            >
-              <svg
-                aria-hidden="true"
-                class="css-qhpjst-Icon"
-                clip-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M22 6C22 4.9 21.1 4 20 4H4C2.9 4 2 4.9 2 6M22 6V18C22 19.1 21.1 20 20 20H4C2.9 20 2 19.1 2 18V6M22 6L12 13L2 6"
-                />
-              </svg>
-              <span>
-                Messages
-              </span>
-              <span>
-                <span
-                  aria-hidden="true"
-                  class="css-uouzcn-boxStyles-Text-NotificationBadge"
-                >
-                  6
-                </span>
-                <span
-                  class="css-avudkd-VisuallyHidden"
-                >
-                  , 6 unread
-                </span>
-              </span>
-            </a>
-          </li>
-          <li
-            class="css-11lpl70-AppLayoutSidebarNavItemInner"
-          >
-            <a
-              href="/account/settings"
-            >
-              <svg
-                aria-hidden="true"
-                class="css-qhpjst-Icon"
-                clip-rule="evenodd"
-                focusable="false"
-                height="24"
-                role="img"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r="3"
-                />
-                <path
-                  d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"
-                />
-              </svg>
-              <span>
-                Account settings
-              </span>
-            </a>
-          </li>
-          <li
             class="css-11lpl70-AppLayoutSidebarNavItemInner"
           >
             <a
@@ -507,7 +437,7 @@ exports[`AppLayout renders correctly 1`] = `
           </li>
           <li
             aria-hidden="true"
-            class="css-1dz6j0b-boxStyles"
+            class="css-boytaj-boxStyles"
           >
             <hr
               class="css-166wurb-AppLayoutSidebarNavDivider"

--- a/packages/react/src/app-layout/test-utils.tsx
+++ b/packages/react/src/app-layout/test-utils.tsx
@@ -25,27 +25,33 @@ import {
 } from '../dropdown-menu';
 
 export const navigationItems = (businessName: string) => [
-	[
-		{
-			label: 'Back to my account',
-			icon: ChevronsLeftIcon,
-			href: '/account',
-		},
-	],
-	[
-		{
-			label: (
-				<Fragment>
-					<Text fontWeight="bold" fontSize="xs">
-						{businessName}
-					</Text>
-					<Text color="muted" fontSize="xs">
-						ABN: 00 000 000 000
-					</Text>
-				</Fragment>
-			),
-		},
-	],
+	{
+		options: { disableGroupPadding: true },
+		items: [
+			{
+				label: 'Back to my account',
+				icon: ChevronsLeftIcon,
+				href: '/account',
+			},
+		],
+	},
+	{
+		options: { disableGroupPadding: true },
+		items: [
+			{
+				label: (
+					<Fragment>
+						<Text fontWeight="bold" fontSize="xs">
+							{businessName}
+						</Text>
+						<Text color="muted" fontSize="xs">
+							ABN: 00 000 000 000
+						</Text>
+					</Fragment>
+				),
+			},
+		],
+	},
 	[
 		{
 			label: 'Dashboard',
@@ -68,23 +74,8 @@ export const navigationItems = (businessName: string) => [
 			href: '/compliance',
 		},
 	],
+
 	[
-		{
-			label: 'Messages',
-			icon: EmailIcon,
-			href: '/account/messages',
-			endElement: (
-				<span>
-					<NotificationBadge tone="action" value={6} max={99} aria-hidden />
-					<VisuallyHidden>, 6 unread</VisuallyHidden>
-				</span>
-			),
-		},
-		{
-			label: 'Account settings',
-			icon: SettingsIcon,
-			href: '/account/settings',
-		},
 		{
 			label: 'Help',
 			icon: HelpIcon,


### PR DESCRIPTION
Extended the `items` prop in `AppLayoutSidebar` to accept an object with `options` and `items`. This allows consumers to control the padding between sidebar navigation groups.

```tsx
<AppLayoutSidebar
  activePath="/"
  items={[
    // pass an object with `options` and `items`
    {
      options: { disableGroupPadding: true },
      items: [{ label: 'Item A' }],
    },
    // or pass an array of items (current syntax)
    [
      { label: 'Item B', href: '/b' },
      { label: 'Item C', href: '/c' },
      { label: 'Item D', href: '/c' },
    ],
  ]}
/>
```

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1410/components/app-layout)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
- [x] Add pictogram to Docs (`docs/components/pictograms/index.tsx`)
