### PR TITLE
file-upload: export `formatFileSize` util function

### DIFF
--- a/.changeset/tall-zebras-watch.md
+++ b/.changeset/tall-zebras-watch.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+file-upload: Export `formatFileSize` util

--- a/.changeset/tall-zebras-watch.md
+++ b/.changeset/tall-zebras-watch.md
@@ -2,4 +2,8 @@
 '@ag.ds-next/react': patch
 ---
 
-file-upload: Export `formatFileSize` util
+file-upload: Exported `formatFileSize` utility function. Example usage:
+
+```tsx
+import { formatFileSize } from '@ag.ds-next/react/file-upload';
+```

--- a/packages/react/src/file-upload/index.ts
+++ b/packages/react/src/file-upload/index.ts
@@ -3,4 +3,5 @@ export type {
 	AcceptedFileMimeTypes,
 	FileWithStatus,
 	RejectedFile,
+	formatFileSize,
 } from './utils';


### PR DESCRIPTION
file-upload: Exported `formatFileSize` utility function. Example usage:

```tsx
import { formatFileSize } from '@ag.ds-next/react/file-upload';
```

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
