### PR TITLE
file-upload: Show previously uploaded files

### DIFF
--- a/.changeset/pretty-plants-explain.md
+++ b/.changeset/pretty-plants-explain.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-file-upload: Export formatFileSize utility
+file-upload: Export `formatFileSize` utility

--- a/.changeset/pretty-terms-tan.md
+++ b/.changeset/pretty-terms-tan.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-file-upload: Add support for showing previously uploaded files with the new `existingFiles` prop.
+file-upload: Added support for showing previously uploaded files with the new `existingFiles` and `onRemoveExistingFile` props.

--- a/.changeset/pretty-terms-tan.md
+++ b/.changeset/pretty-terms-tan.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+file-upload: Add support for showing previously uploaded files with the new `existingFiles` prop.

--- a/packages/react/src/file-upload/FileUpload.stories.tsx
+++ b/packages/react/src/file-upload/FileUpload.stories.tsx
@@ -251,7 +251,11 @@ export const ExistingFiles: Story = {
 	args: {
 		label: 'Upload evidence',
 		hint: 'General hint information',
-		existingFiles: [
+	},
+	render: function Render(args) {
+		const [value, setValue] = useState<FileWithStatus[]>([]);
+
+		const [existingFiles, setExistingFiles] = useState<ExistingFile[]>([
 			{
 				name: 'police-check.pdf',
 				size: 100000,
@@ -259,15 +263,11 @@ export const ExistingFiles: Story = {
 			{
 				name: 'another-document.pdf',
 				size: 100000,
+				// Use the `meta` key to keep track of any extra file information
+				// This can be useful when deleting the file
+				meta: { uid: 'abc-def', bucketId: '123-456' },
 			},
-		],
-	},
-	render: function Render(args) {
-		const [value, setValue] = useState<FileWithStatus[]>([]);
-
-		const [existingFiles, setExistingFiles] = useState(
-			args.existingFiles || []
-		);
+		]);
 
 		function onRemoveExistingFile(fileToRemove: ExistingFile) {
 			setExistingFiles((existingFiles) =>

--- a/packages/react/src/file-upload/FileUpload.stories.tsx
+++ b/packages/react/src/file-upload/FileUpload.stories.tsx
@@ -246,3 +246,16 @@ const UploadSingleFileOnSubmitTemplate = (args: FileUploadProps) => {
 		</form>
 	);
 };
+
+export const ExistingFiles: Story = {
+	args: {
+		label: 'Documents',
+		existingFiles: [
+			{
+				name: 'police-check.pdf',
+				size: 100000,
+				onDelete: () => console.log('Delete file'),
+			},
+		],
+	},
+};

--- a/packages/react/src/file-upload/FileUpload.stories.tsx
+++ b/packages/react/src/file-upload/FileUpload.stories.tsx
@@ -12,7 +12,7 @@ import { FormStack } from '../form-stack';
 import { Button } from '../button';
 import { LoadingBlanket } from '../loading';
 import { FileUpload, FileUploadProps } from './FileUpload';
-import { FileWithStatus } from './utils';
+import { ExistingFile, FileWithStatus } from './utils';
 import { createExampleFile, createExampleImageFile } from './test-utils';
 
 const meta: Meta<typeof FileUpload> = {
@@ -249,13 +249,40 @@ const UploadSingleFileOnSubmitTemplate = (args: FileUploadProps) => {
 
 export const ExistingFiles: Story = {
 	args: {
-		label: 'Documents',
+		label: 'Upload evidence',
+		hint: 'General hint information',
 		existingFiles: [
 			{
 				name: 'police-check.pdf',
 				size: 100000,
-				onDelete: () => console.log('Delete file'),
+			},
+			{
+				name: 'another-document.pdf',
+				size: 100000,
 			},
 		],
+	},
+	render: function Render(args) {
+		const [value, setValue] = useState<FileWithStatus[]>([]);
+
+		const [existingFiles, setExistingFiles] = useState(
+			args.existingFiles || []
+		);
+
+		function onRemoveExistingFile(fileToRemove: ExistingFile) {
+			setExistingFiles((existingFiles) =>
+				existingFiles.filter(({ name }) => name !== fileToRemove.name)
+			);
+		}
+
+		return (
+			<FileUpload
+				{...args}
+				value={value}
+				onChange={setValue}
+				existingFiles={existingFiles}
+				onRemoveExistingFile={onRemoveExistingFile}
+			/>
+		);
 	},
 };

--- a/packages/react/src/file-upload/FileUpload.test.tsx
+++ b/packages/react/src/file-upload/FileUpload.test.tsx
@@ -4,6 +4,7 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import { useState } from 'react';
 import { cleanup, render } from '../../../../test-utils';
 import { FileWithStatus } from './utils';
+import { createExampleFile } from './test-utils';
 import { FileUpload, FileUploadProps } from './FileUpload';
 
 expect.extend(toHaveNoViolations);
@@ -11,11 +12,7 @@ expect.extend(toHaveNoViolations);
 afterEach(cleanup);
 
 function FileUploadExample(props?: Partial<FileUploadProps>) {
-	const [value, setValue] = useState<FileWithStatus[]>([
-		new File(['this is an example file'], 'example.jpg', {
-			type: 'image/jpeg',
-		}),
-	]);
+	const [value, setValue] = useState<FileWithStatus[]>([createExampleFile()]);
 	return (
 		<FileUpload
 			label="Upload file"

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -68,7 +68,9 @@ export type FileUploadProps = BaseInputProps & {
 	multiple?: boolean;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
+	/** Used to display a list of files that have already been uploaded. */
 	existingFiles?: ExistingFile[];
+	/** Callback function called when an existing file is removed. */
 	onRemoveExistingFile?: (file: ExistingFile) => void;
 };
 

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -23,9 +23,9 @@ import {
 	FileWithStatus,
 	formatFileSize,
 	getAcceptedFilesSummary,
+	getFileListSummaryText,
 	getErrorSummary,
 	getFileRejectionErrorMessage,
-	getFilesTotal,
 	RejectedFile,
 } from './utils';
 import { FileUploadFileList } from './FileUploadFileList';
@@ -69,6 +69,7 @@ export type FileUploadProps = BaseInputProps & {
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
 	existingFiles?: ExistingFile[];
+	onRemoveExistingFile?: (file: ExistingFile) => void;
 };
 
 export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
@@ -90,6 +91,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			invalid,
 			id,
 			existingFiles,
+			onRemoveExistingFile,
 			...consumerProps
 		},
 		forwardedRef
@@ -199,9 +201,14 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			...dropzoneInputProps
 		} = getInputProps();
 
-		const showFileLists =
-			value.length || fileRejections.length || existingFiles?.length;
-		const fileSummaryText = getFilesTotal([...value, ...(existingFiles || [])]);
+		const showFileLists = Boolean(
+			value.length || fileRejections.length || existingFiles?.length
+		);
+
+		const fileSummaryText = getFileListSummaryText([
+			...value,
+			...(existingFiles || []),
+		]);
 
 		return (
 			<Field
@@ -278,6 +285,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 									<Text color="muted">{fileSummaryText}</Text>
 									<FileUploadExistingFileList
 										files={existingFiles}
+										onRemove={onRemoveExistingFile}
 										hideThumbnails={hideThumbnails}
 									/>
 									<FileUploadFileList

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -199,6 +199,8 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			...dropzoneInputProps
 		} = getInputProps();
 
+		const fileSummaryText = getFilesTotal([...value, ...(existingFiles || [])]);
+
 		return (
 			<Field
 				label={label}
@@ -269,29 +271,25 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 									Select {filesPlural}
 								</Button>
 							</Flex>
-							{value.length || fileRejections.length ? (
+							{value.length ||
+							fileRejections.length ||
+							existingFiles?.length ? (
 								<Stack gap={0.5}>
-									<Text color="muted">{getFilesTotal(value)}</Text>
-									{existingFiles?.length ? (
-										<FileUploadExistingFileList
-											files={existingFiles}
-											hideThumbnails={hideThumbnails}
-										/>
-									) : null}
-									{value.length ? (
-										<FileUploadFileList
-											files={value}
-											onRemove={handleRemoveFile}
-											hideThumbnails={hideThumbnails}
-										/>
-									) : null}
-									{fileRejections.length ? (
-										<FileUploadRejectedFileList
-											fileRejections={fileRejections}
-											handleRemoveRejection={handleRemoveRejection}
-											hideThumbnails={hideThumbnails}
-										/>
-									) : null}
+									<Text color="muted">{fileSummaryText}</Text>
+									<FileUploadExistingFileList
+										files={existingFiles}
+										hideThumbnails={hideThumbnails}
+									/>
+									<FileUploadFileList
+										files={value}
+										onRemove={handleRemoveFile}
+										hideThumbnails={hideThumbnails}
+									/>
+									<FileUploadRejectedFileList
+										fileRejections={fileRejections}
+										handleRemoveRejection={handleRemoveRejection}
+										hideThumbnails={hideThumbnails}
+									/>
 								</Stack>
 							) : null}
 						</Stack>

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -18,6 +18,7 @@ import { FileUploadRejectedFileList } from './FileUploadRejectedFileList';
 import {
 	AcceptedFileMimeTypes,
 	CustomFileMimeType,
+	ExistingFile,
 	fileTypeMapping,
 	FileWithStatus,
 	formatFileSize,
@@ -28,6 +29,7 @@ import {
 	RejectedFile,
 } from './utils';
 import { FileUploadFileList } from './FileUploadFileList';
+import { FileUploadExistingFileList } from './FileUploadExistingFileList';
 
 type NativeInputProps = InputHTMLAttributes<HTMLInputElement>;
 
@@ -66,6 +68,7 @@ export type FileUploadProps = BaseInputProps & {
 	multiple?: boolean;
 	/** If true, the invalid state will be rendered. */
 	invalid?: boolean;
+	existingFiles?: ExistingFile[];
 };
 
 export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
@@ -86,6 +89,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			message,
 			invalid,
 			id,
+			existingFiles,
 			...consumerProps
 		},
 		forwardedRef
@@ -268,6 +272,12 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 							{value.length || fileRejections.length ? (
 								<Stack gap={0.5}>
 									<Text color="muted">{getFilesTotal(value)}</Text>
+									{existingFiles?.length ? (
+										<FileUploadExistingFileList
+											files={existingFiles}
+											hideThumbnails={hideThumbnails}
+										/>
+									) : null}
 									{value.length ? (
 										<FileUploadFileList
 											files={value}

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -199,6 +199,8 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 			...dropzoneInputProps
 		} = getInputProps();
 
+		const showFileLists =
+			value.length || fileRejections.length || existingFiles?.length;
 		const fileSummaryText = getFilesTotal([...value, ...(existingFiles || [])]);
 
 		return (
@@ -271,9 +273,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 									Select {filesPlural}
 								</Button>
 							</Flex>
-							{value.length ||
-							fileRejections.length ||
-							existingFiles?.length ? (
+							{showFileLists && (
 								<Stack gap={0.5}>
 									<Text color="muted">{fileSummaryText}</Text>
 									<FileUploadExistingFileList
@@ -291,7 +291,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 										hideThumbnails={hideThumbnails}
 									/>
 								</Stack>
-							) : null}
+							)}
 						</Stack>
 					);
 				}}

--- a/packages/react/src/file-upload/FileUploadExistingFile.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.stories.tsx
@@ -1,0 +1,50 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { FileUploadExistingFile } from './FileUploadExistingFile';
+
+const meta: Meta = {
+	title: 'forms/FileUpload/Primitives/FileUploadExistingFile',
+	component: FileUploadExistingFile,
+	args: {
+		hideThumbnails: false,
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FileUploadExistingFile>;
+
+export const Basic: Story = {
+	name: '.txt file',
+	args: {
+		file: {
+			name: 'example.pdf',
+			size: 123456,
+			onDelete: () => console.log('Delete'),
+		},
+	},
+};
+
+export const Image: Story = {
+	name: '.jpg file',
+	args: {
+		file: {
+			name: 'example.jpg',
+			thumbnailSrc: 'https://via.placeholder.com/150',
+			size: 123456,
+			onDelete: () => console.log('Delete'),
+		},
+	},
+};
+
+export const WithHref: Story = {
+	name: 'with href',
+	args: {
+		file: {
+			name: 'example.jpg',
+			href: '#',
+			thumbnailSrc: 'https://via.placeholder.com/150',
+			size: 123456,
+			onDelete: () => console.log('Delete'),
+		},
+	},
+};

--- a/packages/react/src/file-upload/FileUploadExistingFile.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.stories.tsx
@@ -14,12 +14,11 @@ export default meta;
 type Story = StoryObj<typeof FileUploadExistingFile>;
 
 export const Basic: Story = {
-	name: '.txt file',
+	name: '.png file',
 	args: {
 		file: {
-			name: 'example.pdf',
+			name: 'example.png',
 			size: 123456,
-			onDelete: () => console.log('Delete'),
 		},
 	},
 };
@@ -29,9 +28,18 @@ export const Image: Story = {
 	args: {
 		file: {
 			name: 'example.jpg',
+			size: 123456,
+		},
+	},
+};
+
+export const WithThumbnail: Story = {
+	name: '.jpg file',
+	args: {
+		file: {
+			name: 'example.jpg',
 			thumbnailSrc: 'https://via.placeholder.com/150',
 			size: 123456,
-			onDelete: () => console.log('Delete'),
 		},
 	},
 };
@@ -44,7 +52,6 @@ export const WithHref: Story = {
 			href: '#',
 			thumbnailSrc: 'https://via.placeholder.com/150',
 			size: 123456,
-			onDelete: () => console.log('Delete'),
 		},
 	},
 };

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -3,6 +3,7 @@ import { Flex } from '../flex';
 import { Text } from '../text';
 import { Button } from '../button';
 import { SuccessFilledIcon } from '../icon';
+import { TextLink } from '../text-link';
 import { FileUploadFileThumbnail } from './FileUploadFileThumbnail';
 import { ExistingFile, formatFileSize } from './utils';
 
@@ -15,7 +16,7 @@ export const FileUploadExistingFile = ({
 	file,
 	hideThumbnails,
 }: FileUploadExistingFileProps) => {
-	const { name, size, thumbnailSrc, onDelete } = file;
+	const { name, size, href, thumbnailSrc, onDelete } = file;
 	const showThumbnail = !hideThumbnails;
 	return (
 		<Flex
@@ -38,9 +39,22 @@ export const FileUploadExistingFile = ({
 							css={{ display: 'block' }}
 						/>
 					</Box>
-					<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
-						{name} ({formatFileSize(size)})
-					</Text>
+					{href ? (
+						<Text paddingY={1.5}>
+							<TextLink
+								href={href}
+								target="_blank"
+								rel="noopener noreferrer"
+								css={{ wordBreak: 'break-all' }}
+							>
+								{name} ({formatFileSize(size)})
+							</TextLink>
+						</Text>
+					) : (
+						<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
+							{name} ({formatFileSize(size)})
+						</Text>
+					)}
 				</Flex>
 			</Flex>
 			<Flex flexShrink={0} alignItems="center" paddingRight={1}>

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -48,7 +48,7 @@ export const FileUploadExistingFile = ({
 					<Button
 						variant="text"
 						onClick={onDelete}
-						aria-label={`Delete file, ${name}`}
+						aria-label={`Remove file, ${name}`}
 					>
 						Remove file
 					</Button>

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -1,3 +1,4 @@
+import { MouseEventHandler } from 'react';
 import { Box } from '../box';
 import { Flex } from '../flex';
 import { Text } from '../text';
@@ -9,14 +10,16 @@ import { ExistingFile, formatFileSize } from './utils';
 
 type FileUploadExistingFileProps = {
 	file: ExistingFile;
+	onRemove: MouseEventHandler<HTMLButtonElement>;
 	hideThumbnails?: boolean;
 };
 
 export const FileUploadExistingFile = ({
 	file,
+	onRemove,
 	hideThumbnails,
 }: FileUploadExistingFileProps) => {
-	const { name, size, href, thumbnailSrc, onDelete } = file;
+	const { name, size, href, thumbnailSrc } = file;
 	const showThumbnail = !hideThumbnails;
 	return (
 		<Flex
@@ -47,12 +50,14 @@ export const FileUploadExistingFile = ({
 								rel="noopener noreferrer"
 								css={{ wordBreak: 'break-all' }}
 							>
-								{name} ({formatFileSize(size)})
+								{name}
+								{size ? ` (${formatFileSize(size)})` : null}
 							</TextLink>
 						</Text>
 					) : (
 						<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
-							{name} ({formatFileSize(size)})
+							{name}
+							{size ? ` (${formatFileSize(size)})` : null}
 						</Text>
 					)}
 				</Flex>
@@ -61,7 +66,7 @@ export const FileUploadExistingFile = ({
 				<Box>
 					<Button
 						variant="text"
-						onClick={onDelete}
+						onClick={onRemove}
 						aria-label={`Remove file, ${name}`}
 					>
 						Remove file

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -2,6 +2,7 @@ import { Box } from '../box';
 import { Flex } from '../flex';
 import { Text } from '../text';
 import { Button } from '../button';
+import { SuccessFilledIcon } from '../icon';
 import { FileUploadFileThumbnail } from './FileUploadFileThumbnail';
 import { ExistingFile, formatFileSize } from './utils';
 
@@ -28,6 +29,15 @@ export const FileUploadExistingFile = ({
 			<Flex>
 				{showThumbnail && <FileUploadFileThumbnail src={thumbnailSrc} />}
 				<Flex alignItems="center" paddingLeft={1} gap={0.5}>
+					<Box flexShrink={0}>
+						<SuccessFilledIcon
+							color="success"
+							size="md"
+							aria-hidden="false"
+							aria-label="Success"
+							css={{ display: 'block' }}
+						/>
+					</Box>
 					<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
 						{name} ({formatFileSize(size)})
 					</Text>
@@ -40,7 +50,7 @@ export const FileUploadExistingFile = ({
 						onClick={onDelete}
 						aria-label={`Delete file, ${name}`}
 					>
-						Delete file
+						Remove file
 					</Button>
 				</Box>
 			</Flex>

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -1,0 +1,49 @@
+import { Box } from '../box';
+import { Flex } from '../flex';
+import { Text } from '../text';
+import { Button } from '../button';
+import { FileUploadFileThumbnail } from './FileUploadFileThumbnail';
+import { ExistingFile, formatFileSize } from './utils';
+
+type FileUploadExistingFileProps = {
+	file: ExistingFile;
+	hideThumbnails?: boolean;
+};
+
+export const FileUploadExistingFile = ({
+	file,
+	hideThumbnails,
+}: FileUploadExistingFileProps) => {
+	const { name, size, thumbnailSrc, onDelete } = file;
+	const showThumbnail = !hideThumbnails;
+	return (
+		<Flex
+			rounded
+			as="li"
+			aria-label={`Uploaded file. ${name}`}
+			gap={0.5}
+			justifyContent="space-between"
+			background="success"
+		>
+			<Flex>
+				{showThumbnail && <FileUploadFileThumbnail src={thumbnailSrc} />}
+				<Flex alignItems="center" paddingLeft={1} gap={0.5}>
+					<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
+						{name} ({formatFileSize(size)})
+					</Text>
+				</Flex>
+			</Flex>
+			<Flex flexShrink={0} alignItems="center" paddingRight={1}>
+				<Box>
+					<Button
+						variant="text"
+						onClick={onDelete}
+						aria-label={`Delete file, ${name}`}
+					>
+						Delete file
+					</Button>
+				</Box>
+			</Flex>
+		</Flex>
+	);
+};

--- a/packages/react/src/file-upload/FileUploadExistingFile.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFile.tsx
@@ -57,7 +57,12 @@ export const FileUploadExistingFile = ({
 					) : (
 						<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
 							{name}
-							{size ? ` (${formatFileSize(size)})` : null}
+							{size ? (
+								<Text css={{ whiteSpace: 'nowrap' }}>
+									{' '}
+									({formatFileSize(size)})
+								</Text>
+							) : null}
 						</Text>
 					)}
 				</Flex>

--- a/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { FileUploadExistingFileList } from './FileUploadExistingFileList';
+
+const meta: Meta<typeof FileUploadExistingFileList> = {
+	title: 'forms/FileUpload/Primitives/FileUploadExistingFileList',
+	component: FileUploadExistingFileList,
+	args: {
+		hideThumbnails: false,
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FileUploadExistingFileList>;
+
+export const Basic: Story = {
+	args: {
+		files: [
+			{
+				name: 'example.pdf',
+				size: 123456,
+				thumbnailSrc: 'https://via.placeholder.com/150',
+				onDelete: () => console.log('Delete file'),
+			},
+		],
+	},
+};

--- a/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
@@ -19,13 +19,11 @@ export const Basic: Story = {
 			{
 				name: 'example.pdf',
 				size: 123456,
-				onDelete: () => console.log('Delete file'),
 			},
 			{
 				name: 'example.jpg',
 				size: 123456,
 				thumbnailSrc: 'https://via.placeholder.com/150',
-				onDelete: () => console.log('Delete file'),
 			},
 		],
 	},

--- a/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.stories.tsx
@@ -19,6 +19,11 @@ export const Basic: Story = {
 			{
 				name: 'example.pdf',
 				size: 123456,
+				onDelete: () => console.log('Delete file'),
+			},
+			{
+				name: 'example.jpg',
+				size: 123456,
 				thumbnailSrc: 'https://via.placeholder.com/150',
 				onDelete: () => console.log('Delete file'),
 			},

--- a/packages/react/src/file-upload/FileUploadExistingFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.tsx
@@ -3,21 +3,27 @@ import { FileUploadExistingFile } from './FileUploadExistingFile';
 import { ExistingFile } from './utils';
 
 type FileUploadExistingFileListProps = {
-	files: ExistingFile[];
+	files?: ExistingFile[];
 	hideThumbnails?: boolean;
 };
 
 export const FileUploadExistingFileList = ({
 	files,
 	hideThumbnails,
-}: FileUploadExistingFileListProps) => (
-	<Stack as="ul" aria-label="Existing files" gap={0.5}>
-		{files.map((file, index) => (
-			<FileUploadExistingFile
-				key={index}
-				file={file}
-				hideThumbnails={hideThumbnails}
-			/>
-		))}
-	</Stack>
-);
+}: FileUploadExistingFileListProps) => {
+	if (!files?.length) {
+		return null;
+	}
+
+	return (
+		<Stack as="ul" aria-label="Existing files" gap={0.5}>
+			{files.map((file, index) => (
+				<FileUploadExistingFile
+					key={index}
+					file={file}
+					hideThumbnails={hideThumbnails}
+				/>
+			))}
+		</Stack>
+	);
+};

--- a/packages/react/src/file-upload/FileUploadExistingFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.tsx
@@ -4,12 +4,14 @@ import { ExistingFile } from './utils';
 
 type FileUploadExistingFileListProps = {
 	files?: ExistingFile[];
+	onRemove?: (file: ExistingFile) => void;
 	hideThumbnails?: boolean;
 };
 
 export const FileUploadExistingFileList = ({
 	files,
 	hideThumbnails,
+	onRemove,
 }: FileUploadExistingFileListProps) => {
 	if (!files?.length) {
 		return null;
@@ -22,6 +24,7 @@ export const FileUploadExistingFileList = ({
 					key={index}
 					file={file}
 					hideThumbnails={hideThumbnails}
+					onRemove={() => onRemove?.(file)}
 				/>
 			))}
 		</Stack>

--- a/packages/react/src/file-upload/FileUploadExistingFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadExistingFileList.tsx
@@ -1,0 +1,23 @@
+import { Stack } from '../stack';
+import { FileUploadExistingFile } from './FileUploadExistingFile';
+import { ExistingFile } from './utils';
+
+type FileUploadExistingFileListProps = {
+	files: ExistingFile[];
+	hideThumbnails?: boolean;
+};
+
+export const FileUploadExistingFileList = ({
+	files,
+	hideThumbnails,
+}: FileUploadExistingFileListProps) => (
+	<Stack as="ul" aria-label="Existing files" gap={0.5}>
+		{files.map((file, index) => (
+			<FileUploadExistingFile
+				key={index}
+				file={file}
+				hideThumbnails={hideThumbnails}
+			/>
+		))}
+	</Stack>
+);

--- a/packages/react/src/file-upload/FileUploadFile.tsx
+++ b/packages/react/src/file-upload/FileUploadFile.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useMemo } from 'react';
 import { Box } from '../box';
 import { Flex } from '../flex';
 import { boxPalette } from '../core';
@@ -7,7 +7,7 @@ import { Button } from '../button';
 import { LoadingDots } from '../loading';
 import { SuccessFilledIcon } from '../icon';
 import { FileUploadFileThumbnail } from './FileUploadFileThumbnail';
-import { FileWithStatus, formatFileSize } from './utils';
+import { FileWithStatus, formatFileSize, getImageThumbnail } from './utils';
 
 type FileUploadFileProps = {
 	file: FileWithStatus;
@@ -22,6 +22,7 @@ export const FileUploadFile = ({
 }: FileUploadFileProps) => {
 	const { name, size, status = 'none' } = file;
 	const showThumbnail = !hideThumbnails;
+	const imagePreview = useMemo(() => getImageThumbnail(file), [file]);
 	return (
 		<Flex
 			rounded
@@ -32,7 +33,7 @@ export const FileUploadFile = ({
 			css={{ backgroundColor: TONE_MAP[status] }}
 		>
 			<Flex>
-				{showThumbnail && <FileUploadFileThumbnail file={file} />}
+				{showThumbnail && <FileUploadFileThumbnail src={imagePreview} />}
 				<Flex alignItems="center" paddingLeft={1} gap={0.5}>
 					{status == 'success' && (
 						<Box flexShrink={0}>

--- a/packages/react/src/file-upload/FileUploadFile.tsx
+++ b/packages/react/src/file-upload/FileUploadFile.tsx
@@ -47,7 +47,13 @@ export const FileUploadFile = ({
 						</Box>
 					)}
 					<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
-						{name} ({formatFileSize(size)})
+						{name}
+						{size ? (
+							<Text css={{ whiteSpace: 'nowrap' }}>
+								{' '}
+								({formatFileSize(size)})
+							</Text>
+						) : null}
 					</Text>
 				</Flex>
 			</Flex>

--- a/packages/react/src/file-upload/FileUploadFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadFileList.tsx
@@ -12,15 +12,21 @@ export const FileUploadFileList = ({
 	files,
 	onRemove,
 	hideThumbnails,
-}: FileUploadFileListProps) => (
-	<Stack as="ul" aria-label="Selected files" gap={0.5}>
-		{files.map((file, index) => (
-			<FileUploadFile
-				key={index}
-				file={file}
-				onRemove={() => onRemove(file)}
-				hideThumbnails={hideThumbnails}
-			/>
-		))}
-	</Stack>
-);
+}: FileUploadFileListProps) => {
+	if (!files.length) {
+		return null;
+	}
+
+	return (
+		<Stack as="ul" aria-label="Selected files" gap={0.5}>
+			{files.map((file, index) => (
+				<FileUploadFile
+					key={index}
+					file={file}
+					onRemove={() => onRemove(file)}
+					hideThumbnails={hideThumbnails}
+				/>
+			))}
+		</Stack>
+	);
+};

--- a/packages/react/src/file-upload/FileUploadFileThumbnail.tsx
+++ b/packages/react/src/file-upload/FileUploadFileThumbnail.tsx
@@ -1,21 +1,19 @@
-import { useMemo } from 'react';
 import { Box } from '../box';
 import { tokens } from '../core';
 import { Flex } from '../flex';
 import { FileIcon } from '../icon/icons/FileIcon';
-import { FileWithStatus, getImageThumbnail } from './utils';
 
-export const FileUploadFileThumbnail = ({ file }: { file: FileWithStatus }) => {
-	const imagePreview = useMemo(() => getImageThumbnail(file), [file]);
-	const width = '4.5rem';
-	return imagePreview ? (
+export const width = '4.5rem';
+
+export const FileUploadFileThumbnail = ({ src }: { src?: string }) => {
+	return src ? (
 		<Box
 			flexShrink={0}
 			display={{ xs: 'none', md: 'block' }}
 			css={{
 				borderTopLeftRadius: tokens.borderRadius,
 				borderBottomLeftRadius: tokens.borderRadius,
-				backgroundImage: `url(${imagePreview})`,
+				backgroundImage: `url(${src})`,
 				backgroundSize: 'cover',
 				backgroundPosition: 'center',
 				width: width,

--- a/packages/react/src/file-upload/FileUploadRejectedFile.tsx
+++ b/packages/react/src/file-upload/FileUploadRejectedFile.tsx
@@ -49,7 +49,14 @@ export const FileUploadRejectedFile = ({
 					</Box>
 					<Stack gap={0.5}>
 						<Text fontWeight="bold" color="error">
-							{file.name} ({formatFileSize(file.size)}) could not be selected
+							{file.name}
+							{file.size ? (
+								<span css={{ whiteSpace: 'nowrap' }}>
+									{' '}
+									({formatFileSize(file.size)})
+								</span>
+							) : null}{' '}
+							could not be selected
 						</Text>
 						<ul css={{ margin: 0, padding: 0 }}>
 							{errors.map(({ message }, index) => (

--- a/packages/react/src/file-upload/FileUploadRejectedFile.tsx
+++ b/packages/react/src/file-upload/FileUploadRejectedFile.tsx
@@ -61,9 +61,12 @@ export const FileUploadRejectedFile = ({
 					</Stack>
 				</Flex>
 			</Flex>
-
 			<Flex flexShrink={0} alignItems="center" paddingRight={1}>
-				<Button variant="text" onClick={onRemove}>
+				<Button
+					variant="text"
+					onClick={onRemove}
+					aria-label={`Remove file, ${name}`}
+				>
 					Remove file
 				</Button>
 			</Flex>

--- a/packages/react/src/file-upload/FileUploadRejectedFile.tsx
+++ b/packages/react/src/file-upload/FileUploadRejectedFile.tsx
@@ -1,4 +1,4 @@
-import { MouseEventHandler } from 'react';
+import { MouseEventHandler, useMemo } from 'react';
 import { FileWithPath } from 'react-dropzone';
 import { Box } from '../box';
 import { Flex } from '../flex';
@@ -7,7 +7,7 @@ import { Button } from '../button';
 import { boxPalette } from '../core';
 import { AlertFilledIcon } from '../icon';
 import { Text } from '../text';
-import { formatFileSize } from './utils';
+import { formatFileSize, getImageThumbnail } from './utils';
 import { FileUploadFileThumbnail } from './FileUploadFileThumbnail';
 
 type FileUploadRejectedFileProps = {
@@ -24,6 +24,7 @@ export const FileUploadRejectedFile = ({
 	hideThumbnails,
 }: FileUploadRejectedFileProps) => {
 	const showThumbnail = !hideThumbnails;
+	const imagePreview = useMemo(() => getImageThumbnail(file), [file]);
 	return (
 		<Flex
 			as="li"
@@ -35,7 +36,7 @@ export const FileUploadRejectedFile = ({
 			}}
 		>
 			<Flex>
-				{showThumbnail && <FileUploadFileThumbnail file={file} />}
+				{showThumbnail && <FileUploadFileThumbnail src={imagePreview} />}
 				<Flex paddingLeft={1} gap={0.5} paddingY={0.75}>
 					<Box flexShrink={0}>
 						<AlertFilledIcon

--- a/packages/react/src/file-upload/FileUploadRejectedFileList.tsx
+++ b/packages/react/src/file-upload/FileUploadRejectedFileList.tsx
@@ -13,6 +13,10 @@ export const FileUploadRejectedFileList = ({
 	handleRemoveRejection,
 	hideThumbnails,
 }: FileUploadRejectedFileListProps) => {
+	if (!fileRejections.length) {
+		return null;
+	}
+
 	return (
 		<Stack as="ul" aria-label="Invalid files" gap={0.5}>
 			{fileRejections.map((rejection) => (

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -105,7 +105,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
           class="css-1wcx0lf-boxStyles"
         >
           <li
-            aria-label="File. example.jpg"
+            aria-label="File. example.txt"
             class="css-izqcdk-boxStyles-FileUploadFile"
           >
             <div
@@ -139,9 +139,9 @@ exports[`FileUpload Basic renders correctly 1`] = `
                 <span
                   class="css-w8s9uh-boxStyles-Text-FileUploadFile"
                 >
-                  example.jpg
+                  example.txt
                    (
-                  23 B
+                  18 B
                   )
                 </span>
               </div>
@@ -153,7 +153,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
                 class="css-79i25n-boxStyles"
               >
                 <button
-                  aria-label="Remove file, example.jpg"
+                  aria-label="Remove file, example.txt"
                   class="css-1clbjuu-BaseButton-Button"
                   type="button"
                 >

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -140,9 +140,14 @@ exports[`FileUpload Basic renders correctly 1`] = `
                   class="css-w8s9uh-boxStyles-Text-FileUploadFile"
                 >
                   example.txt
-                   (
-                  18 B
-                  )
+                  <span
+                    class="css-1rfmi7i-boxStyles-Text-FileUploadFile"
+                  >
+                     
+                    (
+                    18 B
+                    )
+                  </span>
                 </span>
               </div>
             </div>

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
         <span
           class="css-1rpt3h8-boxStyles-Text"
         >
-          1 file selected (23 B)
+          1 file selected
         </span>
         <ul
           aria-label="Selected files"

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -142,7 +142,9 @@ This can be done by passing an object instead of a string with `mimeType` and `e
 
 ## Existing files
 
-You can display a list of files that have already been uploaded by using the `existingFiles` prop. Unlike `value` which expects an array of `File`, `existingFiles` expects an array of objects with a name, size, thumbnail url and an onDelete action.
+You can display a list of files that have already been uploaded by using the `existingFiles` and `onRemoveExistingFile` props.
+
+Unlike the `value`prop, which expects an array of`File`objects,`existingFiles` expects an array of objects with a name, size and thumbnail url.
 
 If a user attempts to delete an existing file, a destructive confirmation modal should be displayed. If confirmed, the file should be deleted on the server.
 
@@ -155,8 +157,10 @@ Image files should be displayed with thumbnails which are 72px by 72px. Passing 
 			name: 'example.png',
 			size: 123456,
 			thumbnailUrl: 'https://via.placeholder.com/150',
-			onDelete: () => console.log('Delete file'),
 		},
 	]}
+	onRemoveExistingFile={(fileToRemove) => {
+		console.log('Remove existing file', fileToRemove);
+	}}
 />
 ```

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -139,3 +139,24 @@ This can be done by passing an object instead of a string with `mimeType` and `e
 	accept={[{ mimeType: 'text/javascript', extensions: ['.js'] }]}
 />
 ```
+
+## Existing files
+
+You can display a list of files that have already been uploaded by using the `existingFiles` prop. Unlike `value` which expects an array of `File`, `existingFiles` expects an array of objects with a name, size, thumbnail url and an onDelete action.
+
+If a user attempts to delete an existing file, a destructive confirmation modal should be displayed. If confirmed, the file should be deleted on the server.
+
+Image files should be displayed with thumbnails which are 72px by 72px. Passing full-size images will to `thumbnailUrl` prop will result with long load times.
+
+```jsx
+<FileUpload
+	existingFiles={[
+		{
+			name: 'example.png',
+			size: 123456,
+			thumbnailUrl: 'https://via.placeholder.com/150',
+			onDelete: () => console.log('Delete file'),
+		},
+	]}
+/>
+```

--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -144,7 +144,7 @@ This can be done by passing an object instead of a string with `mimeType` and `e
 
 You can display a list of files that have already been uploaded by using the `existingFiles` and `onRemoveExistingFile` props.
 
-Unlike the `value`prop, which expects an array of`File`objects,`existingFiles` expects an array of objects with a name, size and thumbnail url.
+Unlike the `value`prop, which expects an array of `File` objects, `existingFiles` expects an array of objects with a name, size and thumbnail url.
 
 If a user attempts to delete an existing file, a destructive confirmation modal should be displayed. If confirmed, the file should be deleted on the server.
 
@@ -157,6 +157,9 @@ Image files should be displayed with thumbnails which are 72px by 72px. Passing 
 			name: 'example.png',
 			size: 123456,
 			thumbnailUrl: 'https://via.placeholder.com/150',
+			// Use the meta key to keep track of any extra file info
+			// This can be useful info when deleting the file
+			meta: { uid: 'abc-def', bucketId: '123-456' },
 		},
 	]}
 	onRemoveExistingFile={(fileToRemove) => {

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -13,10 +13,16 @@ export type RejectedFile = {
 };
 
 export type ExistingFile = {
+	/** The file name */
 	name: string;
+	/** The file size in bytes */
 	size: number;
+	/** If the file is an image, provide a URL to a 72x72 thumbnail */
 	thumbnailSrc?: string;
+	/** Callback function when the user clicks the delete button */
 	onDelete: () => void;
+	/** Link to a webpage where the user can view/download the existing file (optional) */
+	href?: string;
 };
 
 export function formatFileSize(bytes: number) {

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -25,8 +25,7 @@ export function formatFileSize(bytes: number) {
 
 export function getFilesTotal(files: { size: number }[]) {
 	const label = files.length > 1 ? 'files' : 'file';
-	const size = files.reduce((a, { size }) => a + size, 0);
-	return `${files.length} ${label} selected (${formatFileSize(size)})`;
+	return `${files.length} ${label} selected`;
 }
 
 export const fileTypeMapping = {
@@ -48,6 +47,7 @@ export const fileTypeMapping = {
 	'audio/*': { extensions: [], label: 'Any audio file' },
 	'audio/mpeg': { extensions: ['.mp3'] },
 	'audio/wav': { extensions: ['.wav'] },
+	// Image
 	'image/*': { extensions: [], label: 'Any image file' },
 	'image/gif': { extensions: ['.gif'] },
 	'image/heic': { extensions: ['.heic'] },

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -21,6 +21,8 @@ export type ExistingFile = {
 	size?: number;
 	/** If the file is an image, provide a URL to a 72x72 thumbnail. */
 	thumbnailSrc?: string;
+	/** Use the meta key to keep track of any extra file information, which can be useful when deleting the file. */
+	meta?: Record<string, unknown>;
 };
 
 export function formatFileSize(bytes: number) {

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -12,6 +12,13 @@ export type RejectedFile = {
 	errors: { message: string; code: string }[];
 };
 
+export type ExistingFile = {
+	name: string;
+	size: number;
+	thumbnailSrc?: string;
+	onDelete: () => void;
+};
+
 export function formatFileSize(bytes: number) {
 	return filesize(bytes);
 }

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -13,24 +13,22 @@ export type RejectedFile = {
 };
 
 export type ExistingFile = {
-	/** The file name */
+	/** The file name. */
 	name: string;
-	/** The file size in bytes */
-	size: number;
-	/** If the file is an image, provide a URL to a 72x72 thumbnail */
-	thumbnailSrc?: string;
-	/** Callback function when the user clicks the delete button */
-	onDelete: () => void;
 	/** Link to a webpage where the user can view/download the existing file (optional) */
 	href?: string;
+	/** The file size in bytes (optional). */
+	size?: number;
+	/** If the file is an image, provide a URL to a 72x72 thumbnail. */
+	thumbnailSrc?: string;
 };
 
 export function formatFileSize(bytes: number) {
 	return filesize(bytes);
 }
 
-export function getFilesTotal(files: { size: number }[]) {
-	const label = files.length > 1 ? 'files' : 'file';
+export function getFileListSummaryText(files: {}[]) {
+	const label = files.length === 1 ? 'file' : 'files';
 	return `${files.length} ${label} selected`;
 }
 


### PR DESCRIPTION
Add support for FileUpload to show previously uploaded files, with the new `existingFiles` prop.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1415/storybook/?path=/story/forms-fileupload--existing-files)

<img width="905" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/376e7146-b4b7-44ed-a6d8-4a7115e17414">

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [x] Create or update stories for Playroom snippets
