### PR TITLE
main-nav: Use light palette for mobile version

### DIFF
--- a/.changeset/large-pumpkins-greet.md
+++ b/.changeset/large-pumpkins-greet.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+main-nav: Updated the mobile variant to always render in the light palette

--- a/packages/react/src/core/boxPalette.ts
+++ b/packages/react/src/core/boxPalette.ts
@@ -113,6 +113,7 @@ export const boxPalette = {
 /**
  * Returns the current palette for a specific DOM element
  * Note: As this function relies on CSS vars, the value returned will not be available on the server
+ * Note: This will only return the value of the palette during the initial render. Any client side updates of the palette will not be captured via this hook.
  */
 export function useBoxPalette(element: RefObject<HTMLElement>) {
 	const [value, setValue] = useState<BoxPalette>();

--- a/packages/react/src/main-nav/NavContainer.tsx
+++ b/packages/react/src/main-nav/NavContainer.tsx
@@ -18,10 +18,9 @@ import {
 	useWindowSize,
 	useAriaModalPolyfill,
 	packs,
-	useBoxPalette,
 	BoxPalette,
 } from '../core';
-import { hoverMap, MainNavBackground, localPaletteVars } from './utils';
+import { hoverMap, MainNavBackground, localPaletteVars, ids } from './utils';
 import { CloseButton, OpenButton } from './MenuButtons';
 
 export type NavContainerProps = PropsWithChildren<{
@@ -46,9 +45,6 @@ export function NavContainer({
 
 	const menuVisiblyOpen =
 		menuOpen && (windowWidth || 0) <= tokens.breakpoint.lg - 1;
-
-	// As the main nav element sometimes renders in a portal for a11y reasons, we need to know about the current box palette
-	const palette = useBoxPalette(containerRef);
 
 	return (
 		<Box
@@ -76,11 +72,7 @@ export function NavContainer({
 					paddingX={{ xs: 0.75, lg: 2 }}
 				>
 					{hasItems ? <OpenButton onClick={open} /> : null}
-					<NavContainerDialog
-						palette={palette}
-						menuVisiblyOpen={menuVisiblyOpen}
-						close={close}
-					>
+					<NavContainerDialog menuVisiblyOpen={menuVisiblyOpen} close={close}>
 						{children}
 					</NavContainerDialog>
 					{rightContent}
@@ -103,7 +95,6 @@ function NavContainerDialog({
 	children,
 	close,
 	menuVisiblyOpen,
-	palette,
 }: NavContainerDialogProps) {
 	// Close the component when the user presses the escape key
 	useEffect(() => {
@@ -124,7 +115,6 @@ function NavContainerDialog({
 	const element = (
 		<Box
 			ref={modalContainerRef}
-			palette={palette}
 			{...(menuVisiblyOpen
 				? {
 						role: 'dialog',
@@ -132,7 +122,7 @@ function NavContainerDialog({
 						'aria-modal': 'true',
 				  }
 				: null)}
-			id="main-nav-dialog"
+			id={ids.dialog}
 			css={{
 				[tokens.mediaQuery.max.md]: {
 					zIndex: tokens.zIndex.dialog,
@@ -145,7 +135,6 @@ function NavContainerDialog({
 					width: '100%',
 					maxWidth: MOBILE_MAX_WIDTH,
 					padding: mapSpacing(1),
-					boxSizing: 'border-box',
 					overflowY: 'auto',
 				},
 			}}

--- a/packages/react/src/main-nav/NavList.tsx
+++ b/packages/react/src/main-nav/NavList.tsx
@@ -95,7 +95,7 @@ function NavListContainer({
 							'& > li': {
 								borderTopWidth: tokens.borderWidth.sm,
 								borderTopStyle: 'solid',
-								borderTopColor: boxPalette.border,
+								borderTopColor: boxPalette.borderMuted,
 							},
 						},
 					}}

--- a/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
+++ b/packages/react/src/main-nav/__snapshots__/MainNav.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`MainNav renders correctly 1`] = `
           </button>
         </div>
         <div
-          class="css-1pzon0t-light-boxStyles-element"
+          class="css-15ay299-boxStyles-element"
           id="main-nav-dialog"
         >
           <div
@@ -103,7 +103,7 @@ exports[`MainNav renders correctly 1`] = `
               class="css-ijor8a-boxStyles"
             >
               <ul
-                class="css-5nrt7j-boxStyles-NavListContainer"
+                class="css-1p6h2o9-boxStyles-NavListContainer"
               >
                 <li
                   class="css-1a7bmr9-boxStyles-NavListItem"

--- a/packages/react/src/main-nav/utils.ts
+++ b/packages/react/src/main-nav/utils.ts
@@ -10,7 +10,12 @@ export const localPaletteVars = {
 	linkActiveBg: '--nav-linkActiveBg',
 	bottomBar: '--nav-bottomBar',
 };
+
 export const localPalette = {
 	linkHoverBg: `var(${localPaletteVars.linkHoverBg})`,
 	linkActiveBg: `var(${localPaletteVars.linkActiveBg})`,
+};
+
+export const ids = {
+	dialog: 'main-nav-dialog',
 };


### PR DESCRIPTION
This PR updates the mobile variant of Main nav to always render in the light palette, which matches other modals such as App Layout Mobile, Modal, Drawer etc.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1416)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.