### PR TITLE
file-upload: Export formatFileSize utility

### DIFF
--- a/.changeset/pretty-plants-explain.md
+++ b/.changeset/pretty-plants-explain.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+file-upload: Export formatFileSize utility

--- a/packages/react/src/file-upload/index.ts
+++ b/packages/react/src/file-upload/index.ts
@@ -1,7 +1,7 @@
 export * from './FileUpload';
+export { formatFileSize } from './utils';
 export type {
 	AcceptedFileMimeTypes,
 	FileWithStatus,
 	RejectedFile,
-	formatFileSize,
 } from './utils';


### PR DESCRIPTION
Export the `formatFileSize` utility from FileUpload. We attempted this change recently, but mistakingly exported it as a type.

## Checklist

**Preflight**

- [X] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [X] Describe the changes clearly in the PR description
- [X] Read and check your code before tagging someone for review
