### PR TITLE
docs: Update table batch actions examples

### DIFF
--- a/.storybook/stories/SelectableTableBatchActions/SelectableTableBatchActions.tsx
+++ b/.storybook/stories/SelectableTableBatchActions/SelectableTableBatchActions.tsx
@@ -15,6 +15,7 @@ import { Checkbox } from '@ag.ds-next/react/checkbox';
 import { ButtonGroup, Button } from '@ag.ds-next/react/button';
 import { PageContent } from '@ag.ds-next/react/content';
 import { H2, Heading } from '@ag.ds-next/react/heading';
+import { TextLink } from '@ag.ds-next/react/text-link';
 import { Flex } from '@ag.ds-next/react/flex';
 import { PaginationButtons } from '@ag.ds-next/react/pagination';
 import { Box } from '@ag.ds-next/react/box';
@@ -119,7 +120,7 @@ export function SelectableTableBatchActions() {
 											<TableHead>
 												<TableRow>
 													<TableHeader scope="col" width="6rem">
-														Selection
+														Select
 													</TableHeader>
 													<TableHeader scope="col">
 														Certificate number
@@ -260,8 +261,8 @@ function Row({
 						aria-label={`Select certificate ${certNumber}`}
 					/>
 				</TableCell>
-				<TableCell as="th" scope="row">
-					{certNumber}
+				<TableCell as="th" scope="row" fontWeight="bold">
+					<TextLink href="#">{certNumber}</TextLink>
 				</TableCell>
 				<TableCell>{exporter}</TableCell>
 				<TableCell>11/02/22 14:06</TableCell>

--- a/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
+++ b/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Selectable tables with batch actions
 description: Selectable tables allow users to select one or more rows simultaneously and perform batch actions against the selected rows.
-storybookPath: /story/content-table--selectable-basic
+storybookPath: /story/content-table--selectable-with-batch-actions
 relatedComponents: ['table', 'checkbox', 'button', 'drawer']
 githubTemplatePath: /.storybook/stories/SelectableTableBatchActions
 ---

--- a/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
+++ b/docs/content/patterns/selectable-table-with-batch-actions/index.mdx
@@ -19,9 +19,10 @@ Selected rows have a solid action coloured outline, which is achieved by setting
 		<Table>
 			<TableHead>
 				<TableRow>
-					<TableHeader scope="col">Select</TableHeader>
-					<TableHeader scope="col">Example Column</TableHeader>
-					<TableHeader scope="col">Example Column</TableHeader>
+					<TableHeader>Select</TableHeader>
+					<TableHeader scope="col">Reference</TableHeader>
+					<TableHeader scope="col">Date submitted</TableHeader>
+					<TableHeader scope="col">Actions</TableHeader>
 				</TableRow>
 			</TableHead>
 			<TableBody>
@@ -35,8 +36,16 @@ Selected rows have a solid action coloured outline, which is achieved by setting
 							<VisuallyHidden>Select row</VisuallyHidden>
 						</Checkbox>
 					</TableCell>
-					<TableCell>Example Row</TableCell>
-					<TableCell>Example Row</TableCell>
+					<TableCell as="th" scope="row" fontWeight="bold">
+						<TextLink href="#">REF-AB3CD4EF</TextLink>
+					</TableCell>
+					<TableCell>20/06/2022</TableCell>
+					<TableCell>
+						<Flex gap={1}>
+							<TextLink href="#">Download</TextLink>
+							<TextLink href="#">Delete</TextLink>
+						</Flex>
+					</TableCell>
 				</TableRow>
 			</TableBody>
 		</Table>
@@ -90,9 +99,10 @@ Unlike the checkboxes in each row, the "Select all rows" checkbox above the tabl
 			<Table>
 				<TableHead>
 					<TableRow>
-						<TableHeader scope="col">Select</TableHeader>
-						<TableHeader scope="col">Example Column</TableHeader>
-						<TableHeader scope="col">Example Column</TableHeader>
+						<TableHeader>Select</TableHeader>
+						<TableHeader scope="col">Reference</TableHeader>
+						<TableHeader scope="col">Date submitted</TableHeader>
+						<TableHeader scope="col">Actions</TableHeader>
 					</TableRow>
 				</TableHead>
 				<TableBody>
@@ -109,8 +119,16 @@ Unlike the checkboxes in each row, the "Select all rows" checkbox above the tabl
 										<VisuallyHidden>Select</VisuallyHidden>
 									</Checkbox>
 								</TableCell>
-								<TableCell>Example Row {idx + 1}</TableCell>
-								<TableCell>Example Row</TableCell>
+								<TableCell as="th" scope="row" fontWeight="bold">
+									<TextLink href="#">REF-AB3CD4EF</TextLink>
+								</TableCell>
+								<TableCell>20/06/2022</TableCell>
+								<TableCell>
+									<Flex gap={1}>
+										<TextLink href="#">Download</TextLink>
+										<TextLink href="#">Delete</TextLink>
+									</Flex>
+								</TableCell>
 							</TableRow>
 						);
 					})}
@@ -181,9 +199,10 @@ Only small [Buttons](/components/button) should be placed inside of the `TableBa
 				<Table>
 					<TableHead>
 						<TableRow>
-							<TableHeader scope="col">Select</TableHeader>
-							<TableHeader scope="col">Example Column</TableHeader>
-							<TableHeader scope="col">Example Column</TableHeader>
+							<TableHeader>Select</TableHeader>
+							<TableHeader scope="col">Reference</TableHeader>
+							<TableHeader scope="col">Date submitted</TableHeader>
+							<TableHeader scope="col">Actions</TableHeader>
 						</TableRow>
 					</TableHead>
 					<TableBody>
@@ -200,8 +219,16 @@ Only small [Buttons](/components/button) should be placed inside of the `TableBa
 											<VisuallyHidden>Select</VisuallyHidden>
 										</Checkbox>
 									</TableCell>
-									<TableCell>Example Row {idx + 1}</TableCell>
-									<TableCell>Example Row</TableCell>
+									<TableCell as="th" scope="row" fontWeight="bold">
+										<TextLink href="#">REF-AB3CD4EF</TextLink>
+									</TableCell>
+									<TableCell>20/06/2022</TableCell>
+									<TableCell>
+										<Flex gap={1}>
+											<TextLink href="#">Download</TextLink>
+											<TextLink href="#">Delete</TextLink>
+										</Flex>
+									</TableCell>
 								</TableRow>
 							);
 						})}
@@ -215,7 +242,7 @@ Only small [Buttons](/components/button) should be placed inside of the `TableBa
 					</TableBatchActionsTitle>
 					<ButtonGroup>
 						<Button variant="secondary" size="sm">
-							Example action
+							Download
 						</Button>
 						<Button variant="secondary" size="sm">
 							Delete

--- a/packages/react/src/table/docs/overview.mdx
+++ b/packages/react/src/table/docs/overview.mdx
@@ -583,9 +583,10 @@ For more information, read the [Selectable tables with batch actions pattern](/p
 				<Table>
 					<TableHead>
 						<TableRow>
-							<TableHeader scope="col">Select</TableHeader>
-							<TableHeader scope="col">Example Column</TableHeader>
-							<TableHeader scope="col">Example Column</TableHeader>
+							<TableHeader>Select</TableHeader>
+							<TableHeader scope="col">Reference</TableHeader>
+							<TableHeader scope="col">Date submitted</TableHeader>
+							<TableHeader scope="col">Actions</TableHeader>
 						</TableRow>
 					</TableHead>
 					<TableBody>
@@ -602,8 +603,16 @@ For more information, read the [Selectable tables with batch actions pattern](/p
 											<VisuallyHidden>Select</VisuallyHidden>
 										</Checkbox>
 									</TableCell>
-									<TableCell>Example Row {idx + 1}</TableCell>
-									<TableCell>Example Row</TableCell>
+									<TableCell as="th" scope="row" fontWeight="bold">
+										<TextLink href="#">REF-AB3CD4EF</TextLink>
+									</TableCell>
+									<TableCell>20/06/2022</TableCell>
+									<TableCell>
+										<Flex gap={1}>
+											<TextLink href="#">Download</TextLink>
+											<TextLink href="#">Delete</TextLink>
+										</Flex>
+									</TableCell>
 								</TableRow>
 							);
 						})}
@@ -613,15 +622,17 @@ For more information, read the [Selectable tables with batch actions pattern](/p
 			{selectedRows.length > 0 ? (
 				<TableBatchActionsBar>
 					<TableBatchActionsTitle>
-						Apply action to {selectedRows.length}{' '}
-						{selectedRows.length === 1 ? 'item' : 'items'}
+						Apply action to {selectedRows.length} items
 					</TableBatchActionsTitle>
 					<ButtonGroup>
 						<Button variant="secondary" size="sm">
-							Example action
+							Download
 						</Button>
-						<Button variant="tertiary" size="sm">
+						<Button variant="secondary" size="sm">
 							Delete
+						</Button>
+						<Button variant="tertiary" size="sm" onClick={toggleAllRows}>
+							Cancel
 						</Button>
 					</ButtonGroup>
 				</TableBatchActionsBar>


### PR DESCRIPTION
Improved code snippets on the "Selectable tables with batch actions" to be more realistic examples, as per feedback from @adhamdannawayaff.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1422/patterns/selectable-table-with-batch-actions)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review