### PR TITLE
file-upload: Remove border from thumbnail

### DIFF
--- a/.changeset/grumpy-flowers-pull.md
+++ b/.changeset/grumpy-flowers-pull.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+file-upload: Removed border from thumbnail

--- a/packages/react/src/file-upload/FileUploadFileThumbnail.tsx
+++ b/packages/react/src/file-upload/FileUploadFileThumbnail.tsx
@@ -24,9 +24,6 @@ export const FileUploadFileThumbnail = ({ file }: { file: FileWithStatus }) => {
 	) : (
 		<Flex
 			flexShrink={0}
-			border
-			borderColor="muted"
-			borderWidth="sm"
 			alignItems="center"
 			justifyContent="center"
 			display={{ xs: 'none', md: 'flex' }}

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
               class="css-1jhrbpg-boxStyles"
             >
               <div
-                class="css-1xdd4ff-boxStyles-FileUploadFileThumbnail"
+                class="css-iineh1-boxStyles-FileUploadFileThumbnail"
               >
                 <svg
                   aria-hidden="true"


### PR DESCRIPTION
Remove the grey border around the outside of the FileUploadThumbnail
| Before | After |
|--------|--------|
| <img width="376" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/1d6b3242-3fb3-4f33-8721-63a8a803be36"> | <img width="302" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/2279c925-fc4a-4571-bda9-9338bab3fc73"> |

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1426/storybook/index.html?path=/story/forms-fileupload-primitives-fileuploadfilelist--mixed-files)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

