### PR TITLE
checkbox: `invalid` prop should override control group

### DIFF
--- a/.changeset/tame-cups-tickle.md
+++ b/.changeset/tame-cups-tickle.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+checkbox: If supplied, the `invalid` prop will now override the value of the `invalid` prop set in `ControlGroup`.

--- a/packages/react/src/checkbox/Checkbox.tsx
+++ b/packages/react/src/checkbox/Checkbox.tsx
@@ -56,7 +56,12 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
 	) {
 		const ref = useRef<HTMLInputElement>(null);
 		const controlGroupContext = useControlGroupContext();
-		const invalid = invalidProp || controlGroupContext?.invalid;
+
+		// The invalid prop should override the context value
+		const invalid =
+			typeof invalidProp === 'boolean'
+				? invalidProp
+				: controlGroupContext?.invalid;
 
 		//`indeterminate` is set using the HTMLInputElement object's indeterminate property via JavaScript (it cannot be set using an HTML attribute)
 		// Read more about this here https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -39,7 +39,6 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 ) {
 	const controlGroupContext = useControlGroupContext();
 	const invalid = invalidProp || controlGroupContext?.invalid;
-
 	return (
 		<RadioContainer disabled={disabled}>
 			<RadioInput

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -38,7 +38,13 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 	ref
 ) {
 	const controlGroupContext = useControlGroupContext();
-	const invalid = invalidProp || controlGroupContext?.invalid;
+
+	// The invalid prop should override the context value
+	const invalid =
+		typeof invalidProp === 'boolean'
+			? invalidProp
+			: controlGroupContext?.invalid;
+
 	return (
 		<RadioContainer disabled={disabled}>
 			<RadioInput

--- a/packages/react/src/radio/Radio.tsx
+++ b/packages/react/src/radio/Radio.tsx
@@ -38,12 +38,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 	ref
 ) {
 	const controlGroupContext = useControlGroupContext();
-
-	// The invalid prop should override the context value
-	const invalid =
-		typeof invalidProp === 'boolean'
-			? invalidProp
-			: controlGroupContext?.invalid;
+	const invalid = invalidProp || controlGroupContext?.invalid;
 
 	return (
 		<RadioContainer disabled={disabled}>


### PR DESCRIPTION
If supplied, the `invalid` prop will now override the value of the `invalid` prop set in `ControlGroup`.

Compare how this works [in this pr preview](https://design-system.agriculture.gov.au/pr-preview/pr-1433/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AlGA7WAnAfAHXQAJDgAKASkIF4cSDjjJ0BnAF0IG0wALGMAaxhQAjABpCzGKwDCvAUOEBdaoTQBDMKwB0AV0kBlVmtYxSAMzUAbSeQDc9BkzacefQVABM4yTLnuPylSqMBraejCGxqasWDowdg6MECzsXH5CAMzeUrJumYHBoboGRibmVjb2RAxYUjpYRKSJDEjSyTEQlgDiWBA6AA7NDISWagBGMJZUeCAAInyjWMYAlskzQwzL6ABuVstQVMAAhK7yIoQAPheEJ%2Bmel9e3eVAZAL4bxAC2MMzMagDmMGmIAAgpZLIRTvwxhAAB4-QhqWqEWoARx0y1qUHW1WGxDRGKxH0IY0sEAEG3wuLxrT8MNhxMYd0OUIU72peMIyVkanQgMOFGotB8uTOwlITzF5HZnOGW12ln2h0l7mEMtlVNlDAAkoj-rUYIRWBAjdxlsxCGZMc4mFBlqxVuhiUgAPSi6FwzWy2luemMyHM4CszzqrXc7i8-lkSg0CQ5O4eCXBjzS-3yvYHY7J0N4r1a3UAg1Gk2sM0WyS2yHJO0OtYclpuume53uv314bBll3N7%2B8ORoHRoVx3zPDJJ7up9ubHYZ5XBntTvOygv6mCG42m82brBQKuYe2O52N33N%2BuutroDrdXoDJcJaqvdmutCYGC4AggV5AA) verus [the live website](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AlGA7WAnAfAHXQAJDgAKASkIF4cSDjjJ0BnAF0IG0wALGMAaxhQAjABpCzGKwDCvAUOEBdaoTQBDMKwB0AV0kBlVmtYxSAMzUAbSeQDc9BkzacefQVABM4yTLnuPylSqMBraejCGxqasWDowdg6MECzsXH5CAMzeUrJumYHBoboGRibmVjb2RAxYUjpYRKSJDEjSyTEQlgDiWBA6AA7NDISWagBGMJZUeCAAInyjWMYAlskzQwzL6ABuVstQVMAAhK7yIoQAPheEJ%2Bmel9e3eVAZAL4bxAC2MMzMagDmMGmIAAgpZLIRTvwxhAAB4-QhqWqEWoARx0y1qUHW1WGxDRGKxH0IY0sEAEG3wuLxrT8MNhxMYd0OUIU72peMIyVkanQgMOFGotB8uTOwlITzF5HZnOGW12ln2h0l7mEMtlVNlDAAkoj-rUYIRWBAjdxlsxCGZMc4mFBlqxVuhiUgAPSi6FwzWy2luemMyHM4CszzqrXc7i8-lkSg0CQ5O4eCXBjzS-3yvYHY7J0N4r1a3UAg1Gk2sM0WyS2yHJO0OtYclpuume53uv314bBll3N7%2B8ORoHRoVx3zPDJJ7up9ubHYZ5XBntTvOygv6mCG42m82brBQKuYe2O52N33N%2BuutroDrdXoDJcJaqvdmutCYGC4AggUQgADu%2B1LzAQDgMgAdgAVlEYQAAYPAAFgggAOSDIMUV4gA)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
