### PR TITLE
file-upload: Make existing file example a live preview

### DIFF
--- a/packages/react/src/file-upload/docs/overview.mdx
+++ b/packages/react/src/file-upload/docs/overview.mdx
@@ -150,7 +150,7 @@ If a user attempts to delete an existing file, a destructive confirmation modal 
 
 Image files should be displayed with thumbnails which are 72px by 72px. Passing full-size images will to `thumbnailUrl` prop will result with long load times.
 
-```jsx
+```jsx live
 <FileUpload
 	existingFiles={[
 		{


### PR DESCRIPTION
Fixing a mistake in the docs of the new FileUpload enhancements, where the example of existing files wasn't made to be a live preview.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1434/components/file-upload#existing-files)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [ ] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [ ] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets