### PR TITLE
dropdown: Minor updates to state reducer

### DIFF
--- a/.changeset/wet-ways-dance.md
+++ b/.changeset/wet-ways-dance.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': patch
 ---
 
-Minor update to state reducer
+dropdown-menu: Minor improvements to internal state reducer

--- a/.changeset/wet-ways-dance.md
+++ b/.changeset/wet-ways-dance.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+Minor update to state reducer

--- a/packages/react/src/dropdown-menu/reducer.tsx
+++ b/packages/react/src/dropdown-menu/reducer.tsx
@@ -27,29 +27,53 @@ type Action =
 	  };
 
 type State = {
-	/** The visibility of the dropdown menu. */
-	isMenuOpen: boolean;
-	/** The index of the active descendantIndex. -1 means there is no active descendant. */
+	/**
+	 * The index of the active descendantIndex.
+	 * -1 means there is no active descendant.
+	 *
+	 * @default -1
+	 */
 	activeDescendantIndex: number;
+
 	/** The HTML node elements containing each menu item (`DropdownMenuItem`, `DropdownMenuLInk` etc). */
 	descendantNodes: NodeListOf<HTMLDivElement> | undefined;
-	/** The count of descendant nodes. */
-	descendantCount: number;
+
 	/**
-	 * Typing any a-z character should focus the menu item with a label that starts with the typed character (if exists)
-	 * https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions-active-descendant/
+	 * The count of descendant nodes.
+	 *
+	 * @default 0
+	 */
+	descendantCount: number;
+
+	/**
+	 * Typing any a-z character should focus the menu item with a label that starts
+	 * with the typed character (if exists).
+	 * @see https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/examples/menu-button-actions-active-descendant/
 	 */
 	descendantSearchTerm: string;
-	/** Time of the last keypress for handling quick successive keypresses. Value is a timestamp in milliseconds. */
+
+	/**
+	 * Indicates if the menu is open.
+	 *
+	 * @default false
+	 */
+	isMenuOpen: boolean;
+
+	/**
+	 * Time of the last key press for handling quick successive key presses.
+	 * Value is a timestamp in milliseconds.
+	 *
+	 * @default 0
+	 */
 	lastKeyPressTime: number;
 };
 
 export const initialState: State = {
-	isMenuOpen: false,
 	activeDescendantIndex: -1,
-	descendantNodes: undefined,
 	descendantCount: 0,
+	descendantNodes: undefined,
 	descendantSearchTerm: '',
+	isMenuOpen: false,
 	lastKeyPressTime: 0,
 };
 
@@ -57,50 +81,53 @@ export function reducer(state: State, action: Action): State {
 	const currentTime = new Date().getTime();
 
 	switch (action.type) {
-		case 'OPEN_MENU':
-			return { ...state, isMenuOpen: true, descendantSearchTerm: '' };
-
-		case 'CLOSE_MENU':
-			// When the menu closes, the state of the dropdown menu should be reset
-			return initialState;
-
-		case 'SET_DESCENDANT_NODES':
+		case 'OPEN_MENU': {
 			return {
 				...state,
+				isMenuOpen: true,
+			};
+		}
+
+		case 'CLOSE_MENU': {
+			// When the menu closes, the state of the dropdown menu should be reset
+			return initialState;
+		}
+
+		case 'SET_DESCENDANT_NODES': {
+			return {
+				...state,
+				descendantCount: action.payload.nodes?.length ?? 0,
 				descendantNodes: action.payload.nodes,
-				descendantCount: action.payload.nodes?.length
-					? action.payload.nodes.length - 1
-					: 0,
 				descendantSearchTerm: '',
 				lastKeyPressTime: 0,
 			};
+		}
 
-		case 'ACTIVATE_FIRST_DESCENDANT':
+		case 'ACTIVATE_FIRST_DESCENDANT': {
 			return {
 				...state,
 				activeDescendantIndex: 0,
 				descendantSearchTerm: '',
 				lastKeyPressTime: 0,
 			};
+		}
 
-		case 'ACTIVATE_LAST_DESCENDANT':
+		case 'ACTIVATE_LAST_DESCENDANT': {
 			return {
 				...state,
-				activeDescendantIndex: state.descendantCount,
+				activeDescendantIndex: state.descendantCount - 1,
 				descendantSearchTerm: '',
 				lastKeyPressTime: 0,
 			};
+		}
 
 		case 'ACTIVATE_NEXT_DESCENDANT': {
-			let newActiveDescendantIndex = 0;
-
 			// If current active descendant is not the last, increment index by 1
-			if (state.activeDescendantIndex < state.descendantCount) {
-				newActiveDescendantIndex = state.activeDescendantIndex + 1;
-			} else {
-				// If last descendant is currently active, loop back to the first
-				newActiveDescendantIndex = 0;
-			}
+			const newActiveDescendantIndex =
+				state.activeDescendantIndex < state.descendantCount - 1
+					? state.activeDescendantIndex + 1
+					: // If last descendant is currently active, loop back to the first
+					  0;
 
 			// Update the state with the new active descendant index and clear search term
 			return {
@@ -112,15 +139,12 @@ export function reducer(state: State, action: Action): State {
 		}
 
 		case 'ACTIVATE_PREVIOUS_DESCENDANT': {
-			let newActiveDescendantIndex = 0;
-
 			// If current active descendant is not the first, decrement index by 1
-			if (state.activeDescendantIndex > 0) {
-				newActiveDescendantIndex = state.activeDescendantIndex - 1;
-			} else {
-				// If first descendant is currently active, loop to the last
-				newActiveDescendantIndex = state.descendantCount;
-			}
+			const newActiveDescendantIndex =
+				state.activeDescendantIndex > 0
+					? state.activeDescendantIndex - 1
+					: // If first descendant is currently active, loop to the last
+					  state.descendantCount - 1;
 
 			// Update the state with the new active descendant index and clear search term
 			return {
@@ -179,7 +203,8 @@ export function reducer(state: State, action: Action): State {
 			};
 		}
 
-		default:
-			return state;
+		default: {
+			throw new Error(`Unhandled action type: ${(action as Action).type}`);
+		}
 	}
 }


### PR DESCRIPTION
Some minor changes to the reducer for the dropdown menu:
- Sort keys for `State` and `initialState` alphabetically
- Improved JSDoc comments with default values
- Wrap cases in curly braces to prevent accidental leaking of scope
- Treat `descendantCount` as a count and not an index
- Use a ternary instead of mutating a let variable for `ACTIVATE_LAST_DESCENDANT` and `ACTIVATE_NEXT_DESCENDANT` cases
- Throw error if an unexpected case is ever reached

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).