### PR TITLE
example-form: Improve sign-in experience

### DIFF
--- a/example-form/components/Layout/AppLayout.tsx
+++ b/example-form/components/Layout/AppLayout.tsx
@@ -33,7 +33,7 @@ import {
 	DropdownMenuPanel,
 } from '@ag.ds-next/react/dropdown-menu';
 import { useAuth, User } from '../../lib/useAuth';
-import NotFoundPage from '../../pages/not-found';
+import { PageNotAllowed } from '../PageNotAllowed';
 import { useLinkedBusinesses } from '../../lib/useLinkedBusinesses';
 
 type AppLayoutProps = PropsWithChildren<{
@@ -77,7 +77,7 @@ export function AppLayout({
 	if (!hasLoadedUser) return null;
 
 	// Application pages are not visible when you are logged out
-	if (!user) return <NotFoundPage />;
+	if (!user) return <PageNotAllowed />;
 
 	return (
 		<Fragment>

--- a/example-form/components/PageNotAllowed.tsx
+++ b/example-form/components/PageNotAllowed.tsx
@@ -1,0 +1,32 @@
+import { useRouter } from 'next/router';
+import { H1 } from '@ag.ds-next/react/heading';
+import { Stack } from '@ag.ds-next/react/stack';
+import { Text } from '@ag.ds-next/react/text';
+import { TextLink } from '@ag.ds-next/react/text-link';
+import { tokens } from '@ag.ds-next/react/core';
+import { PageContent } from '@ag.ds-next/react/content';
+import { SiteLayout } from './Layout/SiteLayout';
+import { DocumentTitle } from './DocumentTitle';
+
+export function PageNotAllowed() {
+	const { asPath } = useRouter();
+	const signInUrl = `/sign-in?redirectTo=${asPath}`;
+	return (
+		<>
+			<DocumentTitle title="403 Error" />
+			<SiteLayout>
+				<PageContent>
+					<Stack gap={1.5} maxWidth={tokens.maxWidth.bodyText}>
+						<H1>Not allowed</H1>
+						<Text as="p" fontSize="md">
+							You do not have permission to access this page.
+						</Text>
+						<Text as="p">
+							<TextLink href={signInUrl}>Sign in</TextLink> to try again.
+						</Text>
+					</Stack>
+				</PageContent>
+			</SiteLayout>
+		</>
+	);
+}

--- a/example-form/lib/useAuth.tsx
+++ b/example-form/lib/useAuth.tsx
@@ -54,7 +54,6 @@ export function AuthProvider({ children }: PropsWithChildren<{}>) {
 	function signIn(user: User) {
 		sessionStorage.setItem('user', JSON.stringify(user));
 		setUserState(user);
-		router.push('/app');
 	}
 
 	function signOut() {

--- a/example-form/pages/sign-in.tsx
+++ b/example-form/pages/sign-in.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'next/router';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState, useRef, Fragment, ReactElement } from 'react';
 import { useForm, SubmitHandler, SubmitErrorHandler } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -21,7 +23,9 @@ import { useAuth, UserRole } from '../lib/useAuth';
 import type { NextPageWithLayout } from './_app';
 
 const Page: NextPageWithLayout = () => {
+	const { push } = useRouter();
 	const { signIn } = useAuth();
+	const searchParams = useSearchParams();
 
 	function onSubmit({ firstName, lastName, role }: FormSchema) {
 		signIn({
@@ -30,6 +34,10 @@ const Page: NextPageWithLayout = () => {
 			displayName: [firstName, lastName].join(' '),
 			role,
 		});
+		// When the user signs in, attempt to redirect them to the page they just tried to visit
+		// `redirectTo` param is set in `components/PageNotAllowed.tsx`
+		const redirectToParam = searchParams.get('redirectTo');
+		push(redirectToParam || '/app');
 	}
 
 	return (


### PR DESCRIPTION
Improved the sign in experience of the sign in flow in the "Example form" application by attempting to redirect them to the page they just tried to visit upon successful sign in.

To test this, in a new incognito tab, try attempting to visit a private route such as the [Account settings page](https://design-system.agriculture.gov.au/pr-preview/pr-1448/example-form/app/account-settings). If you click the "Sign in" link on this page, when you sign in you should be taken back to the account settings page.

Now in a another new incognito tab, attempt to sign in as per usual (sign in link in the main nav). You should be taken the dashboard page as expected.

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
