### PR TITLE
example-form: Add error boundary

### DIFF
--- a/example-form/components/ErrorBoundary.tsx
+++ b/example-form/components/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, PropsWithChildren, ReactNode } from 'react';
+import { useRouter } from 'next/router';
+import { Stack } from '@ag.ds-next/react/stack';
+import { Button } from '@ag.ds-next/react/button';
+import { H1 } from '@ag.ds-next/react/heading';
+import { Text } from '@ag.ds-next/react/text';
+import { PageContent } from '@ag.ds-next/react/content';
+
+// https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+
+export type ErrorBoundaryProps = PropsWithChildren<{
+	fallback: ReactNode;
+}>;
+
+export class ErrorBoundary extends Component<
+	ErrorBoundaryProps,
+	{ hasError: boolean }
+> {
+	constructor(props: ErrorBoundaryProps) {
+		super(props);
+		this.state = { hasError: false };
+	}
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	render() {
+		if (this.state.hasError) {
+			// You can render any custom fallback UI
+			return this.props.fallback;
+		}
+
+		return this.props.children;
+	}
+}
+
+export function ErrorBoundaryPageFallback() {
+	const { reload } = useRouter();
+	return (
+		<PageContent>
+			<Stack gap={2} alignItems="flex-start">
+				<Stack gap={1.5}>
+					<H1>An error occurred</H1>
+					<Text as="p">Something went wrong.</Text>
+				</Stack>
+				<Button onClick={reload}>Reload the page</Button>
+			</Stack>
+		</PageContent>
+	);
+}

--- a/example-form/components/Layout/AppLayout.tsx
+++ b/example-form/components/Layout/AppLayout.tsx
@@ -35,6 +35,7 @@ import {
 import { useAuth, User } from '../../lib/useAuth';
 import NotFoundPage from '../../pages/not-found';
 import { useLinkedBusinesses } from '../../lib/useLinkedBusinesses';
+import { ErrorBoundary, ErrorBoundaryPageFallback } from '../ErrorBoundary';
 
 type AppLayoutProps = PropsWithChildren<{
 	focusMode?: boolean;
@@ -92,7 +93,9 @@ export function AppLayout({
 						flexGrow={1}
 						{...(applyMainElement ? MAIN_CONTENT_ATTRS : undefined)}
 					>
-						{children}
+						<ErrorBoundary fallback={<ErrorBoundaryPageFallback />}>
+							{children}
+						</ErrorBoundary>
 					</Box>
 					<AppLayoutFooter>
 						<nav aria-label="footer">

--- a/example-form/pages/app/businesses/index.tsx
+++ b/example-form/pages/app/businesses/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactElement, useEffect } from 'react';
+import { Fragment, ReactElement } from 'react';
 import { PageContent } from '@ag.ds-next/react/content';
 import { H1 } from '@ag.ds-next/react/heading';
 import { DocumentTitle } from '../../../components/DocumentTitle';
@@ -6,11 +6,6 @@ import { AppLayout } from '../../../components/Layout/AppLayout';
 import type { NextPageWithLayout } from '../../_app';
 
 const Page: NextPageWithLayout = () => {
-	useEffect(() => {
-		// This is just for testing the error boundary. Please delete me.
-		throw new Error('Something went wrong');
-	}, []);
-
 	return (
 		<Fragment>
 			<DocumentTitle title="Businesses" />

--- a/example-form/pages/app/businesses/index.tsx
+++ b/example-form/pages/app/businesses/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactElement } from 'react';
+import { Fragment, ReactElement, useEffect } from 'react';
 import { PageContent } from '@ag.ds-next/react/content';
 import { H1 } from '@ag.ds-next/react/heading';
 import { DocumentTitle } from '../../../components/DocumentTitle';
@@ -6,6 +6,11 @@ import { AppLayout } from '../../../components/Layout/AppLayout';
 import type { NextPageWithLayout } from '../../_app';
 
 const Page: NextPageWithLayout = () => {
+	useEffect(() => {
+		// This is just for testing the error boundary. Please delete me.
+		throw new Error('Something went wrong');
+	}, []);
+
 	return (
 		<Fragment>
 			<DocumentTitle title="Businesses" />


### PR DESCRIPTION
Added a [React Error Boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary) around the application layout main content area, which will stop the whole page from crashing if an error occurred in that part of the page (e.g. hydrating the form state from session storage). This will most likely never occur but it's good to have just in case.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1449/example-form/)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [ ] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
