### PR TITLE
button: Fix icon shrinking

### DIFF
--- a/.changeset/strong-actors-dress.md
+++ b/.changeset/strong-actors-dress.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': patch
+---
+
+button: Added flex-shrinking to icons to prevent from shrinking when the button label spans multiple lines
+
+button: Updated text alignment for the `text` button variant

--- a/packages/react/src/button/Button.tsx
+++ b/packages/react/src/button/Button.tsx
@@ -55,7 +55,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		return (
 			<BaseButton ref={ref} css={styles} type={type} {...props}>
 				{IconBefore ? (
-					<IconBefore size={iconSize[size]} weight="regular" />
+					<IconBefore
+						size={iconSize[size]}
+						weight="regular"
+						css={{ flexShrink: 0 }}
+					/>
 				) : null}
 				<span>
 					<span css={{ opacity: loading ? 0 : 1 }}>{children}</span>
@@ -66,7 +70,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 					/>
 				</span>
 				{IconAfter ? (
-					<IconAfter size={iconSize[size]} weight="regular" />
+					<IconAfter
+						size={iconSize[size]}
+						weight="regular"
+						css={{ flexShrink: 0 }}
+					/>
 				) : null}
 			</BaseButton>
 		);

--- a/packages/react/src/button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button Loading renders correctly 1`] = `
 <div>
   <button
-    class="css-1me5i3x-BaseButton-Button"
+    class="css-1hl1ub4-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -47,7 +47,7 @@ exports[`Button Loading renders correctly 1`] = `
 exports[`Button Small Button renders correctly 1`] = `
 <div>
   <button
-    class="css-1fdo7nw-BaseButton-Button"
+    class="css-4pejr7-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -68,7 +68,7 @@ exports[`Button Small Button renders correctly 1`] = `
 exports[`Button With Icon renders correctly 1`] = `
 <div>
   <button
-    class="css-1me5i3x-BaseButton-Button"
+    class="css-1hl1ub4-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -84,7 +84,7 @@ exports[`Button With Icon renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-9s3cfn-Icon"
+      class="css-10mbdw9-Button"
       clip-rule="evenodd"
       focusable="false"
       height="24"
@@ -109,7 +109,7 @@ exports[`Button With Icon renders correctly 1`] = `
 exports[`Button renders correctly 1`] = `
 <div>
   <button
-    class="css-1me5i3x-BaseButton-Button"
+    class="css-1hl1ub4-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -130,7 +130,7 @@ exports[`Button renders correctly 1`] = `
 exports[`ButtonLink renders correctly 1`] = `
 <div>
   <a
-    class="css-oqbu2u-ButtonLink"
+    class="css-4q9mac-ButtonLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/button/styles.ts
+++ b/packages/react/src/button/styles.ts
@@ -42,6 +42,7 @@ const variants = {
 		},
 	},
 	text: {
+		textAlign: 'left',
 		height: 'auto',
 		paddingLeft: 0,
 		paddingRight: 0,
@@ -103,13 +104,13 @@ export function buttonStyles({
 		display: block ? 'flex' : 'inline-flex',
 		alignItems: 'center',
 		justifyContent: 'center',
+		textAlign: 'center',
 		borderWidth: tokens.borderWidth.lg,
 		borderStyle: 'solid',
 		borderRadius: tokens.borderRadius,
 		cursor: 'pointer',
 		fontFamily: tokens.font.body,
 		margin: 0,
-		textAlign: 'center',
 
 		...(block && {
 			width: '100%',
@@ -118,6 +119,11 @@ export function buttonStyles({
 		'&:disabled': {
 			cursor: 'not-allowed',
 			opacity: 0.3,
+		},
+
+		// Ensure button icons do not shrink
+		'& > svg': {
+			flexShrink: 0,
 		},
 
 		...focusStyles,

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`DatePicker renders correctly 1`] = `
         />
         <button
           aria-label="Change Date, Saturday January 1st, 2000"
-          class="css-1hdallj-BaseButton-DateInput"
+          class="css-1cgdw2g-BaseButton-DateInput"
           type="button"
         >
           <span>

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change Date, Saturday January 1st, 2000"
-                class="css-1hdallj-BaseButton-DateInput"
+                class="css-1cgdw2g-BaseButton-DateInput"
                 type="button"
               >
                 <span>
@@ -138,7 +138,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change Date, Sunday January 2nd, 2000"
-                class="css-1hdallj-BaseButton-DateInput"
+                class="css-1cgdw2g-BaseButton-DateInput"
                 type="button"
               >
                 <span>

--- a/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Drawer renders correctly 1`] = `
           class="css-10pjjkw-boxStyles-DrawerFooter"
         >
           <button
-            class="css-1me5i3x-BaseButton-Button"
+            class="css-1hl1ub4-BaseButton-Button"
             type="button"
           >
             <span>
@@ -66,7 +66,7 @@ exports[`Drawer renders correctly 1`] = `
           </button>
         </div>
         <button
-          class="css-1sdyl83-BaseButton-DrawerDialog"
+          class="css-przh0n-BaseButton-DrawerDialog"
           type="button"
         >
           <span>
@@ -81,7 +81,7 @@ exports[`Drawer renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-9s3cfn-Icon"
+            class="css-10mbdw9-Button"
             clip-rule="evenodd"
             focusable="false"
             height="24"

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     aria-controls="dropdown-menu-:ru:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1clbjuu-BaseButton-Button"
+    class="css-65as1x-BaseButton-Button"
     id="dropdown-menu-:ru:-button"
     type="button"
   >
@@ -22,7 +22,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-9s3cfn-Icon"
+      class="css-10mbdw9-Button"
       clip-rule="evenodd"
       focusable="false"
       height="24"
@@ -182,7 +182,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     aria-controls="dropdown-menu-:r16:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1clbjuu-BaseButton-Button"
+    class="css-65as1x-BaseButton-Button"
     id="dropdown-menu-:r16:-button"
     type="button"
   >
@@ -198,7 +198,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-9s3cfn-Icon"
+      class="css-10mbdw9-Button"
       clip-rule="evenodd"
       focusable="false"
       height="24"
@@ -270,7 +270,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
     aria-controls="dropdown-menu-:r1i:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1clbjuu-BaseButton-Button"
+    class="css-65as1x-BaseButton-Button"
     id="dropdown-menu-:r1i:-button"
     type="button"
   >
@@ -286,7 +286,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-9s3cfn-Icon"
+      class="css-10mbdw9-Button"
       clip-rule="evenodd"
       focusable="false"
       height="24"
@@ -401,7 +401,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     aria-controls="dropdown-menu-:r0:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1clbjuu-BaseButton-Button"
+    class="css-65as1x-BaseButton-Button"
     id="dropdown-menu-:r0:-button"
     type="button"
   >
@@ -417,7 +417,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     </span>
     <svg
       aria-hidden="true"
-      class="css-9s3cfn-Icon"
+      class="css-10mbdw9-Button"
       clip-rule="evenodd"
       focusable="false"
       height="24"

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-z97ug4-FileInput"
+      class="css-13mh0it-FileInput"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-z97ug4-FileInput"
+      class="css-13mh0it-FileInput"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
           </span>
         </div>
         <button
-          class="css-1ycoxnt-BaseButton-Button"
+          class="css-1tw29bg-BaseButton-Button"
           type="button"
         >
           <span>
@@ -159,7 +159,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
               >
                 <button
                   aria-label="Remove file, example.txt"
-                  class="css-1clbjuu-BaseButton-Button"
+                  class="css-65as1x-BaseButton-Button"
                   type="button"
                 >
                   <span>

--- a/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
+++ b/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`GlobalAlert Dismissable renders correctly 1`] = `
         </div>
       </div>
       <button
-        class="css-85zwbi-BaseButton-GlobalAlertCloseButton"
+        class="css-zhbw2y-BaseButton-GlobalAlertCloseButton"
         type="button"
       >
         <span>
@@ -67,7 +67,7 @@ exports[`GlobalAlert Dismissable renders correctly 1`] = `
         </span>
         <svg
           aria-hidden="true"
-          class="css-9s3cfn-Icon"
+          class="css-10mbdw9-Button"
           clip-rule="evenodd"
           focusable="false"
           height="24"

--- a/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`HeroBanner renders correctly 1`] = `
               </p>
             </div>
             <button
-              class="css-1me5i3x-BaseButton-Button"
+              class="css-1hl1ub4-BaseButton-Button"
               type="button"
             >
               <span>

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Modal renders correctly 1`] = `
           class="css-1kzq3kl-boxStyles-ModalDialog"
         >
           <button
-            class="css-1me5i3x-BaseButton-Button"
+            class="css-1hl1ub4-BaseButton-Button"
             type="button"
           >
             <span>
@@ -60,7 +60,7 @@ exports[`Modal renders correctly 1`] = `
         </div>
         <button
           aria-label="Close modal"
-          class="css-1h2z8qx-BaseButton-ModalDialog"
+          class="css-1o5mvjj-BaseButton-ModalDialog"
           type="button"
         >
           <span>
@@ -75,7 +75,7 @@ exports[`Modal renders correctly 1`] = `
           </span>
           <svg
             aria-hidden="true"
-            class="css-9s3cfn-Icon"
+            class="css-10mbdw9-Button"
             clip-rule="evenodd"
             focusable="false"
             height="24"

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`PageAlert with a close button renders correctly 1`] = `
       </div>
       <button
         aria-label="Close"
-        class="css-motjk1-BaseButton-PageAlertCloseButton"
+        class="css-fx8c1r-BaseButton-PageAlertCloseButton"
         type="button"
       >
         <span>
@@ -276,7 +276,7 @@ exports[`PageAlert with a close button renders correctly 1`] = `
         </span>
         <svg
           aria-hidden="true"
-          class="css-9s3cfn-Icon"
+          class="css-10mbdw9-Button"
           clip-rule="evenodd"
           focusable="false"
           height="24"

--- a/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
+++ b/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`SearchBox renders correctly 1`] = `
       >
         <button
           aria-label="Search"
-          class="css-olw5s0-BaseButton-SearchBoxButton"
+          class="css-1ek1wu6-BaseButton-SearchBoxButton"
           type="submit"
         >
           <span>

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`SectionAlert which is dismissable renders correctly 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="css-16p43b8-BaseButton-SectionAlertDismissButton"
+      class="css-1q60cv5-BaseButton-SectionAlertDismissButton"
       type="button"
     >
       <span>
@@ -55,7 +55,7 @@ exports[`SectionAlert which is dismissable renders correctly 1`] = `
       </span>
       <svg
         aria-hidden="true"
-        class="css-9s3cfn-Icon"
+        class="css-10mbdw9-Button"
         clip-rule="evenodd"
         focusable="false"
         height="24"

--- a/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
+++ b/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`SkipLinks renders correctly 1`] = `
     aria-label="skip links"
   >
     <a
-      class="css-1n5lci-SkipLinkItem"
+      class="css-15dkg7y-SkipLinkItem"
       href="#main-content"
     >
       Skip to main content
     </a>
     <a
-      class="css-1n5lci-SkipLinkItem"
+      class="css-15dkg7y-SkipLinkItem"
       href="#main-nav"
     >
       Skip to main navigation


### PR DESCRIPTION
- Added flex-shrinking to icons to prevent from shrinking when the button label spans multiple lines
- Updated text alignment for the `text` button variant

| Before | After |
|--------|--------|
| [Before playroom](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AFAhgcxgYQgOwBcZCA%2BAHTwAJKkAVNAIwBsYB1AJzQAcuZ3yq1GvWYwBQoXUYsAEjDRRxEySJYAlCAHclyldJhyFfSpoCWUAgAsAvGRABWAAwBSO5QDOkXrfAQmdnV0hABkIMDQCU3wKIMkAelUDeVh%2BGNjhfUMUyiIADwIAQSZTDDwfdhLLAjdPCG87SH8QQNiUOoBXJgiovDTYpATM5L4W5SlRLOM8wuLS8srqkA8vGB9GgL707Es0PCxKCAA3Yy52GEOo9vdKAE95dkpXQX7BieHU56Dx2XecmHyiiUynYKhgqjUVms-BtPrFtrt9kcTmcLhArpRYOFYI9NroBolJh8XokNNpcTRXj8FKNvjAAELQG6jai00nMvSibAwJhMEhIOntAgEfCUQ5oCq7Ag%2BaZuUyQPAFABmRHY1mAABEtHgmBAFABJeUAXxIVlM7gAtGbzWhzWc0DybuadXtzYrTCw8GgALYwc1WCLmjAQGAWtBgdgQdwWr2dUwELgsJ2mPAhv2WK1Wm12h1O-AYV3u4je33%2BgiB4Oh8OR6Ox%2BOJ4op9wAOi4ewGAqF%2BD5lJw3N55IktK5PL%2BANmwJAoPBzQA7AAaABsM8cc%2BXjnx%2BmH-dhY0SW9HMyB8zBixIAGYmwBGZwbzl99ksvd9g%2BAuYghYBS8AJibAE4bz2W7sre6haMBJJgQOHIsEBABqcrChKIG9jyD4ZHeI7TK%2BE5Tqe9hzr%2Bv4LnOAAsjjroB95QY%2Bm7Plh47HtOJA-vYAFPqh1HoTBdH-Ieb6Th%2BzS-k2Z5sbRHE7iyPZslBrKQZJ0EobyACK7QwMQ7hdHgUDIUBnFDjxY5Hu%2BJ4BCRc4AByOBZlnkbpVEKTRGFMC%2BDEmUxl5NjOYnOWhBmYbx2GMael4XqJ9kScS%2BgyQpclko5XFKSQrAhiqVAFFcBCcMUaARdu6SJfu9HGQJpnNF%2Bi6OGeBF2ZRkXpP5LnFfxuEBD%2B4V1flDXsU1gVuaVHmeQuPncfVeLSfJ-QQfFBWNSQADKaJWJQGXuFl9qmLlnV%2BT1rkla1zSXqujgVVZFE9Tt4m9UZLWCcxTYuHll3OXtt1lSQC5NhZI1JbJE0zV803PaNvL0O4Xq7JtT36btzU4Xd9iXvOZHnVdwNKa98PvSRP16QljWY8FAT2CJuMOVFogxVN0WTd1aMAHIQOwVh8FQtB8BUiE3ND%2BOw31%2B13V%2BJHmSjPOzXzN1Yx5TZfmTY2A1dhPuaeJFNqxYtfP94E0wD1O%2Bat605VQ2DcHG9qUOz7Cc0z3PbTDitw0TzRnr%2B1Xkajvn2y9jvK21TY4xresg0rA2nsJw2B2MWvkshDJQEymzIUoyEcNwvAfAM6BYLghDEAQAggIaQA) | [After playroom](https://design-system.agriculture.gov.au/pr-preview/pr-1450/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AFAhgcxgYQgOwBcZCA%2BAHTwAJKkAVNAIwBsYB1AJzQAcuZ3yq1GvWYwBQoXUYsAEjDRRxEySJYAlCAHclyldJhyFfSpoCWUAgAsAvGRABWAAwBSO5QDOkXrfAQmdnV0hABkIMDQCU3wKIMkAelUDeVh%2BGNjhfUMUyiIADwIAQSZTDDwfdhLLAjdPCG87SH8QQNiUOoBXJgiovDTYpATM5L4W5SlRLOM8wuLS8srqkA8vGB9GgL707Es0PCxKCAA3Yy52GEOo9vdKAE95dkpXQX7BieHU56Dx2XecmHyiiUynYKhgqjUVms-BtPrFtrt9kcTmcLhArpRYOFYI9NroBolJh8XokNNpcTRXj8FKNvjAAELQG6jai00nMvSibAwJhMEhIOntAgEfCUQ5oCq7Ag%2BaZuUyQPAFABmRHY1mAABEtHgmBAFABJeUAXxIVlM7gAtGbzWhzWc0DybuadXtzYrTCw8GgALYwc1WCLmjAQGAWtBgdgQdwWr2dUwELgsJ2mPAhv2WK1Wm12h1O-AYV3u4je33%2BgiB4Oh8OR6Ox%2BOJ4op9wAOi4ewGAqF%2BD5lJw3N55IktK5PL%2BANmwJAoPBzQA7AAaABsM8cc%2BXjnx%2BmH-dhY0SW9HMyB8zBixIAGYmwBGZwbzl99ksvd9g%2BAuYghYBS8AJibAE4bz2W7sre6haMBJJgQOHIsEBABqcrChKIG9jyD4ZHeI7TK%2BE5Tqe9hzr%2Bv4LnOAAsjjroB95QY%2Bm7Plh47HtOJA-vYAFPqh1HoTBdH-Ieb6Th%2BzS-k2Z5sbRHE7iyPZslBrKQZJ0EobyACK7QwMQ7hdHgUDIUBnFDjxY5Hu%2BJ4BCRc4AByOBZlnkbpVEKTRGFMC%2BDEmUxl5NjOYnOWhBmYbx2GMael4XqJ9kScS%2BgyQpclko5XFKSQrAhiqVAFFcBCcMUaARdu6SJfu9HGQJpnNF%2Bi6OGeBF2ZRkXpP5LnFfxuEBD%2B4V1flDXsU1gVuaVHmeQuPncfVeLSfJ-QQfFBWNSQADKaJWJQGXuFl9qmLlnV%2BT1rkla1zSXqujgVVZFE9Tt4m9UZLWCcxTYuHll3OXtt1lSQC5NhZI1JbJE0zV803PaNvL0O4Xq7JtT36btzU4Xd9iXvOZHnVdwNKa98PvSRP16QljWY8FAT2CJuMOVFogxVN0WTd1aMAHIQOwVh8FQtB8BUiE3ND%2BOw31%2B13V%2BJHmSjPOzXzN1Yx5TZfmTY2A1dhPuaeJFNqxYtfP94E0wD1O%2Bat605VQ2DcHG9qUOz7Cc0z3PbTDitw0TzRnr%2B1Xkajvn2y9jvK21TY4xresg0rA2nsJw2B2MWvkshDJQEymzIUoyEcNwvAfAM6BYLghDEAQAggIaQA) | 

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.