### PR TITLE
button: use min height

### DIFF
--- a/.changeset/famous-parrots-perform.md
+++ b/.changeset/famous-parrots-perform.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+button: Switched to `min-height` instead of `height` to better accommodate buttons with multi-line labels

--- a/packages/react/src/button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button Loading renders correctly 1`] = `
 <div>
   <button
-    class="css-1hl1ub4-BaseButton-Button"
+    class="css-ysvto2-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -47,7 +47,7 @@ exports[`Button Loading renders correctly 1`] = `
 exports[`Button Small Button renders correctly 1`] = `
 <div>
   <button
-    class="css-4pejr7-BaseButton-Button"
+    class="css-1fi344s-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -68,7 +68,7 @@ exports[`Button Small Button renders correctly 1`] = `
 exports[`Button With Icon renders correctly 1`] = `
 <div>
   <button
-    class="css-1hl1ub4-BaseButton-Button"
+    class="css-ysvto2-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -109,7 +109,7 @@ exports[`Button With Icon renders correctly 1`] = `
 exports[`Button renders correctly 1`] = `
 <div>
   <button
-    class="css-1hl1ub4-BaseButton-Button"
+    class="css-ysvto2-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -130,7 +130,7 @@ exports[`Button renders correctly 1`] = `
 exports[`ButtonLink renders correctly 1`] = `
 <div>
   <a
-    class="css-4q9mac-ButtonLink"
+    class="css-hssjvn-ButtonLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react/src/button/__snapshots__/Button.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Button Loading renders correctly 1`] = `
 <div>
   <button
-    class="css-ysvto2-BaseButton-Button"
+    class="css-1xaxpdg-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -47,7 +47,7 @@ exports[`Button Loading renders correctly 1`] = `
 exports[`Button Small Button renders correctly 1`] = `
 <div>
   <button
-    class="css-1fi344s-BaseButton-Button"
+    class="css-uwq2hm-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -68,7 +68,7 @@ exports[`Button Small Button renders correctly 1`] = `
 exports[`Button With Icon renders correctly 1`] = `
 <div>
   <button
-    class="css-ysvto2-BaseButton-Button"
+    class="css-1xaxpdg-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -109,7 +109,7 @@ exports[`Button With Icon renders correctly 1`] = `
 exports[`Button renders correctly 1`] = `
 <div>
   <button
-    class="css-ysvto2-BaseButton-Button"
+    class="css-1xaxpdg-BaseButton-Button"
     data-testid="example"
     type="button"
   >
@@ -130,7 +130,7 @@ exports[`Button renders correctly 1`] = `
 exports[`ButtonLink renders correctly 1`] = `
 <div>
   <a
-    class="css-hssjvn-ButtonLink"
+    class="css-pvrlzo-ButtonLink"
     data-testid="example"
     href="#"
   >

--- a/packages/react/src/button/styles.ts
+++ b/packages/react/src/button/styles.ts
@@ -61,20 +61,20 @@ const variants = {
 
 export type ButtonVariant = keyof typeof variants;
 
-const { height: smButtonHeight, ...smButtonStyles } = packs.input.sm;
-const { height: mdButtonHeight, ...mdButtonStyles } = packs.input.md;
+const { height: smHeight, ...smStyles } = packs.input.sm;
+const { height: mdHeight, ...mdStyles } = packs.input.md;
 
 const sizes = {
 	sm: {
-		...smButtonStyles,
-		minHeight: smButtonHeight,
+		...smStyles,
+		minHeight: smHeight,
 		gap: mapSpacing(0.5),
 		paddingLeft: mapSpacing(0.75),
 		paddingRight: mapSpacing(0.75),
 	},
 	md: {
-		...mdButtonStyles,
-		minHeight: mdButtonHeight,
+		...mdStyles,
+		minHeight: mdHeight,
 		gap: mapSpacing(0.5),
 		paddingLeft: mapSpacing(1.5),
 		paddingRight: mapSpacing(1.5),

--- a/packages/react/src/button/styles.ts
+++ b/packages/react/src/button/styles.ts
@@ -103,6 +103,7 @@ export function buttonStyles({
 	size: ButtonSize;
 }) {
 	return {
+		appearance: 'none',
 		boxSizing: 'border-box',
 		position: 'relative',
 		display: block ? 'flex' : 'inline-flex',
@@ -112,6 +113,8 @@ export function buttonStyles({
 		borderWidth: tokens.borderWidth.lg,
 		borderStyle: 'solid',
 		borderRadius: tokens.borderRadius,
+		cursor: 'pointer',
+		fontFamily: tokens.font.body,
 		margin: 0,
 
 		...(block && {

--- a/packages/react/src/button/styles.ts
+++ b/packages/react/src/button/styles.ts
@@ -43,7 +43,7 @@ const variants = {
 	},
 	text: {
 		textAlign: 'left',
-		height: 'auto',
+		minHeight: 'auto',
 		paddingLeft: 0,
 		paddingRight: 0,
 		borderWidth: 0,
@@ -61,15 +61,20 @@ const variants = {
 
 export type ButtonVariant = keyof typeof variants;
 
+const { height: smButtonHeight, ...smButtonStyles } = packs.input.sm;
+const { height: mdButtonHeight, ...mdButtonStyles } = packs.input.md;
+
 const sizes = {
 	sm: {
-		...packs.input.sm,
+		...smButtonStyles,
+		minHeight: smButtonHeight,
 		gap: mapSpacing(0.5),
 		paddingLeft: mapSpacing(0.75),
 		paddingRight: mapSpacing(0.75),
 	},
 	md: {
-		...packs.input.md,
+		...mdButtonStyles,
+		minHeight: mdButtonHeight,
 		gap: mapSpacing(0.5),
 		paddingLeft: mapSpacing(1.5),
 		paddingRight: mapSpacing(1.5),
@@ -98,7 +103,6 @@ export function buttonStyles({
 	size: ButtonSize;
 }) {
 	return {
-		appearance: 'none',
 		boxSizing: 'border-box',
 		position: 'relative',
 		display: block ? 'flex' : 'inline-flex',
@@ -108,8 +112,6 @@ export function buttonStyles({
 		borderWidth: tokens.borderWidth.lg,
 		borderStyle: 'solid',
 		borderRadius: tokens.borderRadius,
-		cursor: 'pointer',
-		fontFamily: tokens.font.body,
 		margin: 0,
 
 		...(block && {

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`DatePicker renders correctly 1`] = `
         />
         <button
           aria-label="Change Date, Saturday January 1st, 2000"
-          class="css-1cgdw2g-BaseButton-DateInput"
+          class="css-mpdp9f-BaseButton-DateInput"
           type="button"
         >
           <span>

--- a/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/react/src/date-picker/__snapshots__/DatePicker.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`DatePicker renders correctly 1`] = `
         />
         <button
           aria-label="Change Date, Saturday January 1st, 2000"
-          class="css-mpdp9f-BaseButton-DateInput"
+          class="css-1martsc-BaseButton-DateInput"
           type="button"
         >
           <span>

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change Date, Saturday January 1st, 2000"
-                class="css-mpdp9f-BaseButton-DateInput"
+                class="css-1martsc-BaseButton-DateInput"
                 type="button"
               >
                 <span>
@@ -138,7 +138,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change Date, Sunday January 2nd, 2000"
-                class="css-mpdp9f-BaseButton-DateInput"
+                class="css-1martsc-BaseButton-DateInput"
                 type="button"
               >
                 <span>

--- a/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
+++ b/packages/react/src/date-range-picker/__snapshots__/DateRangePicker.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change Date, Saturday January 1st, 2000"
-                class="css-1cgdw2g-BaseButton-DateInput"
+                class="css-mpdp9f-BaseButton-DateInput"
                 type="button"
               >
                 <span>
@@ -138,7 +138,7 @@ exports[`DateRangePicker renders correctly 1`] = `
               />
               <button
                 aria-label="Change Date, Sunday January 2nd, 2000"
-                class="css-1cgdw2g-BaseButton-DateInput"
+                class="css-mpdp9f-BaseButton-DateInput"
                 type="button"
               >
                 <span>

--- a/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Drawer renders correctly 1`] = `
           class="css-10pjjkw-boxStyles-DrawerFooter"
         >
           <button
-            class="css-ysvto2-BaseButton-Button"
+            class="css-1xaxpdg-BaseButton-Button"
             type="button"
           >
             <span>
@@ -66,7 +66,7 @@ exports[`Drawer renders correctly 1`] = `
           </button>
         </div>
         <button
-          class="css-1yjf0d9-BaseButton-DrawerDialog"
+          class="css-1ubheky-BaseButton-DrawerDialog"
           type="button"
         >
           <span>

--- a/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/react/src/drawer/__snapshots__/Drawer.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`Drawer renders correctly 1`] = `
           class="css-10pjjkw-boxStyles-DrawerFooter"
         >
           <button
-            class="css-1hl1ub4-BaseButton-Button"
+            class="css-ysvto2-BaseButton-Button"
             type="button"
           >
             <span>
@@ -66,7 +66,7 @@ exports[`Drawer renders correctly 1`] = `
           </button>
         </div>
         <button
-          class="css-przh0n-BaseButton-DrawerDialog"
+          class="css-1yjf0d9-BaseButton-DrawerDialog"
           type="button"
         >
           <span>

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     aria-controls="dropdown-menu-:ru:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1qbgh2t-BaseButton-Button"
+    class="css-psfrx5-BaseButton-Button"
     id="dropdown-menu-:ru:-button"
     type="button"
   >
@@ -182,7 +182,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     aria-controls="dropdown-menu-:r16:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1qbgh2t-BaseButton-Button"
+    class="css-psfrx5-BaseButton-Button"
     id="dropdown-menu-:r16:-button"
     type="button"
   >
@@ -270,7 +270,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
     aria-controls="dropdown-menu-:r1i:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1qbgh2t-BaseButton-Button"
+    class="css-psfrx5-BaseButton-Button"
     id="dropdown-menu-:r1i:-button"
     type="button"
   >
@@ -401,7 +401,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     aria-controls="dropdown-menu-:r0:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-1qbgh2t-BaseButton-Button"
+    class="css-psfrx5-BaseButton-Button"
     id="dropdown-menu-:r0:-button"
     type="button"
   >

--- a/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/packages/react/src/dropdown-menu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DropdownMenu Decorative renders correctly 1`] = `
     aria-controls="dropdown-menu-:ru:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-65as1x-BaseButton-Button"
+    class="css-1qbgh2t-BaseButton-Button"
     id="dropdown-menu-:ru:-button"
     type="button"
   >
@@ -182,7 +182,7 @@ exports[`DropdownMenu Links renders correctly 1`] = `
     aria-controls="dropdown-menu-:r16:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-65as1x-BaseButton-Button"
+    class="css-1qbgh2t-BaseButton-Button"
     id="dropdown-menu-:r16:-button"
     type="button"
   >
@@ -270,7 +270,7 @@ exports[`DropdownMenu Radio Group renders correctly 1`] = `
     aria-controls="dropdown-menu-:r1i:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-65as1x-BaseButton-Button"
+    class="css-1qbgh2t-BaseButton-Button"
     id="dropdown-menu-:r1i:-button"
     type="button"
   >
@@ -401,7 +401,7 @@ exports[`DropdownMenu renders correctly 1`] = `
     aria-controls="dropdown-menu-:r0:-panel"
     aria-expanded="true"
     aria-haspopup="true"
-    class="css-65as1x-BaseButton-Button"
+    class="css-1qbgh2t-BaseButton-Button"
     id="dropdown-menu-:r0:-button"
     type="button"
   >

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-ng06ov-FileInput"
+      class="css-1tm6i4y-FileInput"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-ng06ov-FileInput"
+      class="css-1tm6i4y-FileInput"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-13mh0it-FileInput"
+      class="css-ng06ov-FileInput"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-13mh0it-FileInput"
+      class="css-ng06ov-FileInput"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
           </span>
         </div>
         <button
-          class="css-1tw29bg-BaseButton-Button"
+          class="css-4w2xrh-BaseButton-Button"
           type="button"
         >
           <span>
@@ -159,7 +159,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
               >
                 <button
                   aria-label="Remove file, example.txt"
-                  class="css-65as1x-BaseButton-Button"
+                  class="css-1qbgh2t-BaseButton-Button"
                   type="button"
                 >
                   <span>

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
           </span>
         </div>
         <button
-          class="css-4w2xrh-BaseButton-Button"
+          class="css-g9kgvi-BaseButton-Button"
           type="button"
         >
           <span>
@@ -159,7 +159,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
               >
                 <button
                   aria-label="Remove file, example.txt"
-                  class="css-1qbgh2t-BaseButton-Button"
+                  class="css-psfrx5-BaseButton-Button"
                   type="button"
                 >
                   <span>

--- a/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
+++ b/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`GlobalAlert Dismissable renders correctly 1`] = `
         </div>
       </div>
       <button
-        class="css-elpnnz-BaseButton-GlobalAlertCloseButton"
+        class="css-12jvszj-BaseButton-GlobalAlertCloseButton"
         type="button"
       >
         <span>

--- a/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
+++ b/packages/react/src/global-alert/__snapshots__/GlobalAlert.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`GlobalAlert Dismissable renders correctly 1`] = `
         </div>
       </div>
       <button
-        class="css-zhbw2y-BaseButton-GlobalAlertCloseButton"
+        class="css-elpnnz-BaseButton-GlobalAlertCloseButton"
         type="button"
       >
         <span>

--- a/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`HeroBanner renders correctly 1`] = `
               </p>
             </div>
             <button
-              class="css-ysvto2-BaseButton-Button"
+              class="css-1xaxpdg-BaseButton-Button"
               type="button"
             >
               <span>

--- a/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
+++ b/packages/react/src/hero-banner/HeroBanner/__snapshots__/HeroBanner.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`HeroBanner renders correctly 1`] = `
               </p>
             </div>
             <button
-              class="css-1hl1ub4-BaseButton-Button"
+              class="css-ysvto2-BaseButton-Button"
               type="button"
             >
               <span>

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Modal renders correctly 1`] = `
           class="css-1kzq3kl-boxStyles-ModalDialog"
         >
           <button
-            class="css-ysvto2-BaseButton-Button"
+            class="css-1xaxpdg-BaseButton-Button"
             type="button"
           >
             <span>
@@ -60,7 +60,7 @@ exports[`Modal renders correctly 1`] = `
         </div>
         <button
           aria-label="Close modal"
-          class="css-1sy4cxu-BaseButton-ModalDialog"
+          class="css-xzbqql-BaseButton-ModalDialog"
           type="button"
         >
           <span>

--- a/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react/src/modal/__snapshots__/Modal.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Modal renders correctly 1`] = `
           class="css-1kzq3kl-boxStyles-ModalDialog"
         >
           <button
-            class="css-1hl1ub4-BaseButton-Button"
+            class="css-ysvto2-BaseButton-Button"
             type="button"
           >
             <span>
@@ -60,7 +60,7 @@ exports[`Modal renders correctly 1`] = `
         </div>
         <button
           aria-label="Close modal"
-          class="css-1o5mvjj-BaseButton-ModalDialog"
+          class="css-1sy4cxu-BaseButton-ModalDialog"
           type="button"
         >
           <span>

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`PageAlert with a close button renders correctly 1`] = `
       </div>
       <button
         aria-label="Close"
-        class="css-almsqq-BaseButton-PageAlertCloseButton"
+        class="css-hze38i-BaseButton-PageAlertCloseButton"
         type="button"
       >
         <span>

--- a/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
+++ b/packages/react/src/page-alert/__snapshots__/PageAlert.test.tsx.snap
@@ -261,7 +261,7 @@ exports[`PageAlert with a close button renders correctly 1`] = `
       </div>
       <button
         aria-label="Close"
-        class="css-fx8c1r-BaseButton-PageAlertCloseButton"
+        class="css-almsqq-BaseButton-PageAlertCloseButton"
         type="button"
       >
         <span>

--- a/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
+++ b/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`SearchBox renders correctly 1`] = `
       >
         <button
           aria-label="Search"
-          class="css-tain81-BaseButton-SearchBoxButton"
+          class="css-ta2vha-BaseButton-SearchBoxButton"
           type="submit"
         >
           <span>

--- a/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
+++ b/packages/react/src/search-box/__snapshots__/Search.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`SearchBox renders correctly 1`] = `
       >
         <button
           aria-label="Search"
-          class="css-1ek1wu6-BaseButton-SearchBoxButton"
+          class="css-tain81-BaseButton-SearchBoxButton"
           type="submit"
         >
           <span>

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`SectionAlert which is dismissable renders correctly 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="css-1q60cv5-BaseButton-SectionAlertDismissButton"
+      class="css-u2q96j-BaseButton-SectionAlertDismissButton"
       type="button"
     >
       <span>

--- a/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
+++ b/packages/react/src/section-alert/__snapshots__/SectionAlert.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`SectionAlert which is dismissable renders correctly 1`] = `
     </div>
     <button
       aria-label="Close"
-      class="css-u2q96j-BaseButton-SectionAlertDismissButton"
+      class="css-1myr4hy-BaseButton-SectionAlertDismissButton"
       type="button"
     >
       <span>

--- a/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
+++ b/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`SkipLinks renders correctly 1`] = `
     aria-label="skip links"
   >
     <a
-      class="css-15dkg7y-SkipLinkItem"
+      class="css-6a91y6-SkipLinkItem"
       href="#main-content"
     >
       Skip to main content
     </a>
     <a
-      class="css-15dkg7y-SkipLinkItem"
+      class="css-6a91y6-SkipLinkItem"
       href="#main-nav"
     >
       Skip to main navigation

--- a/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
+++ b/packages/react/src/skip-link/__snapshots__/SkipLinks.test.tsx.snap
@@ -6,13 +6,13 @@ exports[`SkipLinks renders correctly 1`] = `
     aria-label="skip links"
   >
     <a
-      class="css-6a91y6-SkipLinkItem"
+      class="css-168ctfx-SkipLinkItem"
       href="#main-content"
     >
       Skip to main content
     </a>
     <a
-      class="css-6a91y6-SkipLinkItem"
+      class="css-168ctfx-SkipLinkItem"
       href="#main-nav"
     >
       Skip to main navigation


### PR DESCRIPTION
This pull request updates our "Button" component to use `min-height` instead of `height`. This adjustment ensures that buttons with multi-line labels are better accommodated.

| Before | After |
|--------|--------|
| [View before playroom](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AFAhgcxgYQgOwBcZCA%2BAHTwAJKkBlAtMAa0ozQAcBeYAZgF9yVajXqMWbLsACMfSmgA2ASwx4AkkQC2AZ05kQAM3kwAHgFotDAE4E9g4cKQAhAK4EC%2BSgDc0lxWkK6IOy%2BGj4AnnqUipB4AIL6RJbcACIQAO548hBoUKoxAhT29igh4ZQARq7ueIVFSAD0Lm74dnVN1V4%2BfgF6WjAxUOGR0fjxiSnpmdm5%2Ba1FlLT9%2BIOWYRVV%2BLX2De0tWw67VN6%2B-gSBiQR%2Bq8MxYzBJwKkZWTl5%2BAVC8wAq95dllc0qPI0OUYPJ9tQdhs8HMDtDOiceiAiMYbCAorcEvcJs9pm88B95tQfqj1oDKMDQeDPg5GtDYQ1RMwGclFJ5FLBLJR6gymeIONwZHIlCp1DBtIFDCZzFY0bDIYcEd0znpgopQtd0SM4liHk8pq9ZhDhAQABaKLSmC2mNCmSwwBTyMKmLJ4DCmfSKIx4NAaGCmM1oAimDAQGCWxiWCBaS0aZxKAjsIwuxR4cMB82W622%2B2O52u92e72%2B-2B4Oh9OR6Ox%2BOKRPJpRprQAOnYbuNUMB8poiuOysCfQGQy1mPGj0mLxm7271DN1uzdod8idLvwha9xBLGaDIbDEbAUZjpjjCaT-sb6bnWYji7zq7dHo3Pr92-Le5tB%2Brx9r9fPqfDrbtjSkJ0l2Ha9l0pznL8VwRCOoy6jiBpTgSM6UFeVo3rmy75muj7Fi%2BZa7pWn5HiedZnimTYZvOWFLiuBb4ZuhGmjuFb7oeNang2-4tm2GAdqB1Tdk48J9lBegomiGIIWO%2BqTvihJEhhC7YQxeFFsxpasW%2BJGcd%2B3F-tRKl0XejGac%2B2lse%2BVZkT%2BlEXnxQHzJ2wn7IyDDMrUHliIIDToFguCEMQBCCCAfBAA) | [View after playroom](https://design-system.agriculture.gov.au/pr-preview/pr-1451/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AFAhgcxgYQgOwBcZCA%2BAHTwAJKkBlAtMAa0ozQAcBeYAZgF9yVajXqMWbLsACMfSmgA2ASwx4AkkQC2AZ05kQAM3kwAHgFotDAE4E9g4cKQAhAK4EC%2BSgDc0lxWkK6IOy%2BGj4AnnqUipB4AIL6RJbcACIQAO548hBoUKoxAhT29igh4ZQARq7ueIVFSAD0Lm74dnVN1V4%2BfgF6WjAxUOGR0fjxiSnpmdm5%2Ba1FlLT9%2BIOWYRVV%2BLX2De0tWw67VN6%2B-gSBiQR%2Bq8MxYzBJwKkZWTl5%2BAVC8wAq95dllc0qPI0OUYPJ9tQdhs8HMDtDOiceiAiMYbCAorcEvcJs9pm88B95tQfqj1oDKMDQeDPg5GtDYQ1RMwGclFJ5FLBLJR6gymeIONwZHIlCp1DBtIFDCZzFY0bDIYcEd0znpgopQtd0SM4liHk8pq9ZhDhAQABaKLSmC2mNCmSwwBTyMKmLJ4DCmfSKIx4NAaGCmM1oAimDAQGCWxiWCBaS0aZxKAjsIwuxR4cMB82W622%2B2O52u92e72%2B-2B4Oh9OR6Ox%2BOKRPJpRprQAOnYbuNUMB8poiuOysCfQGQy1mPGj0mLxm7271DN1uzdod8idLvwha9xBLGaDIbDEbAUZjpjjCaT-sb6bnWYji7zq7dHo3Pr92-Le5tB%2Brx9r9fPqfDrbtjSkJ0l2Ha9l0pznL8VwRCOoy6jiBpTgSM6UFeVo3rmy75muj7Fi%2BZa7pWn5HiedZnimTYZvOWFLiuBb4ZuhGmjuFb7oeNang2-4tm2GAdqB1Tdk48J9lBegomiGIIWO%2BqTvihJEhhC7YQxeFFsxpasW%2BJGcd%2B3F-tRKl0XejGac%2B2lse%2BVZkT%2BlEXnxQHzJ2wn7IyDDMrUHliIIDToFguCEMQBCCCAfBAA) | 

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
