### PR TITLE
Adjust card spacing in search-filters example

### DIFF
--- a/docs/content/foundations/tokens/spacing.mdx
+++ b/docs/content/foundations/tokens/spacing.mdx
@@ -53,6 +53,7 @@ between them.
 					Used in medium sized components, like [Callout](/components/callout),
 					for the space between typography.
 				</li>
+				<li>Used for gaps between cards in Card lists.</li>
 				<li>
 					Used for the padding in small sized components like
 					[Accordion](/components/accordion).
@@ -65,6 +66,9 @@ between them.
 		<SummaryListItemDescription>
 			<ul>
 				<li>Used for the gutter between layout columns.</li>
+				<li>
+					Used for the horizontal and vertical gaps between cards in Card grids.
+				</li>
 				<li>
 					Used for the padding inside medium sized components, like
 					[Callout](/components/callout), [Card](/components/card) and [Page

--- a/docs/content/patterns/search-filters/index.mdx
+++ b/docs/content/patterns/search-filters/index.mdx
@@ -60,7 +60,7 @@ The dataset should be displayed in a [Table](/components/table) or a list of [Ca
 		</Flex>
 		<Divider />
 	</Stack>
-	<Stack gap={1.5}>
+	<Stack gap={1}>
 		<H3>25 results</H3>
 		{Array.from(Array(5).keys()).map((idx) => (
 			<Card key={idx} shadow clickable>


### PR DESCRIPTION
- Tweak spacing within list of cards, in the example published on the [search-filters pattern page](https://design-system.agriculture.gov.au/pr-preview/pr-1457/patterns/search-filters) (was 24px, now 16px)
- Add documentation to [spacing tokens page](https://design-system.agriculture.gov.au/pr-preview/pr-1457/foundations/tokens/spacing) about card list/grid gaps