### PR TITLE
file-upload: Support `href` attribute on files

### DIFF
--- a/.changeset/happy-trees-serve.md
+++ b/.changeset/happy-trees-serve.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-file-upload: Added support for `href` attribute on selected files
+file-upload: Added support for `href` in `FileWithStatus`

--- a/.changeset/happy-trees-serve.md
+++ b/.changeset/happy-trees-serve.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+file-upload: Added support for href attribute on files

--- a/.changeset/happy-trees-serve.md
+++ b/.changeset/happy-trees-serve.md
@@ -2,4 +2,4 @@
 '@ag.ds-next/react': minor
 ---
 
-file-upload: Added support for href attribute on files
+file-upload: Added support for `href` attribute on selected files

--- a/packages/react/src/file-upload/FileUpload.stories.tsx
+++ b/packages/react/src/file-upload/FileUpload.stories.tsx
@@ -153,7 +153,10 @@ const InstantUploadTemplate = (args: FileUploadProps) => {
 		setTimeout(() => {
 			setValue(
 				acceptedFiles.map((file) => {
-					if (file.status === 'uploading') file.status = 'success';
+					if (file.status === 'uploading') {
+						file.status = 'success';
+						file.href = '#';
+					}
 					return file;
 				})
 			);

--- a/packages/react/src/file-upload/FileUploadFile.stories.tsx
+++ b/packages/react/src/file-upload/FileUploadFile.stories.tsx
@@ -35,6 +35,15 @@ export const Success: Story = {
 	},
 };
 
+export const WithLink: Story = {
+	name: '.txt file (with href)',
+	args: {
+		file: createExampleFile({
+			href: '#',
+		}),
+	},
+};
+
 export const Image: Story = {
 	name: '.jpg file',
 	args: {

--- a/packages/react/src/file-upload/FileUploadFile.tsx
+++ b/packages/react/src/file-upload/FileUploadFile.tsx
@@ -6,6 +6,7 @@ import { Text } from '../text';
 import { Button } from '../button';
 import { LoadingDots } from '../loading';
 import { SuccessFilledIcon } from '../icon';
+import { TextLink } from '../text-link';
 import { FileUploadFileThumbnail } from './FileUploadFileThumbnail';
 import { FileWithStatus, formatFileSize, getImageThumbnail } from './utils';
 
@@ -20,7 +21,7 @@ export const FileUploadFile = ({
 	hideThumbnails,
 	onRemove,
 }: FileUploadFileProps) => {
-	const { name, size, status = 'none' } = file;
+	const { name, size, status = 'none', href } = file;
 	const showThumbnail = !hideThumbnails;
 	const imagePreview = useMemo(() => getImageThumbnail(file), [file]);
 	return (
@@ -46,15 +47,29 @@ export const FileUploadFile = ({
 							/>
 						</Box>
 					)}
-					<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
-						{name}
-						{size ? (
-							<Text css={{ whiteSpace: 'nowrap' }}>
-								{' '}
-								({formatFileSize(size)})
-							</Text>
-						) : null}
-					</Text>
+					{href ? (
+						<Text paddingY={1.5}>
+							<TextLink
+								href={href}
+								target="_blank"
+								rel="noopener noreferrer"
+								css={{ wordBreak: 'break-all' }}
+							>
+								{name}
+								{size ? ` (${formatFileSize(size)})` : null}
+							</TextLink>
+						</Text>
+					) : (
+						<Text paddingY={1.5} css={{ wordBreak: 'break-all' }}>
+							{name}
+							{size ? (
+								<Text css={{ whiteSpace: 'nowrap' }}>
+									{' '}
+									({formatFileSize(size)})
+								</Text>
+							) : null}
+						</Text>
+					)}
 				</Flex>
 			</Flex>
 			<Flex flexShrink={0} alignItems="center" paddingRight={1}>

--- a/packages/react/src/file-upload/test-utils.ts
+++ b/packages/react/src/file-upload/test-utils.ts
@@ -4,14 +4,21 @@ export function createExampleFile(args?: {
 	status?: FileStatus;
 	name?: string;
 	type?: string;
+	href?: string;
 }): FileWithStatus {
-	const { status, name = 'example.txt', type = 'text/plain' } = args || {};
+	const {
+		status,
+		name = 'example.txt',
+		type = 'text/plain',
+		href,
+	} = args || {};
 
 	const bits = ['examplefilecontent'];
 	const file: FileWithStatus = new File(bits, name, {
 		type,
 	});
 	file.status = status;
+	file.href = href;
 	return file;
 }
 

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -4,8 +4,9 @@ import { filesize } from './filesize';
 export type FileStatus = 'none' | 'uploading' | 'success';
 
 export type FileWithStatus = FileWithPath & {
+	/** Use to indicate the upload status of a file. */
 	status?: FileStatus;
-	/** Link to a webpage where the user can view/download the existing file (optional) */
+	/** Used to link to a webpage where the user can view/download the existing file. */
 	href?: string;
 };
 

--- a/packages/react/src/file-upload/utils.tsx
+++ b/packages/react/src/file-upload/utils.tsx
@@ -5,6 +5,8 @@ export type FileStatus = 'none' | 'uploading' | 'success';
 
 export type FileWithStatus = FileWithPath & {
 	status?: FileStatus;
+	/** Link to a webpage where the user can view/download the existing file (optional) */
+	href?: string;
 };
 
 export type RejectedFile = {


### PR DESCRIPTION
Add support for href attributes on files, so they can link to a view/download page.

Requested by Anand.

<img width="424" alt="image" src="https://github.com/steelthreads/agds-next/assets/12689383/5244e6cb-28aa-4de5-be69-8c5c3e7893ec">

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1460/storybook/?path=/story/forms-fileupload--instant-upload)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
