### PR TITLE
docs: Fix broken link on control group page

### DIFF
--- a/packages/react/src/control-group/docs/overview.mdx
+++ b/packages/react/src/control-group/docs/overview.mdx
@@ -9,7 +9,7 @@ relatedComponents: ['checkbox', 'radio']
 
 <DoHeading />
 
-- only use with [Checkboxes](/components/checkbox) and [Radios](/component/radios)
+- only use with [Checkboxes](/components/checkbox) and [Radios](/component/radio)
 - use for a short list of options
 - use to help users select one or more items
 - indicate if input is optional
@@ -34,7 +34,7 @@ Multiple [Checkboxes](components/checkbox) can be placed inside a Control group 
 
 ## Radios
 
-Multiple [Radios](components/checkbox) can be placed inside a Control group to allow users to select a single item from a list of options.
+Multiple [Radios](components/radio) can be placed inside a Control group to allow users to select a single item from a list of options.
 
 ```jsx live
 () => {


### PR DESCRIPTION
Fixed broken links on the Control group documentation page.