### PR TITLE
file-input: Fix hover states

### DIFF
--- a/.changeset/metal-donkeys-live.md
+++ b/.changeset/metal-donkeys-live.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+file-input: Fixed hover styles in file selector button

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -82,20 +82,24 @@ function useFileInputStyles({ disabled }: { disabled?: boolean }) {
 		variant: 'secondary',
 		block: false,
 	});
-	// '&:not(:disabled):hover' is not supported by the '::file-selector-button' component, but we still want the hover styles
-	const fileSelectorButtonStyles = {
-		...defaultButtonStyles,
-		margin: `0 ${mapSpacing(1)} 0 0`,
-		'&:hover': disabled
-			? { cursor: 'not-allowed' }
-			: defaultButtonStyles['&:not(:disabled):hover'],
-	};
+
 	return {
 		...fontGrid('sm', 'default'),
 		fontFamily: tokens.font.body,
 		color: boxPalette.foregroundText,
 
-		'&::file-selector-button': fileSelectorButtonStyles,
+		'&::file-selector-button': {
+			...defaultButtonStyles,
+			margin: `0 ${mapSpacing(1)} 0 0`,
+		},
+
+		'&:hover': {
+			cursor: 'pointer',
+			'&::file-selector-button': disabled
+				? { cursor: 'not-allowed' }
+				: // '&:not(:disabled):hover' is not supported by the '::file-selector-button' component, but we still want the hover styles
+				  defaultButtonStyles['&:not(:disabled):hover'],
+		},
 
 		'&:disabled': {
 			cursor: 'not-allowed',

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -49,7 +49,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		},
 		ref
 	) {
-		const styles = useFileInputStyles({ disabled });
+		const styles = useFileInputStyles();
 		return (
 			<Field
 				label={label}
@@ -75,7 +75,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 	}
 );
 
-function useFileInputStyles({ disabled }: { disabled?: boolean }) {
+function useFileInputStyles() {
 	// Use `buttonStyles` to generate the styles for a standard secondary button
 	const defaultButtonStyles = buttonStyles({
 		size: 'md',
@@ -95,15 +95,14 @@ function useFileInputStyles({ disabled }: { disabled?: boolean }) {
 
 		'&:hover': {
 			cursor: 'pointer',
-			'&::file-selector-button': disabled
-				? { cursor: 'not-allowed' }
-				: // '&:not(:disabled):hover' is not supported by the '::file-selector-button' component, but we still want the hover styles
-				  defaultButtonStyles['&:not(:disabled):hover'],
+			'&:not(:disabled)::file-selector-button':
+				defaultButtonStyles['&:not(:disabled):hover'],
 		},
 
 		'&:disabled': {
 			cursor: 'not-allowed',
 			opacity: 0.3,
+			'&::file-selector-button': { cursor: 'not-allowed' },
 		},
 
 		'&:focus': packs.outline,

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -44,7 +44,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 			message,
 			invalid,
 			id,
-			disabled = false,
+			disabled,
 			...props
 		},
 		ref
@@ -75,7 +75,7 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 	}
 );
 
-function useFileInputStyles({ disabled }: { disabled: boolean }) {
+function useFileInputStyles({ disabled }: { disabled?: boolean }) {
 	const fileSelectorButtonStyles = useMemo(() => {
 		// Use `buttonStyles` to generate the styles for a standard secondary button
 		const defaultButtonStyles = buttonStyles({

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes, useMemo } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 import { Field } from '../field';
 import { packs, boxPalette, fontGrid, mapSpacing, tokens } from '../core';
 import { buttonStyles } from '../button';
@@ -76,23 +76,20 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 );
 
 function useFileInputStyles({ disabled }: { disabled?: boolean }) {
-	const fileSelectorButtonStyles = useMemo(() => {
-		// Use `buttonStyles` to generate the styles for a standard secondary button
-		const defaultButtonStyles = buttonStyles({
-			size: 'md',
-			variant: 'secondary',
-			block: false,
-		});
-		return {
-			...defaultButtonStyles,
-			margin: `0 ${mapSpacing(1)} 0 0`,
-			// '&:not(:disabled):hover' is not supported by the '::file-selector-button' component, but we still want the hover styles
-			'&:hover': disabled
-				? { cursor: 'not-allowed' }
-				: defaultButtonStyles['&:not(:disabled):hover'],
-		};
-	}, [disabled]);
-
+	// Use `buttonStyles` to generate the styles for a standard secondary button
+	const defaultButtonStyles = buttonStyles({
+		size: 'md',
+		variant: 'secondary',
+		block: false,
+	});
+	// '&:not(:disabled):hover' is not supported by the '::file-selector-button' component, but we still want the hover styles
+	const fileSelectorButtonStyles = {
+		...defaultButtonStyles,
+		margin: `0 ${mapSpacing(1)} 0 0`,
+		'&:hover': disabled
+			? { cursor: 'not-allowed' }
+			: defaultButtonStyles['&:not(:disabled):hover'],
+	};
 	return {
 		...fontGrid('sm', 'default'),
 		fontFamily: tokens.font.body,

--- a/packages/react/src/file-input/FileInput.tsx
+++ b/packages/react/src/file-input/FileInput.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes, useMemo } from 'react';
 import { Field } from '../field';
 import { packs, boxPalette, fontGrid, mapSpacing, tokens } from '../core';
 import { buttonStyles } from '../button';
@@ -44,10 +44,12 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 			message,
 			invalid,
 			id,
+			disabled = false,
 			...props
 		},
 		ref
 	) {
+		const styles = useFileInputStyles({ disabled });
 		return (
 			<Field
 				label={label}
@@ -61,29 +63,10 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 				{(a11yProps) => (
 					<input
 						ref={ref}
-						css={{
-							...fontGrid('sm', 'default'),
-							fontFamily: tokens.font.body,
-							color: boxPalette.foregroundText,
-
-							'::file-selector-button': {
-								...buttonStyles({
-									size: 'md',
-									variant: 'secondary',
-									block: false,
-								}),
-								margin: `0 ${mapSpacing(1)} 0 0`,
-							},
-
-							'&:disabled': {
-								cursor: 'not-allowed',
-								opacity: 0.3,
-							},
-
-							'&:focus': packs.outline,
-						}}
+						css={styles}
 						{...a11yProps}
 						type="file"
+						disabled={disabled}
 						{...props}
 					/>
 				)}
@@ -91,3 +74,37 @@ export const FileInput = forwardRef<HTMLInputElement, FileInputProps>(
 		);
 	}
 );
+
+function useFileInputStyles({ disabled }: { disabled: boolean }) {
+	const fileSelectorButtonStyles = useMemo(() => {
+		// Use `buttonStyles` to generate the styles for a standard secondary button
+		const defaultButtonStyles = buttonStyles({
+			size: 'md',
+			variant: 'secondary',
+			block: false,
+		});
+		return {
+			...defaultButtonStyles,
+			margin: `0 ${mapSpacing(1)} 0 0`,
+			// '&:not(:disabled):hover' is not supported by the '::file-selector-button' component, but we still want the hover styles
+			'&:hover': disabled
+				? { cursor: 'not-allowed' }
+				: defaultButtonStyles['&:not(:disabled):hover'],
+		};
+	}, [disabled]);
+
+	return {
+		...fontGrid('sm', 'default'),
+		fontFamily: tokens.font.body,
+		color: boxPalette.foregroundText,
+
+		'&::file-selector-button': fileSelectorButtonStyles,
+
+		'&:disabled': {
+			cursor: 'not-allowed',
+			opacity: 0.3,
+		},
+
+		'&:focus': packs.outline,
+	};
+}

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-fhgp6v"
+      class="css-19x5ykz"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-fhgp6v"
+      class="css-19x5ykz"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-1tm6i4y-FileInput"
+      class="css-fhgp6v"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-1tm6i4y-FileInput"
+      class="css-fhgp6v"
       id="field-:r0:"
       type="file"
     />

--- a/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
+++ b/packages/react/src/file-input/__snapshots__/FileInput.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`FileInput invalid renders correctly 1`] = `
       aria-describedby="field-:r2:-message"
       aria-invalid="true"
       aria-required="false"
-      class="css-19x5ykz"
+      class="css-wl06dq"
       id="field-:r2:"
       type="file"
     />
@@ -91,7 +91,7 @@ exports[`FileInput renders correctly 1`] = `
     <input
       aria-invalid="false"
       aria-required="false"
-      class="css-19x5ykz"
+      class="css-wl06dq"
       id="field-:r0:"
       type="file"
     />


### PR DESCRIPTION
Fixed hover styles in the `FileInput` component. These hover styles are currently broken because `&:not(:disabled):hover` is not supported by the `::file-selector-button` selector.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1475/components/file-input)

| Before | After |
|--------|--------|
| <img width="821" alt="Screenshot 2023-11-02 at 2 01 17 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/4cadb413-3ef2-4b49-ad30-d886eaaabe4e"> | <img width="822" alt="Screenshot 2023-11-02 at 2 01 04 pm" src="https://github.com/steelthreads/agds-next/assets/6265154/a4bb05a6-2f70-4421-bd80-6d3ccb140da6"> | 

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
