### PR TITLE
combobox: Support 4 lines of text

### DIFF
--- a/.changeset/moody-games-think.md
+++ b/.changeset/moody-games-think.md
@@ -1,0 +1,7 @@
+---
+'@ag.ds-next/react': minor
+---
+
+combobox: Added support for react nodes in the `secondaryText` and `tertiaryText` props in the  `ComboboxRenderItem` component
+
+autocomplete: Added support for react nodes in the `secondaryText` and `tertiaryText` props in the  `AutocompleteRenderItem` component

--- a/packages/react/src/combobox/ComboboxRenderItem.stories.tsx
+++ b/packages/react/src/combobox/ComboboxRenderItem.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react';
+import { Fragment } from 'react';
 import { Avatar } from '../avatar';
 import { NotificationBadge } from '../notification-badge';
+import { Text } from '../text';
 import { Popover } from '../_popover';
 import { ComboboxListItem } from './ComboboxBase/ComboboxListItem';
 import {
@@ -81,5 +83,25 @@ export const WithEndElement: Story = {
 			<Avatar name={nameOption.fullName} size="sm" tone="action" />
 		),
 		endElement: <NotificationBadge value={2} tone="action" />,
+	},
+};
+
+export const WithThreeLinesText: Story = {
+	args: {
+		inputValue: '',
+		itemLabel: nameOption.fullName,
+		secondaryText: (
+			<Fragment>
+				<Text color="muted" fontSize="xs">
+					Role: {nameOption.jobTitle}
+				</Text>
+				<Text color="muted" fontSize="xs">
+					Status: {nameOption.status}
+				</Text>
+				<Text color="muted" fontSize="xs">
+					Another text line
+				</Text>
+			</Fragment>
+		),
 	},
 };

--- a/packages/react/src/combobox/ComboboxRenderItem.stories.tsx
+++ b/packages/react/src/combobox/ComboboxRenderItem.stories.tsx
@@ -86,7 +86,7 @@ export const WithEndElement: Story = {
 	},
 };
 
-export const WithThreeLinesText: Story = {
+export const WithFourLinesText: Story = {
 	args: {
 		inputValue: '',
 		itemLabel: nameOption.fullName,

--- a/packages/react/src/combobox/ComboboxRenderItem.tsx
+++ b/packages/react/src/combobox/ComboboxRenderItem.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from 'react';
+import { Fragment, isValidElement, ReactNode } from 'react';
 import { Text } from '../text';
 import { Stack } from '../stack';
 import { splitLabel } from './utils';
@@ -9,9 +9,9 @@ export type ComboboxRenderItemProps = {
 	/** The value of the Combobox/Autocomplete text input. */
 	inputValue: string;
 	/** Supporting text for the item. */
-	tertiaryText?: string;
+	tertiaryText?: ReactNode;
 	/** Supporting text for the item. */
-	secondaryText?: string;
+	secondaryText?: ReactNode;
 	/** Used to add decorative elements to the end of the item such as Indicator dot or Notification badge. */
 	beforeElement?: ReactNode;
 	/** Used to add decorative elements to the end of the item such as Indicator dot or Notification badge. */
@@ -34,14 +34,22 @@ export function ComboboxRenderItem({
 			<Stack as="span">
 				<span>{renderItemLabel(itemLabel, inputValue)}</span>
 				{secondaryText ? (
-					<Text color="muted" fontSize="xs">
-						{secondaryText}
-					</Text>
+					isValidElement(secondaryText) ? (
+						secondaryText
+					) : (
+						<Text color="muted" fontSize="xs">
+							{secondaryText}
+						</Text>
+					)
 				) : null}
 				{tertiaryText ? (
-					<Text color="muted" fontSize="xs">
-						{tertiaryText}
-					</Text>
+					isValidElement(tertiaryText) ? (
+						tertiaryText
+					) : (
+						<Text color="muted" fontSize="xs">
+							{tertiaryText}
+						</Text>
+					)
 				) : null}
 			</Stack>
 			{endElement ? (


### PR DESCRIPTION
A consuming team of AgDS needs to support 4 lines of text in the Combobox component. We currently have support for `secondaryText` and `tertiaryText`, but we don't allow a 4th line of text.

Rather than adding in a new prop `quaternaryText` (lol), I've added support for react nodes in the `secondaryText` and `tertiaryText` props in the `ComboboxRenderItem` component.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1476/storybook/index.html?path=/story/forms-combobox-primitives-comboboxrenderitem--with-four-lines-text)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.