### PR TITLE
box: Add new `textAlign` prop

### DIFF
--- a/packages/react/src/app-layout/AppLayoutHeaderAccount.tsx
+++ b/packages/react/src/app-layout/AppLayoutHeaderAccount.tsx
@@ -39,9 +39,9 @@ export function AppLayoutHeaderAccount({
 			alignItems="center"
 			flexShrink={0}
 			gap={0.5}
+			textAlign="right"
 			css={mq({
 				textDecoration: 'none',
-				textAlign: 'right',
 				maxWidth: ['16rem', '18rem'],
 				...(hasLink && {
 					'&:hover': {

--- a/packages/react/src/box/styles.ts
+++ b/packages/react/src/box/styles.ts
@@ -114,6 +114,7 @@ type TypographyProps = Partial<{
 	fontFamily: ResponsiveProp<Font>;
 	fontSize: ResponsiveProp<FontSize>;
 	lineHeight: LineHeight;
+	textAlign: ResponsiveProp<'left' | 'center' | 'right'>;
 }>;
 
 function typographyStyles({
@@ -121,6 +122,7 @@ function typographyStyles({
 	fontFamily,
 	fontSize: _fontSize,
 	lineHeight: _lineHeight = 'default',
+	textAlign,
 }: TypographyProps) {
 	const responsiveFontGrid = mapResponsiveProp(_fontSize, (t) =>
 		fontGrid(t, _lineHeight)
@@ -143,6 +145,7 @@ function typographyStyles({
 		fontFamily: mapResponsiveProp(fontFamily, (t) => tokens.font[t]),
 		fontSize,
 		lineHeight,
+		textAlign: mapResponsiveProp(textAlign),
 		'& ::selection': {
 			color: boxPalette.backgroundBody,
 			backgroundColor: boxPalette.foregroundAction,
@@ -459,6 +462,7 @@ export function boxStyles({
 	fontFamily,
 	fontSize,
 	lineHeight,
+	textAlign,
 	focus,
 	link,
 	highContrastOutline,
@@ -533,6 +537,7 @@ export function boxStyles({
 					fontFamily,
 					fontSize,
 					lineHeight,
+					textAlign,
 				}),
 
 				...(link ? linkStyles : undefined),

--- a/packages/react/src/file-upload/FileUpload.tsx
+++ b/packages/react/src/file-upload/FileUpload.tsx
@@ -250,7 +250,7 @@ export const FileUpload = forwardRef<HTMLInputElement, FileUploadProps>(
 								<Flex
 									flexDirection="column"
 									alignItems="center"
-									css={{ textAlign: 'center' }}
+									textAlign="center"
 								>
 									<Text
 										color={isDragActive ? 'action' : 'muted'}

--- a/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
+++ b/packages/react/src/file-upload/__snapshots__/FileUpload.test.tsx.snap
@@ -67,7 +67,7 @@ exports[`FileUpload Basic renders correctly 1`] = `
           type="file"
         />
         <div
-          class="css-107qz7x-boxStyles-FileUpload"
+          class="css-iij6ui-boxStyles"
         >
           <span
             class="css-g6olve-boxStyles-Text"

--- a/packages/react/src/loading/LoadingBlanketContent.tsx
+++ b/packages/react/src/loading/LoadingBlanketContent.tsx
@@ -10,7 +10,7 @@ export const LoadingBlanketContent = ({
 	children,
 }: LoadingBlanketContentProps) => (
 	<Content as="div">
-		<Stack gap={1} alignItems="center" css={{ textAlign: 'center' }}>
+		<Stack gap={1} alignItems="center" textAlign="center">
 			{children}
 		</Stack>
 	</Content>

--- a/packages/react/src/table/TableCaption.tsx
+++ b/packages/react/src/table/TableCaption.tsx
@@ -13,9 +13,7 @@ export const TableCaption = ({ children }: TableCaptionProps) => {
 			fontWeight="bold"
 			paddingBottom={0.5}
 			display="table-caption"
-			css={{
-				textAlign: 'left',
-			}}
+			textAlign="left"
 		>
 			{children}
 		</Text>

--- a/packages/react/src/table/TableCell.tsx
+++ b/packages/react/src/table/TableCell.tsx
@@ -36,7 +36,8 @@ export const TableCell = ({
 			fontWeight={fontWeight}
 			focus
 			display={display}
-			css={{ verticalAlign, textAlign }}
+			textAlign={textAlign}
+			css={{ verticalAlign }}
 			scope={scope}
 		>
 			{children}

--- a/packages/react/src/table/TableHeader.tsx
+++ b/packages/react/src/table/TableHeader.tsx
@@ -27,9 +27,7 @@ export const TableHeader = ({
 			fontWeight="bold"
 			focus
 			width={width}
-			css={{
-				textAlign,
-			}}
+			textAlign={textAlign}
 			{...props}
 		>
 			{children}

--- a/packages/react/src/table/TableHeaderSortable.tsx
+++ b/packages/react/src/table/TableHeaderSortable.tsx
@@ -40,9 +40,7 @@ export const TableHeaderSortable = ({
 				borderBottom: true,
 				borderBottomWidth: 'xl',
 			})}
-			css={{
-				textAlign,
-			}}
+			textAlign={textAlign}
 		>
 			<Flex
 				as={BaseButton}

--- a/packages/react/src/table/__snapshots__/Table.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/Table.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Table with TableCaption renders correctly 1`] = `
       id="table"
     >
       <caption
-        class="css-qt4zh6-boxStyles-Text-TableCaption"
+        class="css-1hi5g7n-boxStyles-Text"
       >
         Population of Australian states and territories, December 2015
       </caption>
@@ -21,25 +21,25 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-10w2jzf-boxStyles-TableHeader"
+            class="css-1gy3b36-boxStyles"
             scope="col"
           >
             Location
           </th>
           <th
-            class="css-1o9pafm-boxStyles-TableHeader"
+            class="css-gt3plj-boxStyles"
             scope="col"
           >
             Population
           </th>
           <th
-            class="css-1o9pafm-boxStyles-TableHeader"
+            class="css-gt3plj-boxStyles"
             scope="col"
           >
             Change over previous year %
           </th>
           <th
-            class="css-1o9pafm-boxStyles-TableHeader"
+            class="css-gt3plj-boxStyles"
             scope="col"
           >
             Change over previous decade %
@@ -53,23 +53,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             New South Wales
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             7,670,700
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             3.1%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             12.9%
           </td>
@@ -78,23 +78,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             Victoria
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             5,996,400
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             2.5%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             9.3%
           </td>
@@ -103,23 +103,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             Queensland
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             4,808,800
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             1.7%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             13.3%
           </td>
@@ -128,23 +128,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             Western Australia
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             2,603,900
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             2.3%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             11.6%
           </td>
@@ -153,23 +153,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             South Australia
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             1,702,800
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             2.0%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             6.8%
           </td>
@@ -178,23 +178,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             Tasmania
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             517,400
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             4%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             5.3%
           </td>
@@ -203,23 +203,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             Northern Territory
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             244,400
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             1.2%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             4.5%
           </td>
@@ -228,23 +228,23 @@ exports[`Table with TableCaption renders correctly 1`] = `
           class="css-0"
         >
           <th
-            class="css-eaiq6e-boxStyles-TableCell"
+            class="css-1qlct29-boxStyles-TableCell"
             scope="row"
           >
             Australian Capital Territory
           </th>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             393,000
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             2.4%
           </td>
           <td
-            class="css-1d44a78-boxStyles-TableCell"
+            class="css-18s06pf-boxStyles-TableCell"
           >
             9.6%
           </td>

--- a/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
+++ b/packages/react/src/table/__snapshots__/TableHeaderSortable.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TableHeaderSortable with sort direction: ASC renders correctly 1`] = `
       >
         <th
           aria-sort="ascending"
-          class="css-15z6ccd-boxStyles-TableHeaderSortable"
+          class="css-vjwr8b-boxStyles"
           scope="col"
         >
           <button
@@ -60,7 +60,7 @@ exports[`TableHeaderSortable with sort direction: DESC renders correctly 1`] = `
       >
         <th
           aria-sort="descending"
-          class="css-15z6ccd-boxStyles-TableHeaderSortable"
+          class="css-vjwr8b-boxStyles"
           scope="col"
         >
           <button
@@ -106,7 +106,7 @@ exports[`TableHeaderSortable with sort direction: undefined renders correctly 1`
         class="css-0"
       >
         <th
-          class="css-1qjmip9-boxStyles-TableHeaderSortable"
+          class="css-1m18mdw-boxStyles"
           scope="col"
         >
           <button


### PR DESCRIPTION
Added `text-align` prop to `BoxProps

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1485/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AhCAPABAFxu7AggDYCWA5gHYC8wA2gDrgwW4BOjANJo6%2BQBbZO3EERgAzQSC49%2BkgLoBfAHwAJGEQ0RMAdwisiUJAHo06JfQogFQA)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).
