### PR TITLE
combobox: Fixed stale options bug

### DIFF
--- a/.changeset/funny-students-happen.md
+++ b/.changeset/funny-students-happen.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/docs': patch
+---
+
+combobox: Fixed a bug where changing the value of the `options` prob would not immediately update the list of options.

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Ref, useState } from 'react';
+import { ReactNode, Ref, useEffect, useState } from 'react';
 import { useCombobox } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxBase } from './ComboboxBase';
@@ -57,6 +57,11 @@ export function Combobox<Option extends DefaultComboboxOption>({
 }: ComboboxProps<Option>) {
 	const inputId = useComboboxInputId(id);
 	const [inputItems, setInputItems] = useState<Option[]>(options);
+
+	// The effect ensures the list of options change whenever the `options` prop changes
+	useEffect(() => {
+		setInputItems(options);
+	}, [options]);
 
 	const combobox = useCombobox<Option>({
 		items: inputItems,


### PR DESCRIPTION
Fixed a bug in the `Combobox` component where changing the value of the `options` prop would not immediately update the list of options.

This is because in the `Combobox` component, we keep track of the list of options with internal `useState`, using the `options` prop as an initial value. But if that list of option prop ever changes, the options don't update until the component re-renders for whatever reason.

To view the current bug, [use this playroom link](https://design-system.agriculture.gov.au/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AlGA7WAnAfAHXQAJDgAKASkIF4cSDjjJ0BnAF0IG0IAHVgSwgsANIWYxWAeV4CWAXWqE0AQzCsAdAFcxAZVZLWMUh1nkA3AXoNlqzWICiAMwcxVpCtVrBLDUeIAqfAC2MBAarG6UNHREPgxiktKCzKQAwhIAqgByfigAmgD6EgAKfgCSEpnaZt4MAL4iAMwADC3VMcT1nCbm6DVY4hpYREgpEIEARhCTAB6EADZK4zBzVHgg2ssu7Dz8gmuEOzLMVMCHSbWEAPQ4PR21BEiXaJgwuAQgtUA). Notice how the list of options does not change, until you start typing in the combobox.

[View fixed bug](https://design-system.agriculture.gov.au/pr-preview/pr-1487/playroom/index.html#?code=N4Igxg9gJgpiBcIA8AlGA7WAnAfAHXQAJDgAKASkIF4cSDjjJ0BnAF0IG0IAHVgSwgsANIWYxWAeV4CWAXWqE0AQzCsAdAFcxAZVZLWMUh1nkA3AXoNlqzWICiAMwcxVpCtVrBLDUeIAqfAC2MBAarG6UNHREPgxiktKCzKQAwhIAqgByfigAmgD6EgAKfgCSEpnaZt4MAL4iAMwADC3VMcT1nCbm6DVY4hpYREgpEIEARhCTAB6EADZK4zBzVHgg2ssu7Dz8gmuEOzLMVMCHSbWEAPQ4PR21BEiXaJgwuAQgtUA)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

