### PR TITLE
combobox: Document `clearable` prop

### DIFF
--- a/.changeset/large-melons-drive.md
+++ b/.changeset/large-melons-drive.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+combobox: Added new `clearable` prop to `Combobox`. If true, the clear button ("x") will be rendered when there is a selected option.

--- a/packages/react/src/combobox/Combobox.stories.tsx
+++ b/packages/react/src/combobox/Combobox.stories.tsx
@@ -67,6 +67,13 @@ export const Block: Story = {
 	},
 };
 
+export const Clearable: Story = {
+	args: {
+		...defaultArgs,
+		clearable: true,
+	},
+};
+
 type NameOption = (typeof NAME_OPTIONS)[number];
 
 export const CustomRender: Story = {

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -45,8 +45,7 @@ export type ComboboxProps<
 	inputRef?: Ref<HTMLInputElement>;
 	/** Used to override the default item rendering. */
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
-
-	/** Clearable */
+	/** If true, the clear button will be rendered when there is a selected option. */
 	clearable?: boolean;
 };
 
@@ -74,8 +73,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 		onSelectedItemChange: ({ selectedItem = null }) => {
 			onChange?.(selectedItem);
 		},
-		onInputValueChange: ({ inputValue, isOpen, selectedItem }) => {
-			inputValue = inputValue?.toLowerCase() ?? '';
+		onInputValueChange: ({ inputValue, isOpen }) => {
 			if (isOpen) {
 				setInputItems(filterOptions(options, inputValue));
 			} else {

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -45,6 +45,9 @@ export type ComboboxProps<
 	inputRef?: Ref<HTMLInputElement>;
 	/** Used to override the default item rendering. */
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
+
+	/** Clearable */
+	clearable?: boolean;
 };
 
 export function Combobox<Option extends DefaultComboboxOption>({
@@ -71,7 +74,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 		onSelectedItemChange: ({ selectedItem = null }) => {
 			onChange?.(selectedItem);
 		},
-		onInputValueChange: ({ inputValue, isOpen }) => {
+		onInputValueChange: ({ inputValue, isOpen, selectedItem }) => {
 			inputValue = inputValue?.toLowerCase() ?? '';
 			if (isOpen) {
 				setInputItems(filterOptions(options, inputValue));

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -74,6 +74,7 @@ export function Combobox<Option extends DefaultComboboxOption>({
 			onChange?.(selectedItem);
 		},
 		onInputValueChange: ({ inputValue, isOpen }) => {
+			inputValue = inputValue?.toLowerCase() ?? '';
 			if (isOpen) {
 				setInputItems(filterOptions(options, inputValue));
 			} else {

--- a/packages/react/src/combobox/ComboboxAsync.stories.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.stories.tsx
@@ -78,6 +78,13 @@ export const Block: Story = {
 	},
 };
 
+export const Clearable: Story = {
+	args: {
+		...defaultArgs,
+		clearable: true,
+	},
+};
+
 type NameOption = (typeof NAME_OPTIONS)[number];
 
 export const CustomRender: Story = {

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -38,7 +38,7 @@ export type ComboboxAsyncProps<Option extends DefaultComboboxOption> = {
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
 	/** Message to display when no options match the users search term. */
 	emptyResultsMessage?: string;
-	/** If true, the clear button will be rendered. */
+	/** If true, the clear button will be rendered when there is a selected option. */
 	clearable?: boolean;
 	/** @deprecated This prop is no longer being used. When true, the dropdown will open when the user focuses on the element  */
 	openDropdownOnFocus?: boolean;

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -127,19 +127,19 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 					/>
 					{hasButtons && (
 						<ComboboxButtonContainer>
+							{showClearButton && (
+								<ComboboxClearButton
+									disabled={disabled}
+									onClick={combobox.reset}
+								/>
+							)}
+							{hasBothButtons && <ComboboxButtonDivider />}
 							{showDropdownTrigger && (
 								<ComboboxDropdownTrigger
 									{...combobox.getToggleButtonProps({
 										isOpen: combobox.isOpen,
 										disabled,
 									})}
-								/>
-							)}
-							{hasBothButtons && <ComboboxButtonDivider />}
-							{showClearButton && (
-								<ComboboxClearButton
-									disabled={disabled}
-									onClick={combobox.reset}
 								/>
 							)}
 						</ComboboxButtonContainer>

--- a/packages/react/src/combobox/docs/overview.mdx
+++ b/packages/react/src/combobox/docs/overview.mdx
@@ -215,6 +215,26 @@ Disabled input elements are unusable and can not be clicked. This prevents a use
 };
 ```
 
+## Clearable
+
+Use the `clearable` prop to render a clear ("x") button when there is a selected option.
+
+```jsx live
+() => {
+	const [value, setValue] = React.useState(null);
+	return (
+		<Combobox
+			label="Select country"
+			hint="Start typing to see results"
+			value={value}
+			onChange={setValue}
+			options={COUNTRY_OPTIONS}
+			clearable
+		/>
+	);
+};
+```
+
 ## Custom rendering
 
 Use the `renderItem` prop to customise how each option in the dropdown list is rendered. Inside this function, you can make use of the `ComboboxRenderItem` component to style extra information.


### PR DESCRIPTION
Added new `clearable` prop to `Combobox`. If true, the clear button ("x") will be rendered when there is a selected option. `clearable` is already a prop in `ComboboxAsync`, but it didn't have docs or stories, and the ordering of the buttons was incorrect.

- [Preview clearable documentation](https://design-system.agriculture.gov.au/pr-preview/pr-1489/components/combobox#clearable)
- [Preview clearable storybook](https://design-system.agriculture.gov.au/pr-preview/pr-1489/storybook/index.html?path=/story/forms-combobox-combobox--clearable)
- [Preview async storybook](https://design-system.agriculture.gov.au/pr-preview/pr-1489/storybook/index.html?path=/story/forms-combobox-comboboxasync--clearable)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets

