### PR TITLE
docs: Loading, empty and error states space

### DIFF
--- a/docs/content/patterns/loading-error-empty-states/index.mdx
+++ b/docs/content/patterns/loading-error-empty-states/index.mdx
@@ -3,7 +3,7 @@ title: Loading, empty and error states
 group: Patterns
 description: When loading data in an application, it is important to consider and design for loading, empty, and error states. These states will help set user expectations and prevent them from assuming that the interface is unresponsive.
 figmaTemplateNodeId: 18846-97172
-storybookPath: /story/patterns-data-loading
+storybookPath: /story/patterns-data-loading-cards--basic
 relatedComponents: ['skeleton', 'icon', 'button', 'text', 'heading']
 ---
 
@@ -112,11 +112,13 @@ Below is an example of an error that occured at the component level.
 <Flex gap={0.75}>
 	<AlertFilledIcon color="error" />
 	<Stack gap={1} alignItems="flex-start">
-		<Text>
+		<Stack gap={0.5}>
 			<Text fontWeight="bold">Failed to load</Text>
-			<br />
-			There was an error loading the data. Click retry to try again.
-		</Text>
+			<Text>
+				There was an error loading the data. Click retry to try again.
+			</Text>
+		</Stack>
+
 		<Button variant="text">Retry</Button>
 	</Stack>
 </Flex>
@@ -175,11 +177,10 @@ Below is an example of an empty state at the component level.
 <Flex gap={0.75}>
 	<HelpIcon color="muted" />
 	<Stack gap={1} alignItems="flex-start">
-		<Text>
+		<Stack gap={0.5}>
 			<Text fontWeight="bold">No results found</Text>
-			<br />
-			Try adjusting your filter options.
-		</Text>
+			<Text>Try adjusting your filter options.</Text>
+		</Stack>
 		<Button variant="text">Clear filters</Button>
 	</Stack>
 </Flex>


### PR DESCRIPTION
- Component level error state
- Component level empty state
- Current gap: 0
- Should be: 0.5rem (8px)

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1494/patterns/loading-error-empty-states)