### PR TITLE
combobox: Add `onBlur` and `onFocus` events

### DIFF
--- a/.changeset/dull-houses-return.md
+++ b/.changeset/dull-houses-return.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/minor': minor
+---
+
+combobox: Added support for `onBlur` and `onFocus` props to all Combobox component variants (`Combobox`, `ComboboxAsync`, `ComboboxMulti`, `ComboboxAsyncMulti`)

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -83,6 +83,31 @@ describe('Combobox', () => {
 		expect(inputRef.current?.id).toBe(id);
 	});
 
+	it('accepts `onFocus` and `onBlur` props', async () => {
+		const onFocus = jest.fn();
+		const onBlur = jest.fn();
+		const { container } = renderCombobox({ onFocus, onBlur });
+
+		const input = container.querySelector('input');
+		expect(input).toBeInTheDocument();
+		if (!input) return;
+
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(input).toHaveAttribute('aria-expanded', 'true');
+
+		// Check the events have been called correctly
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(0);
+
+		// After blur of the input, // check the events have been called correctly
+		await act(async () => await input.blur());
+		expect(input).not.toHaveAttribute('aria-expanded', 'true');
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
+
 	it('listBox is described by the label correctly', async () => {
 		const { container } = renderCombobox();
 		const label = container.querySelector('label');

--- a/packages/react/src/combobox/Combobox.test.tsx
+++ b/packages/react/src/combobox/Combobox.test.tsx
@@ -92,12 +92,8 @@ describe('Combobox', () => {
 		expect(input).toBeInTheDocument();
 		if (!input) return;
 
-		// Click the input, which should focus the element
-		await act(async () => await input.click());
-		await waitFor(() => expect(input).toHaveFocus());
-		expect(input).toHaveAttribute('aria-expanded', 'true');
-
-		// Check the events have been called correctly
+		// After focus of the input, check the events have been called correctly
+		await act(async () => await input.focus());
 		expect(onFocus).toHaveBeenCalledTimes(1);
 		expect(onBlur).toHaveBeenCalledTimes(0);
 

--- a/packages/react/src/combobox/Combobox.tsx
+++ b/packages/react/src/combobox/Combobox.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Ref, useEffect, useState } from 'react';
+import { FocusEventHandler, ReactNode, Ref, useEffect, useState } from 'react';
 import { useCombobox } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxBase } from './ComboboxBase';
@@ -37,6 +37,10 @@ export type ComboboxProps<
 	value?: Option | null;
 	/** Function to be fired following a change event. */
 	onChange?: (value: Option | null) => void;
+	/** Function to be fired following a focus event. */
+	onFocus?: FocusEventHandler<HTMLInputElement>;
+	/** Function to be fired following a blur event. */
+	onBlur?: FocusEventHandler<HTMLInputElement>;
 	/** The list of options to show in the dropdown. */
 	options: Option[];
 	/** Message to display when no options match the users search term. */

--- a/packages/react/src/combobox/ComboboxAsync.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.test.tsx
@@ -136,4 +136,29 @@ describe('ComboboxAsync', () => {
 		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
 		expect(inputRef.current?.id).toBe(id);
 	});
+
+	it('accepts `onFocus` and `onBlur` props', async () => {
+		const onFocus = jest.fn();
+		const onBlur = jest.fn();
+		const { container } = renderComboboxAsync({ onFocus, onBlur });
+
+		const input = container.querySelector('input');
+		expect(input).toBeInTheDocument();
+		if (!input) return;
+
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(input).toHaveAttribute('aria-expanded', 'true');
+
+		// Check the events have been called correctly
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(0);
+
+		// After blur of the input, // check the events have been called correctly
+		await act(async () => await input.blur());
+		expect(input).not.toHaveAttribute('aria-expanded', 'true');
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/react/src/combobox/ComboboxAsync.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.test.tsx
@@ -146,12 +146,8 @@ describe('ComboboxAsync', () => {
 		expect(input).toBeInTheDocument();
 		if (!input) return;
 
-		// Click the input, which should focus the element
-		await act(async () => await input.click());
-		await waitFor(() => expect(input).toHaveFocus());
-		expect(input).toHaveAttribute('aria-expanded', 'true');
-
-		// Check the events have been called correctly
+		// After focus of the input, check the events have been called correctly
+		await act(async () => await input.focus());
 		expect(onFocus).toHaveBeenCalledTimes(1);
 		expect(onBlur).toHaveBeenCalledTimes(0);
 

--- a/packages/react/src/combobox/ComboboxAsync.tsx
+++ b/packages/react/src/combobox/ComboboxAsync.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, RefObject } from 'react';
+import { FocusEventHandler, ReactNode, RefObject } from 'react';
 import { useCombobox } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxBase } from './ComboboxBase';
@@ -32,6 +32,10 @@ export type ComboboxAsyncProps<Option extends DefaultComboboxOption> = {
 	value?: Option | null;
 	/** Function to be fired following a change event. */
 	onChange?: (value: Option | null) => void;
+	/** Function to be fired following a focus event. */
+	onFocus?: FocusEventHandler<HTMLInputElement>;
+	/** Function to be fired following a blur event. */
+	onBlur?: FocusEventHandler<HTMLInputElement>;
 	/** Function to be used when options need to be loaded over the network. */
 	loadOptions: (inputValue: string) => Promise<Option[]>;
 	/** Used to override the default item rendering. */

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -141,12 +141,8 @@ describe('ComboboxAsyncMulti', () => {
 		expect(input).toBeInTheDocument();
 		if (!input) return;
 
-		// Click the input, which should focus the element
-		await act(async () => await input.click());
-		await waitFor(() => expect(input).toHaveFocus());
-		expect(input).toHaveAttribute('aria-expanded', 'true');
-
-		// Check the events have been called correctly
+		// After focus of the input, check the events have been called correctly
+		await act(async () => await input.focus());
 		expect(onFocus).toHaveBeenCalledTimes(1);
 		expect(onBlur).toHaveBeenCalledTimes(0);
 

--- a/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.test.tsx
@@ -131,4 +131,29 @@ describe('ComboboxAsyncMulti', () => {
 		expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
 		expect(inputRef.current?.id).toBe(id);
 	});
+
+	it('accepts `onFocus` and `onBlur` props', async () => {
+		const onFocus = jest.fn();
+		const onBlur = jest.fn();
+		const { container } = renderComboboxAsyncMulti({ onFocus, onBlur });
+
+		const input = container.querySelector('input');
+		expect(input).toBeInTheDocument();
+		if (!input) return;
+
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(input).toHaveAttribute('aria-expanded', 'true');
+
+		// Check the events have been called correctly
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(0);
+
+		// After blur of the input, // check the events have been called correctly
+		await act(async () => await input.blur());
+		expect(input).not.toHaveAttribute('aria-expanded', 'true');
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/react/src/combobox/ComboboxAsyncMulti.tsx
+++ b/packages/react/src/combobox/ComboboxAsyncMulti.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, Ref, useCallback, useMemo, useState } from 'react';
+import {
+	FocusEventHandler,
+	ReactNode,
+	Ref,
+	useCallback,
+	useMemo,
+	useState,
+} from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxMultiBase } from './ComboboxBase';
@@ -36,6 +43,10 @@ export type ComboboxAsyncMultiProps<Option extends DefaultComboboxOption> = {
 	value?: Option[];
 	/** Function to be fired following a change event. */
 	onChange?: (value: Option[]) => void;
+	/** Function to be fired following a focus event. */
+	onFocus?: FocusEventHandler<HTMLInputElement>;
+	/** Function to be fired following a blur event. */
+	onBlur?: FocusEventHandler<HTMLInputElement>;
 	/** Function to be used when options need to be loaded over the network. */
 	loadOptions: (inputValue: string) => Promise<Option[]>;
 	/** Used to override the default item rendering. */

--- a/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxBase.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, Ref } from 'react';
+import { FocusEventHandler, Fragment, ReactNode, Ref } from 'react';
 import { UseComboboxReturnValue } from 'downshift';
 import { FieldMaxWidth, packs } from '../../core';
 import { Popover, usePopover } from '../../_popover';
@@ -36,13 +36,16 @@ type ComboboxBaseProps<Option extends DefaultComboboxOption> = {
 	clearable?: boolean;
 	isAutocomplete: boolean;
 	// Downshift
-	inputRef?: Ref<HTMLInputElement>;
 	loading?: boolean;
 	inputItems?: Option[];
 	networkError?: boolean;
 	emptyResultsMessage?: string;
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
 	combobox: UseComboboxReturnValue<Option>;
+	// input props
+	inputRef?: Ref<HTMLInputElement>;
+	onBlur?: FocusEventHandler<HTMLInputElement>;
+	onFocus?: FocusEventHandler<HTMLInputElement>;
 };
 
 export function ComboboxBase<Option extends DefaultComboboxOption>({
@@ -66,6 +69,8 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 	combobox,
 	inputItems,
 	inputRef: inputRefProp,
+	onBlur,
+	onFocus,
 	renderItem = (item, inputValue) => (
 		<ComboboxRenderItem itemLabel={item.label} inputValue={inputValue} />
 	),
@@ -123,6 +128,8 @@ export function ComboboxBase<Option extends DefaultComboboxOption>({
 							ref: inputRefProp,
 							type: 'text',
 							name: inputName,
+							onBlur,
+							onFocus,
 						})}
 					/>
 					{hasButtons && (

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -5,6 +5,7 @@ import {
 	MouseEvent,
 	useRef,
 	ReactNode,
+	FocusEventHandler,
 } from 'react';
 import {
 	UseComboboxReturnValue,
@@ -63,8 +64,10 @@ type ComboboxMultiBaseProps<Option extends DefaultComboboxOption> = {
 	networkError?: boolean;
 	emptyResultsMessage?: string;
 	renderItem?: (item: Option, inputValue: string) => ReactNode;
-	// input ref
+	// input props
 	inputRef?: Ref<HTMLInputElement>;
+	onBlur?: FocusEventHandler<HTMLInputElement>;
+	onFocus?: FocusEventHandler<HTMLInputElement>;
 };
 
 export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
@@ -91,6 +94,8 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 	setSelectedItems,
 	multiSelection,
 	inputRef: inputRefProp,
+	onBlur,
+	onFocus,
 }: ComboboxMultiBaseProps<Option>) {
 	const inputRef = useRef<HTMLInputElement>(null);
 
@@ -188,8 +193,20 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 										ref: inputRefs,
 										type: 'text',
 										preventKeyAction: combobox.isOpen,
-										onFocus: setInputFocused,
-										onBlur: setInputBlurred,
+										onFocus: (event) => {
+											// Ignoring typescript here as the downshift has typed this event with `HTMLElement`, not `HTMLInputElement` element
+											// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+											// @ts-ignore
+											onFocus?.(event);
+											setInputFocused();
+										},
+										onBlur: (event) => {
+											// Ignoring typescript here as the downshift has typed this event with `HTMLElement`, not `HTMLInputElement` element
+											// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+											// @ts-ignore
+											onBlur?.(event);
+											setInputBlurred();
+										},
 									})
 								)}
 								css={styles.input}

--- a/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
+++ b/packages/react/src/combobox/ComboboxBase/ComboboxMultiBase.tsx
@@ -6,6 +6,7 @@ import {
 	useRef,
 	ReactNode,
 	FocusEventHandler,
+	FocusEvent,
 } from 'react';
 import {
 	UseComboboxReturnValue,
@@ -193,17 +194,11 @@ export function ComboboxMultiBase<Option extends DefaultComboboxOption>({
 										ref: inputRefs,
 										type: 'text',
 										preventKeyAction: combobox.isOpen,
-										onFocus: (event) => {
-											// Ignoring typescript here as the downshift has typed this event with `HTMLElement`, not `HTMLInputElement` element
-											// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-											// @ts-ignore
+										onFocus: (event: FocusEvent<HTMLInputElement>) => {
 											onFocus?.(event);
 											setInputFocused();
 										},
-										onBlur: (event) => {
-											// Ignoring typescript here as the downshift has typed this event with `HTMLElement`, not `HTMLInputElement` element
-											// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-											// @ts-ignore
+										onBlur: (event: FocusEvent<HTMLInputElement>) => {
 											onBlur?.(event);
 											setInputBlurred();
 										},

--- a/packages/react/src/combobox/ComboboxMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.test.tsx
@@ -109,4 +109,29 @@ describe('ComboboxMulti', () => {
 		expect(listBox).toBeInTheDocument();
 		expect(listBox).toHaveAttribute('aria-labelledby', label?.id);
 	});
+
+	it('accepts `onFocus` and `onBlur` props', async () => {
+		const onFocus = jest.fn();
+		const onBlur = jest.fn();
+		const { container } = renderComboboxMulti({ onFocus, onBlur });
+
+		const input = container.querySelector('input');
+		expect(input).toBeInTheDocument();
+		if (!input) return;
+
+		// Click the input, which should focus the element
+		await act(async () => await input.click());
+		await waitFor(() => expect(input).toHaveFocus());
+		expect(input).toHaveAttribute('aria-expanded', 'true');
+
+		// Check the events have been called correctly
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(0);
+
+		// After blur of the input, // check the events have been called correctly
+		await act(async () => await input.blur());
+		expect(input).not.toHaveAttribute('aria-expanded', 'true');
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onBlur).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/react/src/combobox/ComboboxMulti.test.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.test.tsx
@@ -119,12 +119,8 @@ describe('ComboboxMulti', () => {
 		expect(input).toBeInTheDocument();
 		if (!input) return;
 
-		// Click the input, which should focus the element
-		await act(async () => await input.click());
-		await waitFor(() => expect(input).toHaveFocus());
-		expect(input).toHaveAttribute('aria-expanded', 'true');
-
-		// Check the events have been called correctly
+		// After focus of the input, check the events have been called correctly
+		await act(async () => await input.focus());
 		expect(onFocus).toHaveBeenCalledTimes(1);
 		expect(onBlur).toHaveBeenCalledTimes(0);
 

--- a/packages/react/src/combobox/ComboboxMulti.tsx
+++ b/packages/react/src/combobox/ComboboxMulti.tsx
@@ -1,4 +1,11 @@
-import { ReactNode, Ref, useCallback, useMemo, useState } from 'react';
+import {
+	FocusEventHandler,
+	ReactNode,
+	Ref,
+	useCallback,
+	useMemo,
+	useState,
+} from 'react';
 import { useCombobox, useMultipleSelection } from 'downshift';
 import { FieldMaxWidth } from '../core';
 import { ComboboxMultiBase } from './ComboboxBase';
@@ -35,6 +42,10 @@ export type ComboboxMultiProps<Option extends DefaultComboboxOption> = {
 	value?: Option[];
 	/** Function to be fired following a change event. */
 	onChange?: (value: Option[]) => void;
+	/** Function to be fired following a focus event. */
+	onFocus?: FocusEventHandler<HTMLInputElement>;
+	/** Function to be fired following a blur event. */
+	onBlur?: FocusEventHandler<HTMLInputElement>;
 	/** The list of options to show in the dropdown. */
 	options: Option[];
 	/** Used to override the default item rendering. */


### PR DESCRIPTION
Added support for `onBlur` and `onFocus` props to all Combobox component variants (`Combobox`, `ComboboxAsync`, `ComboboxMulti`, `ComboboxAsyncMulti`).

- [View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1498/components/combobox)
- [View preview in Playroom](https://design-system.agriculture.gov.au/pr-preview/pr-1498/playroom/index.html#?code=N4Igxg9gJgpiBcIA8BlALgQzAawAQHMMAHAXmAGYBfXIjKKASwDt8yBGagWwwA8B1BlDQALEgB0QAVgAMAJxicJAPjFNcuJAGEInAEYR9PVevUAbDLpinxIbXoMQjIYyYhE0DCEwDOZANouJrjAuABuGKYArjDwuBIYEgA0uOaWprESAPLunmoAghK4lImBJiHhUTFxILpJKRZWGSDZHl64AEKFxaXq5RHRTWB1qY3VLbm4ml0laiYAupSluqYQOKVeAGKrkb7AABQwoTBMaACUuCRKuJA%2BEKYwAHQr%2BHsSm9vekzr6hnWHx2dFrN1F52lFZGQDkcTudLtcvN47o9nq8QKDwV97L8QMl-jCgeoAPQqJguLTfBw8ACykVMHlKI2sEjsP0cNLpDAk6xyCP8PWCYX6VXiwwa6TGPPy035fUqTVqOPqaSa4zanRARRmQV6grl1SGisZKslk2lwNwCyWKzW5veYB2kLxZwuVxuiPuTwgLzeTC29s%2BLMp7PpiqdpwJriYYMiEP2YZd8NuHpRPujskxrOptJDuOhgJcxNUZMDhjy3gAnkwhubGTYS44y5WDQyIHRVT4yBgK1XcAAzSJV1pqFZtyXePbMIiRNAANSF52A-MJhNwKAYnFpGDQMFwGFw3hWAHdcEwYGhDxBZHgwBFTPyMIeMAw0CeYMeAAqyHQMbwwPZ7eR3SOWErl-NAABV1xgCBpwAmAgJgZI2BkaRTlOABufl5DQGM1E0TIAFUADlwIAJQATQAfUyd9wIASUyIiUEw81KAjdRllWbB1l9D5HTzEDE3dZEvVRO0dgzSlGyrP4BPY3B0RjfiAUEt0kU9b00SjDF6x4aSDVzFSI0LUlZnJLEG27MBg05GsxTrClSysmyuRrVsoHbXYuybPsBzAIcUnczyJyYKdZ3nYIlxXNcN3Mbdd33I9X3PS9r1ve9H2fV8Py-Tgfz-OCEMEsDIM4aDYMAu4jiQlC0JY7VcGw3DJkIkiKOo2iGKY%2BqTDYq0uJ4v0HTjASEzU5NRJ9IaA0cyymxc0M5J4tNlJhMaEXUlMtLTSSnPm7NOUWoyCxJJBCXQLBsBJHEQEPQQRG8BA-AATmegAmBYgA)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [x] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
