### PR TITLE
control-group: Fix broken links

### DIFF
--- a/packages/react/src/control-group/docs/overview.mdx
+++ b/packages/react/src/control-group/docs/overview.mdx
@@ -9,7 +9,7 @@ relatedComponents: ['checkbox', 'radio']
 
 <DoHeading />
 
-- only use with [Checkboxes](/components/checkbox) and [Radios](/component/radio)
+- only use with [Checkboxes](/components/checkbox) and [Radios](/component/radios)
 - use for a short list of options
 - use to help users select one or more items
 - indicate if input is optional


### PR DESCRIPTION
Fixed broken link to the Radio component from the Control Group page.