### PR TITLE
progress-indicator: Fix spacing bugs

### DIFF
--- a/.changeset/proud-jars-complain.md
+++ b/.changeset/proud-jars-complain.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': patch
+---
+
+progress-indicator: Tweaked padding and spacing values of list item elements to more closely match designs

--- a/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
+++ b/packages/react/src/progress-indicator/ProgressIndicatorItem.tsx
@@ -119,9 +119,9 @@ const ProgressIndicatorItem = ({
 					as="span"
 					flexDirection="column-reverse"
 					flexGrow={1}
-					gap={0}
+					gap={0.25}
 					justifyContent="center"
-					paddingY={0.75}
+					paddingY={1}
 					fontFamily="body"
 					fontWeight={active ? 'bold' : 'normal'}
 					borderBottom

--- a/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/react/src/progress-indicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <span
-                class="css-1bt7nbc-boxStyles"
+                class="css-kcfiwy-boxStyles"
                 data-agds-progress-indicator-item-text-container=""
               >
                 <span
@@ -172,7 +172,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <span
-                class="css-48tv73-boxStyles"
+                class="css-vly98i-boxStyles"
                 data-agds-progress-indicator-item-text-container=""
               >
                 <span
@@ -233,7 +233,7 @@ exports[`ProgressIndicator With anchors renders correctly 1`] = `
                 />
               </span>
               <span
-                class="css-1bt7nbc-boxStyles"
+                class="css-kcfiwy-boxStyles"
                 data-agds-progress-indicator-item-text-container=""
               >
                 <span
@@ -355,7 +355,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 />
               </span>
               <span
-                class="css-1bt7nbc-boxStyles"
+                class="css-kcfiwy-boxStyles"
                 data-agds-progress-indicator-item-text-container=""
               >
                 <span
@@ -429,7 +429,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 />
               </span>
               <span
-                class="css-48tv73-boxStyles"
+                class="css-vly98i-boxStyles"
                 data-agds-progress-indicator-item-text-container=""
               >
                 <span
@@ -490,7 +490,7 @@ exports[`ProgressIndicator With buttons renders correctly 1`] = `
                 />
               </span>
               <span
-                class="css-1bt7nbc-boxStyles"
+                class="css-kcfiwy-boxStyles"
                 data-agds-progress-indicator-item-text-container=""
               >
                 <span


### PR DESCRIPTION
Tweaked padding and spacing values of list item elements in the [Progress Indicator](https://design-system.agriculture.gov.au/components/progress-indicator) component to more closely match designs.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1500/components/progress-indicator)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [x] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [ ] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.
