### PR TITLE
docs: Various broad a11y fixes to docs & docs components

### DIFF
--- a/.changeset/few-humans-grin.md
+++ b/.changeset/few-humans-grin.md
@@ -1,5 +1,4 @@
 ---
-'@ag.ds-next/react': patch
 '@ag.ds-next/docs': patch
 ---
 

--- a/.changeset/few-humans-grin.md
+++ b/.changeset/few-humans-grin.md
@@ -1,0 +1,6 @@
+---
+'@ag.ds-next/react': patch
+'@ag.ds-next/docs': patch
+---
+
+Fix many, simple a11y errors detected by axe such as incorrect landmarks, incorrect heading order and incorrect use of aria attributes.

--- a/docs/components/Code.tsx
+++ b/docs/components/Code.tsx
@@ -115,7 +115,7 @@ function LiveCode({
 				</CardHeader>
 			)}
 			<LivePreview
-				aria-label="Rendered code snippet example"
+				aria-label={`Rendered code snippet example ${id}`}
 				// Prevents prose styles from being inherited in live code examples (except for the prose example)
 				className={enableProse ? undefined : unsetProseStylesClassname}
 				css={{
@@ -125,6 +125,7 @@ function LiveCode({
 					fontFamily: tokens.font.body, // because pre applies gets monospace font.
 					padding: mapSpacing(1.5),
 				}}
+				role="region"
 			/>
 			<Flex
 				flexWrap="wrap"
@@ -221,7 +222,6 @@ const StaticCode = ({
 			rounded
 			borderColor="muted"
 			css={{
-				overflow: 'hidden',
 				marginTop: mapSpacing(1.5),
 
 				pre: {
@@ -242,6 +242,7 @@ const StaticCode = ({
 						<pre
 							className={[className, unsetProseStylesClassname].join(' ')}
 							style={style}
+							tabIndex={0}
 						>
 							<code>
 								{tokens.map((line, lineKey) => (

--- a/docs/components/PageLayout.tsx
+++ b/docs/components/PageLayout.tsx
@@ -5,7 +5,6 @@ import { Flex } from '@ag.ds-next/react/flex';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Columns, Column } from '@ag.ds-next/react/columns';
 import { SideNav } from '@ag.ds-next/react/side-nav';
-import { SkipLinks, SkipLinksProps } from '@ag.ds-next/react/skip-link';
 import { Breadcrumbs, BreadcrumbsProps } from '@ag.ds-next/react/breadcrumbs';
 import { EditPage } from './EditPage';
 
@@ -22,8 +21,6 @@ type PageLayoutProps = PropsWithChildren<{
 		titleLink: string;
 		items: ComponentProps<typeof SideNav>['items'];
 	};
-	/** The skip links to render. */
-	skipLinks?: SkipLinksProps['links'];
 }>;
 
 export function PageLayout({
@@ -32,7 +29,6 @@ export function PageLayout({
 	children,
 	editPath,
 	sideNav,
-	skipLinks,
 }: PageLayoutProps) {
 	const router = useRouter();
 	return (
@@ -61,7 +57,6 @@ export function PageLayout({
 					columnSpan={{ xs: 12, md: 8 }}
 					columnStart={{ lg: sideNav ? 5 : 1 }}
 				>
-					{skipLinks?.length ? <SkipLinks links={skipLinks} /> : null}
 					<Stack flexGrow={1} gap={3}>
 						{breadcrumbs?.length ? <Breadcrumbs links={breadcrumbs} /> : null}
 						{children}

--- a/docs/components/PkgLayout.tsx
+++ b/docs/components/PkgLayout.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import { ButtonLink } from '@ag.ds-next/react/button';
 import { Flex } from '@ag.ds-next/react/flex';
 import { Prose } from '@ag.ds-next/react/prose';
-import { SkipLinksProps } from '@ag.ds-next/react/skip-link';
 import { SubNav } from '@ag.ds-next/react/sub-nav';
 import { Text } from '@ag.ds-next/react/text';
 import { TextLink } from '@ag.ds-next/react/text-link';
@@ -21,13 +20,11 @@ export function PkgLayout({
 	pkg,
 	navLinks,
 	breadcrumbs,
-	skipLinks,
 	editPath,
 }: PropsWithChildren<{
 	pkg: Pkg;
 	navLinks: Awaited<ReturnType<typeof getPkgNavLinks>>;
 	breadcrumbs: Awaited<ReturnType<typeof getPkgBreadcrumbs>>;
-	skipLinks?: SkipLinksProps['links'];
 	editPath?: string;
 }>) {
 	const { asPath } = useRouter();
@@ -42,7 +39,6 @@ export function PkgLayout({
 				}}
 				editPath={editPath}
 				breadcrumbs={breadcrumbs}
-				skipLinks={skipLinks}
 			>
 				<PageTitle
 					title={pkg.title}

--- a/docs/components/mdxComponents.tsx
+++ b/docs/components/mdxComponents.tsx
@@ -12,7 +12,11 @@ import type { MDXRemoteProps } from 'next-mdx-remote';
 import Link from 'next/link';
 import { Box } from '@ag.ds-next/react/box';
 import { proseBlockClassname } from '@ag.ds-next/react/prose';
-import { PageAlert, PageAlertProps } from '@ag.ds-next/react/page-alert';
+import {
+	PageAlert,
+	PageAlertProps,
+	PageAlertTitle,
+} from '@ag.ds-next/react/page-alert';
 import { ButtonLink } from '@ag.ds-next/react/button';
 import {
 	SummaryList,
@@ -99,7 +103,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 		</Box>
 	),
 	ButtonLink,
-	FigmaEmbed: ({ src }: { src: string }) => (
+	FigmaEmbed: ({ src, title }: { src: string; title: string }) => (
 		<Box
 			width="100%"
 			height="0"
@@ -118,6 +122,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 				allowFullScreen
 				height="100%"
 				width="100%"
+				title={title}
 				css={{
 					position: 'absolute',
 					top: 0,
@@ -154,6 +159,7 @@ export const mdxComponents: MDXRemoteProps['components'] = {
 			<PageAlert {...props} />
 		</div>
 	),
+	PageAlertTitle,
 	ComponentPropsTable: ({ name }: { name: string }) => {
 		if (!(name in generatedComponentPropsData)) {
 			return (

--- a/docs/components/prism-theme.ts
+++ b/docs/components/prism-theme.ts
@@ -19,7 +19,6 @@ export const prismTheme = {
 				'boolean',
 				'variable',
 				'tag',
-
 				'builtin',
 				'char',
 				'class-name',
@@ -45,7 +44,7 @@ export const prismTheme = {
 				'deleted',
 			],
 			style: {
-				color: '#f55d70',
+				color: '#f56172',
 			},
 		},
 		{

--- a/docs/content/content/content-styles.mdx
+++ b/docs/content/content/content-styles.mdx
@@ -251,7 +251,7 @@ For more information, see Structuring headings and labels in [Content structure]
 	<H2>What do you want to export or prepare for export?</H2>
 
 	<Stack as="ul" gap={1}>
-		<Card shadow clickable>
+		<Card as="li" shadow clickable>
 			<CardInner>
 				<Stack gap={1}>
 					<H3>
@@ -265,7 +265,7 @@ For more information, see Structuring headings and labels in [Content structure]
 			</CardInner>
 		</Card>
 
-		<Card shadow clickable>
+		<Card as="li" shadow clickable>
 			<CardInner>
 				<Stack gap={1}>
 					<H3>
@@ -661,11 +661,11 @@ A search engine optimised (SEO) URL:
 - has 20 to 70 characters if possible
 - is consistent with the H1 on the page if possible. But try not to repeat a word if it's already a part of the URL domain/folder URL stem.
 
-<ExampleContent heading={<H4>Example</H4>}>
+<ExampleContent heading={<H3>Example</H3>}>
 	https://exports.agriculture.gov.au/help/register-establishment
 </ExampleContent>
 
-<ExampleContent heading={<H4>Example</H4>}>
+<ExampleContent heading={<H3>Example</H3>}>
 	https://exports.agriculture.gov.au/guides/export-guide-agricultural-goods
 </ExampleContent>
 

--- a/docs/content/guides/change-management.mdx
+++ b/docs/content/guides/change-management.mdx
@@ -17,7 +17,7 @@ This is a general guideline, and we may release more frequently if there are imp
 
 When contributing changes to the design system, it is important to understand how we classify and communicate them. This helps us to understand the impact of changes and to communicate them to our users.
 
-We follow the [Semantic Versioning](https://semver.org/) system to classify changes. This system uses three classificatons to describe the type of change...
+We follow the [Semantic Versioning](https://semver.org/) system to classify changes. This system uses three classificatons to describe the type of change…
 
 - Patch
 - Minor
@@ -27,7 +27,7 @@ We follow the [Semantic Versioning](https://semver.org/) system to classify chan
 
 A change that fixes a bug or makes a small improvement which does not affect the API of the component. The consumer isn't expected to change their code to implement the update.
 
-For example...
+For example…
 
 - A minor visual change to a component
 - Resolving a crash or other kind of bug
@@ -38,7 +38,7 @@ The GitHub pull request related to a patch change can reviewed, merged, and rele
 
 A new feature to an existing component, or the introduction of a new standalone component. The user can elect to implement the change but isn't forced to change existing code.
 
-For example...
+For example…
 
 - A new component
 - A new prop on an existing component
@@ -49,7 +49,7 @@ The GitHub pull request related to a patch change can be reviewed, merged, and r
 
 A change which breaks the API of existing component(s). A user is expected to make a change to their code for it to continue working.
 
-For example...
+For example…
 
 - Removing a component
 - Removing a prop from a component

--- a/docs/content/guides/custom-theme.mdx
+++ b/docs/content/guides/custom-theme.mdx
@@ -80,7 +80,7 @@ In the example below, change the palette prop in the parent Stack to see this be
 
 We will now go through the technical steps of defining a new `Theme`. We will assume you are implementing this in an existing NextJS application that already uses AgDS.
 
-In your app, create a file called theme.tsx...
+In your app, create a file called theme.tsx…
 
 ```tsx
 // theme.tsx

--- a/docs/content/guides/figma.mdx
+++ b/docs/content/guides/figma.mdx
@@ -3,7 +3,10 @@ title: Using Figma
 opener: How to access the AgDS design files.
 ---
 
-<FigmaEmbed src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FSgSHfK8AUadp7aEzD34ZG3%2FAgDS---Agriculture-Design-System-1.2.1%3Fnode-id%3D10942%253A92273%26t%3DJ4Xy0yzc44JjeRPS-1" />
+<FigmaEmbed
+	src="https://www.figma.com/embed?embed_host=share&url=https%3A%2F%2Fwww.figma.com%2Ffile%2FSgSHfK8AUadp7aEzD34ZG3%2FAgDS---Agriculture-Design-System-1.2.1%3Fnode-id%3D10942%253A92273%26t%3DJ4Xy0yzc44JjeRPS-1"
+	title="Visual overview of the AgDS"
+/>
 
 Figma is an interface design tool that allows you to create, test, and iterate on your designs collaboratively. It is used by the Design System team to create and maintain the AgDS, and is the tool of choice for designing and prototyping applications for the Export Service.
 

--- a/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
+++ b/docs/content/guides/how-to-write-guidance/how-to-present-guidance.mdx
@@ -56,9 +56,9 @@ For example, to deliver results at the end of a multi-page form experience such 
 		<Card shadow clickable>
 			<CardInner>
 				<Stack gap={1}>
-					<H3>
+					<Heading as="h2" type="h3">
 						<CardLink href="#">Registering an establishment</CardLink>
-					</H3>
+					</Heading>
 					<Text as="p">
 						To process, prepare or store prescribed dairy and dairy products for
 						export, you must have specific approvals in place.
@@ -70,11 +70,11 @@ For example, to deliver results at the end of a multi-page form experience such 
 		<Card shadow clickable>
 			<CardInner>
 				<Stack gap={1}>
-					<H3>
+					<Heading as="h2" type="h3">
 						<CardLink href="#">
 							How to become an exporter or milk and milk products
 						</CardLink>
-					</H3>
+					</Heading>
 					<Text as="p">
 						You must have specific approvals in place before you can start
 						exporting.
@@ -268,7 +268,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 
 ### Step-by-step instructions
 
-```jsx live enableProse exampleContentHeadingType="h5"
+```jsx live enableProse exampleContentHeadingType="h4"
 <Prose>
 	<h2>To remove someone's access:</h2>
 	<ol>
@@ -289,7 +289,7 @@ See the Export Service [Help](https://exports.agriculture.gov.au/help) section f
 </Prose>
 ```
 
-```jsx live exampleContentHeadingType="h5"
+```jsx live exampleContentHeadingType="h4"
 <p>
 	On the Insert tab, select Symbol > More symbols > Special characters > En
 	dash.

--- a/docs/content/updates/2022-08-26.mdx
+++ b/docs/content/updates/2022-08-26.mdx
@@ -246,7 +246,7 @@ Selected days in range mode now have more rounded borders
 
 If no `colour` prop is supplied, the svg colour will now defualt to `currentColor`.
 
-### And more...
+### And more…
 
 - `@ag.ds-next/badge@2.0.0`: Update references to colour tokens
 - `@ag.ds-next/box@7.0.0`: Update references to colour tokens

--- a/docs/pages/about.tsx
+++ b/docs/pages/about.tsx
@@ -19,6 +19,7 @@ export default function AboutPage({
 			<DocumentTitle title={title} />
 			<SiteLayout applyMainElement={false}>
 				<PageLayout
+					applyMainElement={true}
 					breadcrumbs={[{ href: '/', label: 'Home' }, { label: title }]}
 					editPath="/docs/content/about.mdx"
 				>

--- a/docs/pages/components/[slug]/accessibility.tsx
+++ b/docs/pages/components/[slug]/accessibility.tsx
@@ -29,12 +29,6 @@ export default function PackagesAccessibility({
 				pkg={pkg}
 				navLinks={navLinks}
 				breadcrumbs={breadcrumbs}
-				skipLinks={[
-					{
-						label: `Skip to ${pkg.title} accessibility`,
-						href: '#pkg-content',
-					},
-				]}
 				editPath={`/packages/react/src/${pkg.slug}/docs/accessibility.mdx`}
 			>
 				{toc?.length > 1 ? (

--- a/docs/pages/components/[slug]/code.tsx
+++ b/docs/pages/components/[slug]/code.tsx
@@ -29,12 +29,6 @@ export default function PackagesCode({
 				pkg={pkg}
 				navLinks={navLinks}
 				breadcrumbs={breadcrumbs}
-				skipLinks={[
-					{
-						label: `Skip to ${pkg.title} code`,
-						href: '#pkg-content',
-					},
-				]}
 				editPath={`/packages/react/src/${pkg.slug}/docs/code.mdx`}
 			>
 				<InpageNav

--- a/docs/pages/components/[slug]/content.tsx
+++ b/docs/pages/components/[slug]/content.tsx
@@ -29,12 +29,6 @@ export default function PackagesContent({
 				pkg={pkg}
 				navLinks={navLinks}
 				breadcrumbs={breadcrumbs}
-				skipLinks={[
-					{
-						label: `Skip to ${pkg.title} content`,
-						href: '#pkg-content',
-					},
-				]}
 				editPath={`/packages/react/src/${pkg.slug}/docs/content.mdx`}
 			>
 				{toc?.length > 1 ? (

--- a/docs/pages/components/[slug]/index.tsx
+++ b/docs/pages/components/[slug]/index.tsx
@@ -34,12 +34,6 @@ export default function Packages({
 				pkg={pkg}
 				navLinks={navLinks}
 				breadcrumbs={breadcrumbs}
-				skipLinks={[
-					{
-						label: `Skip to ${pkg.title} overview`,
-						href: '#pkg-content',
-					},
-				]}
 				editPath={`/packages/react/src/${pkg.slug}/docs/overview.mdx`}
 			>
 				{toc?.length > 1 ? (

--- a/docs/pages/components/[slug]/rationale.tsx
+++ b/docs/pages/components/[slug]/rationale.tsx
@@ -29,12 +29,6 @@ export default function PackagesRationale({
 				pkg={pkg}
 				navLinks={navLinks}
 				breadcrumbs={breadcrumbs}
-				skipLinks={[
-					{
-						label: `Skip to ${pkg.title} rationale`,
-						href: '#pkg-content',
-					},
-				]}
 				editPath={`/packages/react/src/${pkg.slug}/docs/rationale.mdx`}
 			>
 				{toc?.length > 1 ? (

--- a/docs/pages/components/index.tsx
+++ b/docs/pages/components/index.tsx
@@ -112,13 +112,7 @@ export default function PackagesHome({
 						</Stack>
 					</Column>
 
-					<Column
-						as="main"
-						id={listId}
-						tabIndex={-1}
-						css={{ '&:focus': { outline: 'none' } }}
-						columnSpan={{ xs: 12, md: 6, lg: 8 }}
-					>
+					<Column id={listId} columnSpan={{ xs: 12, md: 6, lg: 8 }}>
 						{filteredPkgs?.length ? (
 							<Stack gap={2}>
 								<Text

--- a/docs/pages/content/index.tsx
+++ b/docs/pages/content/index.tsx
@@ -1,7 +1,7 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
 import { MDXRemote } from 'next-mdx-remote';
-import { Box } from '@ag.ds-next/react/box';
 import { Flex } from '@ag.ds-next/react/flex';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Card, CardInner, CardLink } from '@ag.ds-next/react/card';
 import { Columns } from '@ag.ds-next/react/columns';
@@ -34,9 +34,9 @@ export default function ContentPage({
 							<Flex flexDirection="column-reverse">
 								<CardInner>
 									<Stack gap={1} flexGrow={1}>
-										<Box as="h3">
+										<Heading as="h2" type="h4">
 											<CardLink href={`/content/${slug}`}>{title}</CardLink>
-										</Box>
+										</Heading>
 										<Text>{description}</Text>
 									</Stack>
 								</CardInner>

--- a/docs/pages/foundations/index.tsx
+++ b/docs/pages/foundations/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
-import { Box } from '@ag.ds-next/react/box';
 import { Flex } from '@ag.ds-next/react/flex';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Card, CardInner, CardLink } from '@ag.ds-next/react/card';
 import { Columns } from '@ag.ds-next/react/columns';
@@ -30,9 +30,9 @@ export default function FoundationsPage({
 							<Flex flexDirection="column-reverse">
 								<CardInner>
 									<Stack gap={1} flexGrow={1}>
-										<Box as="h3">
+										<Heading as="h2" type="h4">
 											<CardLink href={`/foundations/${slug}`}>{title}</CardLink>
-										</Box>
+										</Heading>
 										<Text>{description}</Text>
 									</Stack>
 								</CardInner>

--- a/docs/pages/foundations/tokens/index.tsx
+++ b/docs/pages/foundations/tokens/index.tsx
@@ -1,6 +1,6 @@
 import { GetStaticProps, InferGetStaticPropsType } from 'next';
-import { Box } from '@ag.ds-next/react/box';
 import { Flex } from '@ag.ds-next/react/flex';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Card, CardInner, CardLink } from '@ag.ds-next/react/card';
 import { Columns } from '@ag.ds-next/react/columns';
@@ -36,9 +36,9 @@ export default function TokensPage({
 							<Flex flexDirection="column-reverse">
 								<CardInner>
 									<Stack gap={1} flexGrow={1}>
-										<Box as="h3">
+										<Heading as="h2" type="h4">
 											<CardLink href={href}>{label}</CardLink>
-										</Box>
+										</Heading>
 										<Text>{description}</Text>
 									</Stack>
 								</CardInner>

--- a/docs/pages/guides/how-to-write-guidance/index.tsx
+++ b/docs/pages/guides/how-to-write-guidance/index.tsx
@@ -1,6 +1,6 @@
 import { normalize } from 'path';
 import { Card, CardInner, CardLink } from '@ag.ds-next/react/card';
-import { Box } from '@ag.ds-next/react/box';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Text } from '@ag.ds-next/react/text';
 import { Columns } from '@ag.ds-next/react/columns';
@@ -34,11 +34,11 @@ export default function ContentGuidesHome({
 						<Card as="li" key={title} clickable shadow>
 							<CardInner>
 								<Stack gap={1}>
-									<Box as="h3">
+									<Heading as="h2" type="h4">
 										<CardLink href={`/guides/how-to-write-guidance/${slug}`}>
 											{title}
 										</CardLink>
-									</Box>
+									</Heading>
 									{overview ? <Text as="p">{overview}</Text> : null}
 								</Stack>
 							</CardInner>

--- a/docs/pages/guides/index.tsx
+++ b/docs/pages/guides/index.tsx
@@ -1,6 +1,6 @@
 import { normalize } from 'path';
 import { Card, CardInner, CardLink } from '@ag.ds-next/react/card';
-import { Box } from '@ag.ds-next/react/box';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Text } from '@ag.ds-next/react/text';
 import { Columns } from '@ag.ds-next/react/columns';
@@ -29,9 +29,9 @@ export default function GuidesHome({
 						<Card as="li" key={title} clickable shadow>
 							<CardInner>
 								<Stack gap={1}>
-									<Box as="h3">
+									<Heading as="h2" type="h4">
 										<CardLink href={`/guides/${slug}`}>{title}</CardLink>
-									</Box>
+									</Heading>
 									{overview ? <Text as="p">{overview}</Text> : null}
 								</Stack>
 							</CardInner>

--- a/docs/pages/patterns/index.tsx
+++ b/docs/pages/patterns/index.tsx
@@ -1,6 +1,6 @@
 import { normalize } from 'path';
 import { Fragment } from 'react';
-import { Box } from '@ag.ds-next/react/box';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Card, CardLink, CardInner } from '@ag.ds-next/react/card';
 import { Columns } from '@ag.ds-next/react/columns';
@@ -48,9 +48,9 @@ function PatternCard({
 		<Card key={slug} as="li" clickable shadow>
 			<CardInner>
 				<Stack gap={1} flexGrow={1}>
-					<Box as="h3">
+					<Heading as="h2" type="h4">
 						<CardLink href={`/patterns/${slug}`}>{title}</CardLink>
-					</Box>
+					</Heading>
 					<Text>{description}</Text>
 				</Stack>
 			</CardInner>

--- a/docs/pages/roadmap.tsx
+++ b/docs/pages/roadmap.tsx
@@ -19,6 +19,7 @@ export default function RoadmapPage({
 			<DocumentTitle title={title} />
 			<SiteLayout applyMainElement={false}>
 				<PageLayout
+					applyMainElement={true}
 					breadcrumbs={[{ href: '/', label: 'Home' }, { label: title }]}
 					editPath="/docs/content/roadmap.mdx"
 				>

--- a/docs/pages/templates/index.tsx
+++ b/docs/pages/templates/index.tsx
@@ -2,7 +2,7 @@ import { normalize } from 'path';
 import { Fragment } from 'react';
 import { Columns } from '@ag.ds-next/react/columns';
 import { boxPalette } from '@ag.ds-next/react/core';
-import { Box } from '@ag.ds-next/react/box';
+import { Heading } from '@ag.ds-next/react/heading';
 import { Stack } from '@ag.ds-next/react/stack';
 import { Card, CardLink, CardInner } from '@ag.ds-next/react/card';
 import { mq } from '@ag.ds-next/react/core';
@@ -62,9 +62,9 @@ function TemplateCard({
 			/>
 			<CardInner>
 				<Stack gap={1} flexGrow={1}>
-					<Box as="h3">
+					<Heading as="h2" type="h4">
 						<CardLink href={`/templates/${slug}`}>{title}</CardLink>
-					</Box>
+					</Heading>
 					<Text>{description}</Text>
 				</Stack>
 			</CardInner>

--- a/docs/pages/updates/index.tsx
+++ b/docs/pages/updates/index.tsx
@@ -31,7 +31,7 @@ export default function UpdatesHome({
 								<Card as="li" key={label} clickable shadow>
 									<CardInner>
 										<Stack gap={1}>
-											<Heading type="h3">
+											<Heading as="h2" type="h3">
 												<CardLink href={href}>{label}</CardLink>
 											</Heading>
 											{description ? <Text as="p">{description}</Text> : null}

--- a/packages/react/src/badge/docs/overview.mdx
+++ b/packages/react/src/badge/docs/overview.mdx
@@ -5,7 +5,12 @@ group: Content
 deprecated: true
 ---
 
-<PageAlert tone="info" title="This component has been renamed">
+<PageAlert
+	tone="info"
+	title={
+		<PageAlertTitle as="h2">This component has been renamed</PageAlertTitle>
+	}
+>
 	<Text as="p">
 		{'Badge has been split into separate three components: '}
 		<TextLink href="/components/indicator-dot">{'Indicator dot'}</TextLink>

--- a/packages/react/src/card/docs/overview.mdx
+++ b/packages/react/src/card/docs/overview.mdx
@@ -27,9 +27,9 @@ Consider using other formats such as tables if more than 12 cards are required.
 		<Card shadow clickable>
 			<CardInner>
 				<Stack gap={1}>
-					<Box as="h3">
+					<Heading as="h3" type="h4">
 						<CardLink href="#">Card link</CardLink>
-					</Box>
+					</Heading>
 					<Text>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non
 						finibus leo.
@@ -48,9 +48,9 @@ Consider using other formats such as tables if more than 12 cards are required.
 		<Card clickable>
 			<CardInner>
 				<Stack gap={1}>
-					<Box as="h3">
+					<Heading as="h3" type="h4">
 						<CardLink href="#">Card link</CardLink>
-					</Box>
+					</Heading>
 					<Text>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras non
 						finibus leo.
@@ -120,7 +120,9 @@ Use feature headers to give the card heading more visual prominence.
 	<Column columnSpan={6}>
 		<Card>
 			<CardHeader>
-				<Heading type="h4">Feature card title</Heading>
+				<Heading as="h3" type="h4">
+					Feature card title
+				</Heading>
 			</CardHeader>
 			<CardInner>
 				<Text as="p">Additional conent relating to the card</Text>
@@ -130,7 +132,9 @@ Use feature headers to give the card heading more visual prominence.
 	<Column columnSpan={6}>
 		<Card>
 			<CardHeader background="bodyAlt">
-				<Heading type="h4">Feature card title</Heading>
+				<Heading as="h3" type="h4">
+					Feature card title
+				</Heading>
 			</CardHeader>
 			<CardInner>
 				<Text as="p">Additional conent relating to the card</Text>

--- a/packages/react/src/control-input/docs/overview.mdx
+++ b/packages/react/src/control-input/docs/overview.mdx
@@ -5,7 +5,12 @@ group: Forms
 deprecated: true
 ---
 
-<PageAlert tone="info" title="This component has been renamed">
+<PageAlert
+	tone="info"
+	title={
+		<PageAlertTitle as="h2">This component has been renamed</PageAlertTitle>
+	}
+>
 	<Text as="p">
 		{'Control input has been split into separate three components: '}
 		<TextLink href="/components/checkbox">{'Checkbox'}</TextLink>

--- a/packages/react/src/core/docs/overview.mdx
+++ b/packages/react/src/core/docs/overview.mdx
@@ -7,7 +7,7 @@ storybookPath: /story/foundations-core--usage
 
 The `Core` component should wrap your entire application, which will enable our CSS variables reset styles.
 
-### Theming
+## Theming
 
 The `Core` component accepts a `theme` prop that enables overwriting of the default theme.
 
@@ -23,7 +23,7 @@ export default function MyApp({ Component, pageProps }) {
 }
 ```
 
-### Routing / Linking
+## Routing / Linking
 
 Our component library has been designed to work with any react routing library. For an example of configuring routing/links in AgDS for a Next.js application, please see [our example site](https://github.com/steelthreads/agds-next/tree/main/example-site/components/LinkComponent.tsx).
 

--- a/packages/react/src/filter-drawer/docs/overview.mdx
+++ b/packages/react/src/filter-drawer/docs/overview.mdx
@@ -5,7 +5,12 @@ group: Layout
 deprecated: true
 ---
 
-<PageAlert tone="info" title="This component has been renamed">
+<PageAlert
+	tone="info"
+	title={
+		<PageAlertTitle as="h2">This component has been renamed</PageAlertTitle>
+	}
+>
 	<Text as="p">
 		{'Filter drawer has been renamed to '}
 		<TextLink href="/components/drawer">{'Drawer'}</TextLink>

--- a/packages/react/src/indicator-dot/docs/overview.mdx
+++ b/packages/react/src/indicator-dot/docs/overview.mdx
@@ -28,7 +28,6 @@ An Indicator dot should not be used on its own, as it gives no context. It shoul
 <Flex flexDirection="column" as="ul">
 	<Flex
 		as="li"
-		aria-selected="false"
 		borderColor="muted"
 		borderY
 		css={{

--- a/packages/react/src/page-alert/docs/accessibility.mdx
+++ b/packages/react/src/page-alert/docs/accessibility.mdx
@@ -1,8 +1,8 @@
-To improve accessibility, you may consider using the ARIA alert role ( role="alert" ) in certain situations.
+To improve accessibility, you may consider using the ARIA alert role (`role="alert"`) in certain situations.
 
-Using role="alert" will immediately interrupt assistive technology to inform users of the alert and for this reason should be used sparingly.
+Using `role="alert"` will immediately interrupt assistive technology to inform users of the alert and for this reason should be used sparingly.
 
-We recommend only using the role="alert" when there is important time-sensitive information that would be detrimental for a user to miss.
+We recommend only using the `role="alert"` when there is important time-sensitive information that would be detrimental for a user to miss.
 
 More information on [ARIA alert role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Alert_Role)
 

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -96,7 +96,7 @@ import { PageAlertTitle } from '@ag.ds-next/react/page-alert';
 	title={<PageAlertTitle as="h2">Submission successful</PageAlertTitle>}
 >
 	<Text as="p">Your application has been successfully submitted.</Text>
-</PageAlert>;
+</PageAlert>
 ```
 
 ## Dismissable

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -86,15 +86,17 @@ Use warning page alerts (orange) to tell the user how to avoid a problem. Only u
 
 ## Title
 
-You can use the `PageAlertTitle` component in the title prop to change the element used for the title.
+By default, `PageAlert` renders `PageAlertTitle` as an `h3`. If you need to change the title’s semantic tag to an `h2`, for instance, you can use the `PageAlertTitle` component in the `title` prop to explicitly set it.
 
-```jsx live
+```jsx
+import { PageAlertTitle } from '@ag.ds-next/react/page-alert';
+
 <PageAlert
 	tone="success"
 	title={<PageAlertTitle as="h2">Submission successful</PageAlertTitle>}
 >
 	<Text as="p">Your application has been successfully submitted.</Text>
-</PageAlert>
+</PageAlert>;
 ```
 
 ## Dismissable

--- a/packages/react/src/page-alert/docs/overview.mdx
+++ b/packages/react/src/page-alert/docs/overview.mdx
@@ -96,7 +96,7 @@ import { PageAlertTitle } from '@ag.ds-next/react/page-alert';
 	title={<PageAlertTitle as="h2">Submission successful</PageAlertTitle>}
 >
 	<Text as="p">Your application has been successfully submitted.</Text>
-</PageAlert>
+</PageAlert>;
 ```
 
 ## Dismissable

--- a/packages/react/src/search-box/docs/overview.mdx
+++ b/packages/react/src/search-box/docs/overview.mdx
@@ -28,7 +28,7 @@ Use the `SearchBox` component to help users find content or pages through keywor
 - indicate that the field is optional
 - include a label.
 
-### Responsive icon
+## Responsive icon
 
 Use the `iconOnly` prop to configure at which breakpoints the search icon should replace the button label. This allows more space for text to be written in the text input.
 

--- a/plop-templates/component/docs/overview.mdx.hbs
+++ b/plop-templates/component/docs/overview.mdx.hbs
@@ -17,12 +17,12 @@ __High-level introduction to the component. This paragraph should only be a few 
 
 <DoHeading />
 
-- use this component to....
+- use this component to…
 - aim for 3-5 bullet points here
 
 <DontHeading />
 
-- use this component in this way....
+- use this component in this way…
 - aim for 3-5 bullet points here
 
 ## Name of variant or feature


### PR DESCRIPTION
Fix many, simple a11y errors detected by axe such as incorrect landmarks, incorrect heading order and incorrect use of aria attributes throughout the documentation.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-1503)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [x] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [x] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [ ] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [x] Create or update documentation on the website
- [ ] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets