### PR TITLE
callout: Add ReactNode support to title prop as was previously documented

### DIFF
--- a/.changeset/blue-bugs-buy.md
+++ b/.changeset/blue-bugs-buy.md
@@ -1,0 +1,5 @@
+---
+'@ag.ds-next/react': minor
+---
+
+callout: Add `ReactNode` support to `title` prop as was previously documented.

--- a/packages/react/src/callout/Callout.stories.tsx
+++ b/packages/react/src/callout/Callout.stories.tsx
@@ -163,17 +163,11 @@ export const NoTitle: Story = {
 	},
 };
 
-export const CustomTitleSize: Story = {
-	render: (args) => (
-		<Callout {...args}>
-			<CalloutTitle as="h3" variant={args.variant}>
-				Callout heading
-			</CalloutTitle>
-			<Text as="p">Description of the callout.</Text>
-		</Callout>
-	),
+export const WithTitleElement: Story = {
 	args: {
+		title: <CalloutTitle as="h3">Custom feature title (H3)</CalloutTitle>,
+		children: <Text as="p">Description of the callout.</Text>,
 		tone: 'neutral',
-		variant: 'regular',
+		variant: 'feature',
 	},
 };

--- a/packages/react/src/callout/Callout.test.tsx
+++ b/packages/react/src/callout/Callout.test.tsx
@@ -2,9 +2,10 @@ import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { Text } from '../text';
-import { cleanup, render } from '../../../../test-utils';
+import { cleanup, render, screen } from '../../../../test-utils';
 import { Callout, CalloutProps } from './Callout';
 import { calloutToneMap, calloutVariantMap } from './utils';
+import { CalloutTitle } from './CalloutTitle';
 
 expect.extend(toHaveNoViolations);
 
@@ -61,5 +62,15 @@ describe('Callout', () => {
 				});
 			});
 		});
+	});
+
+	it('can render a different heading level', () => {
+		renderCallout({
+			variant: 'feature',
+			title: <CalloutTitle as="h3">Title</CalloutTitle>,
+		});
+		const el = screen.getByText('Title');
+		expect(el).toBeInTheDocument();
+		expect(el.tagName).toBe('H3');
 	});
 });

--- a/packages/react/src/callout/Callout.tsx
+++ b/packages/react/src/callout/Callout.tsx
@@ -1,12 +1,18 @@
-import { ElementType, PropsWithChildren, ReactNode } from 'react';
+import {
+	cloneElement,
+	isValidElement,
+	type ElementType,
+	type PropsWithChildren,
+	type ReactNode,
+} from 'react';
 import { Flex } from '../flex';
 import { Stack } from '../stack';
 import { CalloutTitle } from './CalloutTitle';
 import {
-	CalloutTone,
 	calloutToneMap,
-	CalloutVariant,
 	calloutVariantMap,
+	type CalloutTone,
+	type CalloutVariant,
 } from './utils';
 
 export type CalloutProps = PropsWithChildren<{
@@ -18,7 +24,7 @@ export type CalloutProps = PropsWithChildren<{
 	/** If the Callout component is placed on a page with `bodyAlt` background, set this prop to `true`. */
 	onBodyAlt?: boolean;
 	/** Title will appear in bold */
-	title?: string;
+	title?: ReactNode;
 	/** Tone will change the background color */
 	tone?: CalloutTone;
 	/** Variant will change the padding and gap */
@@ -58,7 +64,13 @@ export const Callout = ({
 		>
 			{iconProp || icon ? <Flex flexShrink={0}>{iconProp || icon}</Flex> : null}
 			<Stack css={{ paddingTop: titlePaddingTop }} gap={textGap}>
-				{title ? <CalloutTitle variant={variant}>{title}</CalloutTitle> : null}
+				{title ? (
+					isValidElement(title) ? (
+						cloneElement(title, { variant })
+					) : (
+						<CalloutTitle variant={variant}>{title}</CalloutTitle>
+					)
+				) : null}
 				{children}
 			</Stack>
 		</Flex>


### PR DESCRIPTION
The docs told you how to customise the the CalloutTitle to have different semantic heading, but it didn't actually work that way. This change does what it says on the tin and makes it consistent with PageAlert.

[View preview](https://design-system.agriculture.gov.au/pr-preview/pr-2109)

## Checklist

**Preflight**

- [x] Prefix the PR title with the slug of the package or component - e.g. `accordion: Updated padding` or `docs: Updated header links`
- [x] Describe the changes clearly in the PR description
- [x] Read and check your code before tagging someone for review
- [x] Create a changeset file by running `yarn changeset`. [Learn more about change management](https://design-system.agriculture.gov.au/guides/change-management).

**Testing**

- [x] Manually test component in various modern browsers at various sizes (use [Browserstack](https://www.browserstack.com/))
- [ ] Manually test component in various devices (phone, tablet, desktop)
- [ ] Manually test component using a keyboard
- [x] Manually test component using a screen reader
- [ ] Manually tested in dark mode
- [ ] Component meets [Web Content Accessibility Guidelines (WCAG) 2.1 standards](https://www.w3.org/TR/WCAG21/)
- [x] Add any necessary unit tests (HTML validation, snapshots etc)
- [x] Run `yarn test` to ensure tests are passing. If required, run `yarn test -u` to update any generated snapshots.

**Documentation**

- [ ] Create or update documentation on the website
- [x] Create or update stories for Storybook
- [ ] Create or update stories for Playroom snippets
- [ ] Verify hard-coded anchor links and hashes are correct. Check existing links when renaming pages and headings.
